### PR TITLE
[codex] Ticket 3 add baseline repository files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This repository is being rebuilt from an older project README. The original visi
 
 ## Current Status
 
-Project phase: planning and rebuild.
+Project phase: scaffolded rebuild.
 
-The current repository starts with documentation only. Implementation work should begin with the web MVP and backend API described in [docs/development_plan.md](docs/development_plan.md).
+The current repository contains a minimal TypeScript monorepo skeleton with placeholder web, API, shared, and config packages. Feature work should continue with the web MVP and backend API described in [docs/development_plan.md](docs/development_plan.md).
 
 ## Product Goals
 
@@ -99,13 +99,27 @@ WEB_ORIGIN=http://localhost:5173
 API_PORT=3001
 ```
 
-## Planned Local Development
+## Local Development
 
-These commands represent the intended developer workflow after the monorepo is scaffolded:
+Install dependencies:
 
 ```bash
 pnpm install
+```
+
+Run both local app shells:
+
+```bash
 pnpm dev
+```
+
+Run quality checks:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
 ```
 
 Target app URLs:
@@ -153,7 +167,7 @@ flowchart TD
 
 ## License
 
-MIT License. Add a `LICENSE` file before public release.
+MIT License. See [LICENSE](LICENSE).
 
 ## Developer
 


### PR DESCRIPTION
## Ticket scope

Implement Ticket 3: Add Baseline Repository Files. The baseline files already existed on `main`, so this branch focuses on the remaining Ticket 3 acceptance gap: making the README setup/status instructions match the actual scaffolded monorepo and scripts.

## Changes made

- Updated README current status from documentation-only planning to scaffolded rebuild.
- Replaced planned local development wording with actual local development commands.
- Documented `pnpm install`, `pnpm dev`, `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build`.
- Updated the license note to link to the existing `LICENSE` file.

## Tests run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Known risks

- `pnpm install` reports the existing pnpm warning that `esbuild` build scripts are ignored unless approved. The build and test suite still pass.
- `pnpm lint` currently delegates to `pnpm typecheck`; dedicated lint tooling remains future Ticket 4 scope.

## Ticket 4+ confirmation

Ticket 4 and later were not started. This branch does not add ESLint, Prettier, shared tooling changes, CI, business logic, app features, API persistence, or new dependencies.