### PR TITLE
[codex] Ticket 2 scaffold TypeScript monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "pnpm --parallel --filter @japan-travel-planner/web --filter @japan-travel-planner/api dev",
     "dev:web": "pnpm --filter @japan-travel-planner/web dev",
     "dev:api": "pnpm --filter @japan-travel-planner/api dev",
+    "lint": "pnpm typecheck",
     "build": "pnpm --filter @japan-travel-planner/shared build && pnpm --filter @japan-travel-planner/api build && pnpm --filter @japan-travel-planner/web build",
     "typecheck": "pnpm --filter @japan-travel-planner/shared typecheck && pnpm --filter @japan-travel-planner/api typecheck && pnpm --filter @japan-travel-planner/web typecheck",
     "test": "pnpm --filter @japan-travel-planner/shared test && pnpm --filter @japan-travel-planner/api test && pnpm --filter @japan-travel-planner/web test"


### PR DESCRIPTION
## Ticket scope

Implement Ticket 2: Scaffold TypeScript Monorepo. The branch focuses only on the remaining Ticket 2 acceptance criterion: ensuring the root workspace exposes a `lint` script alongside `dev`, `typecheck`, and `test`.

## Changes made

- Added a root `lint` script in `package.json`.
- The script delegates to `pnpm typecheck` as a minimal placeholder until Ticket 4 introduces dedicated lint tooling.

## Tests run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Known risks

- `pnpm lint` currently runs TypeScript checks rather than ESLint. This is intentional for Ticket 2 only; dedicated ESLint/Prettier setup belongs to Ticket 4.
- `pnpm install` reports the existing local pnpm warning that `esbuild` build scripts are ignored unless approved, but build and tests pass.

## Ticket 3+ confirmation

Ticket 3 and later were not started in this branch. No `.env.example`, `.gitignore`, license, baseline repository file, ESLint, business logic, API persistence, or app feature work was changed.