### PR TITLE
[codex] Ticket 5 shared domain schemas

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,5 +20,8 @@
     "@types/node": "^25.9.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
   }
 }

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -1,10 +1,22 @@
 import { describe, expect, test } from "vitest";
 
-import { API_BASE_PATH, PROJECT_NAME } from "./index.js";
+import {
+  API_BASE_PATH,
+  PROJECT_NAME,
+  apiErrorSchema,
+  itinerarySchema,
+  tripRequestSchema
+} from "./index.js";
 
 describe("shared package", () => {
   test("exports project constants", () => {
     expect(PROJECT_NAME).toBe("Japan Travel Planner AI");
     expect(API_BASE_PATH).toBe("/api");
+  });
+
+  test("exports shared schemas", () => {
+    expect(tripRequestSchema).toBeDefined();
+    expect(itinerarySchema).toBeDefined();
+    expect(apiErrorSchema).toBeDefined();
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,3 +5,36 @@ export type HealthResponse = {
   status: "ok";
   service: string;
 };
+
+export {
+  apiErrorSchema,
+  apiFieldErrorSchema,
+  type ApiError,
+  type ApiFieldError
+} from "./schemas/apiError.js";
+export {
+  activityCategorySchema,
+  activityCostLevelSchema,
+  activityLocationSchema,
+  activitySchema,
+  activityTimingSchema,
+  itinerarySchema,
+  tripDaySchema,
+  type Activity,
+  type ActivityCategory,
+  type ActivityCostLevel,
+  type ActivityLocation,
+  type ActivityTiming,
+  type Itinerary,
+  type TripDay
+} from "./schemas/itinerary.js";
+export {
+  isoDateSchema,
+  travelBudgetSchema,
+  travelPaceSchema,
+  tripRequestSchema,
+  type IsoDate,
+  type TravelBudget,
+  type TravelPace,
+  type TripRequest
+} from "./schemas/tripRequest.js";

--- a/packages/shared/src/schemas/apiError.test.ts
+++ b/packages/shared/src/schemas/apiError.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+
+import { apiErrorSchema, type ApiError } from "./apiError.js";
+
+describe("apiErrorSchema", () => {
+  test("accepts a reusable API error payload", () => {
+    const result = apiErrorSchema.safeParse({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Request validation failed.",
+        fieldErrors: [
+          {
+            path: "cities.0",
+            message: "City is required."
+          }
+        ]
+      }
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      const error: ApiError = result.data;
+      expect(error.error.code).toBe("VALIDATION_ERROR");
+    }
+  });
+
+  test("rejects an error without a message", () => {
+    const result = apiErrorSchema.safeParse({
+      error: {
+        code: "VALIDATION_ERROR"
+      }
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/apiError.ts
+++ b/packages/shared/src/schemas/apiError.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const apiFieldErrorSchema = z
+  .object({
+    path: z.string().min(1),
+    message: z.string().min(1)
+  })
+  .strict();
+
+export const apiErrorSchema = z
+  .object({
+    error: z
+      .object({
+        code: z.string().min(1),
+        message: z.string().min(1),
+        details: z.unknown().optional(),
+        fieldErrors: z.array(apiFieldErrorSchema).optional()
+      })
+      .strict()
+  })
+  .strict();
+
+export type ApiFieldError = z.infer<typeof apiFieldErrorSchema>;
+export type ApiError = z.infer<typeof apiErrorSchema>;

--- a/packages/shared/src/schemas/itinerary.test.ts
+++ b/packages/shared/src/schemas/itinerary.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+
+import { itinerarySchema, type Itinerary } from "./itinerary.js";
+
+const validActivity = {
+  title: "Explore Asakusa",
+  category: "culture",
+  timing: {
+    startTime: "10:00",
+    endTime: "12:00"
+  },
+  durationMinutes: 120,
+  location: {
+    name: "Senso-ji",
+    city: "Tokyo"
+  },
+  costLevel: "free",
+  notes: "Start early to avoid the busiest crowds."
+};
+
+const validDay = {
+  date: "2026-10-01",
+  city: "Tokyo",
+  summary: "Arrival day with a relaxed neighborhood walk.",
+  activities: [validActivity]
+};
+
+const validItinerary = {
+  title: "Tokyo Food And Culture",
+  startDate: "2026-10-01",
+  endDate: "2026-10-02",
+  days: [validDay]
+};
+
+describe("itinerarySchema", () => {
+  test("accepts a structured itinerary with days and activities", () => {
+    const result = itinerarySchema.safeParse(validItinerary);
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      const itinerary: Itinerary = result.data;
+      expect(itinerary.days[0]?.activities[0]?.location.name).toBe("Senso-ji");
+    }
+  });
+
+  test("rejects activities without a duration", () => {
+    const result = itinerarySchema.safeParse({
+      ...validItinerary,
+      days: [
+        {
+          ...validDay,
+          activities: [
+            {
+              ...validActivity,
+              durationMinutes: undefined
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an empty day list", () => {
+    const result = itinerarySchema.safeParse({
+      ...validItinerary,
+      days: []
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/itinerary.ts
+++ b/packages/shared/src/schemas/itinerary.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+
+import { isoDateSchema } from "./tripRequest.js";
+
+export const activityCategorySchema = z.enum([
+  "sightseeing",
+  "food",
+  "culture",
+  "nature",
+  "shopping",
+  "transit",
+  "lodging",
+  "other"
+]);
+
+export const activityCostLevelSchema = z.enum([
+  "free",
+  "low",
+  "medium",
+  "high"
+]);
+
+export const activityTimingSchema = z
+  .object({
+    startTime: z
+      .string()
+      .regex(/^([01]\d|2[0-3]):[0-5]\d$/)
+      .optional(),
+    endTime: z
+      .string()
+      .regex(/^([01]\d|2[0-3]):[0-5]\d$/)
+      .optional(),
+    timeOfDay: z.enum(["morning", "afternoon", "evening", "night"]).optional()
+  })
+  .strict()
+  .refine(
+    (timing) => Boolean(timing.startTime ?? timing.timeOfDay),
+    "Provide either startTime or timeOfDay."
+  );
+
+export const activityLocationSchema = z
+  .object({
+    name: z.string().min(1),
+    address: z.string().min(1).optional(),
+    city: z.string().min(1).optional(),
+    latitude: z.number().min(-90).max(90).optional(),
+    longitude: z.number().min(-180).max(180).optional(),
+    mapUrl: z.string().url().optional()
+  })
+  .strict();
+
+export const activitySchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    title: z.string().min(1),
+    category: activityCategorySchema,
+    timing: activityTimingSchema,
+    durationMinutes: z.number().int().positive(),
+    location: activityLocationSchema,
+    costLevel: activityCostLevelSchema,
+    notes: z.string()
+  })
+  .strict();
+
+export const tripDaySchema = z
+  .object({
+    date: isoDateSchema,
+    city: z.string().min(1),
+    summary: z.string().optional(),
+    weatherSummary: z.string().optional(),
+    activities: z.array(activitySchema).min(1)
+  })
+  .strict();
+
+export const itinerarySchema = z
+  .object({
+    title: z.string().min(1),
+    startDate: isoDateSchema,
+    endDate: isoDateSchema,
+    days: z.array(tripDaySchema).min(1)
+  })
+  .strict();
+
+export type ActivityCategory = z.infer<typeof activityCategorySchema>;
+export type ActivityCostLevel = z.infer<typeof activityCostLevelSchema>;
+export type ActivityTiming = z.infer<typeof activityTimingSchema>;
+export type ActivityLocation = z.infer<typeof activityLocationSchema>;
+export type Activity = z.infer<typeof activitySchema>;
+export type TripDay = z.infer<typeof tripDaySchema>;
+export type Itinerary = z.infer<typeof itinerarySchema>;

--- a/packages/shared/src/schemas/tripRequest.test.ts
+++ b/packages/shared/src/schemas/tripRequest.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+
+import { tripRequestSchema, type TripRequest } from "./tripRequest.js";
+
+describe("tripRequestSchema", () => {
+  test("accepts the MVP trip request fields", () => {
+    const result = tripRequestSchema.safeParse({
+      startDate: "2026-10-01",
+      endDate: "2026-10-07",
+      cities: ["Tokyo", "Kyoto"],
+      interests: ["food", "culture"],
+      pace: "balanced",
+      budget: "moderate",
+      constraints: ["vegetarian options"]
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      const request: TripRequest = result.data;
+      expect(request.cities).toContain("Tokyo");
+    }
+  });
+
+  test("defaults constraints to an empty list", () => {
+    const result = tripRequestSchema.safeParse({
+      startDate: "2026-10-01",
+      endDate: "2026-10-07",
+      cities: ["Tokyo"],
+      interests: ["food"],
+      pace: "relaxed",
+      budget: "budget"
+    });
+
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      expect(result.data.constraints).toEqual([]);
+    }
+  });
+
+  test("rejects a request without cities", () => {
+    const result = tripRequestSchema.safeParse({
+      startDate: "2026-10-01",
+      endDate: "2026-10-07",
+      cities: [],
+      interests: ["food"],
+      pace: "balanced",
+      budget: "moderate",
+      constraints: []
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an end date before the start date", () => {
+    const result = tripRequestSchema.safeParse({
+      startDate: "2026-10-07",
+      endDate: "2026-10-01",
+      cities: ["Tokyo"],
+      interests: ["food"],
+      pace: "balanced",
+      budget: "moderate",
+      constraints: []
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/tripRequest.ts
+++ b/packages/shared/src/schemas/tripRequest.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+export const travelPaceSchema = z.enum(["relaxed", "balanced", "packed"]);
+
+export const travelBudgetSchema = z.enum(["budget", "moderate", "luxury"]);
+
+export const tripRequestSchema = z
+  .object({
+    startDate: isoDateSchema,
+    endDate: isoDateSchema,
+    cities: z.array(z.string().min(1)).min(1),
+    interests: z.array(z.string().min(1)).min(1),
+    pace: travelPaceSchema,
+    budget: travelBudgetSchema,
+    constraints: z.array(z.string().min(1)).default([])
+  })
+  .strict()
+  .refine((request) => request.startDate <= request.endDate, {
+    message: "endDate must be on or after startDate.",
+    path: ["endDate"]
+  });
+
+export type IsoDate = z.infer<typeof isoDateSchema>;
+export type TravelPace = z.infer<typeof travelPaceSchema>;
+export type TravelBudget = z.infer<typeof travelBudgetSchema>;
+export type TripRequest = z.infer<typeof tripRequestSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,10 @@ importers:
   packages/config: {}
 
   packages/shared:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^25.9.3
@@ -1364,6 +1368,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@emnapi/core@1.10.0':
@@ -2527,3 +2534,5 @@ snapshots:
   wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## Ticket scope

Implement Ticket 5: Add Shared Domain Schemas And Types. This PR defines shared Zod schemas and inferred TypeScript types for the MVP trip request, itinerary/activity model, and reusable API error response shape.

## Changes made

- Added a trip request schema covering dates, cities, interests, pace, budget, and constraints.
- Added itinerary schemas covering itinerary days and structured activities.
- Added activity sub-schemas for category, timing, duration, location, cost level, and notes.
- Added a reusable API error schema with field-level validation errors.
- Re-exported schemas and inferred TypeScript types from `packages/shared/src/index.ts`.
- Updated shared package tests to confirm schema exports.

## Schema files added/updated

- `packages/shared/src/schemas/tripRequest.ts`
- `packages/shared/src/schemas/itinerary.ts`
- `packages/shared/src/schemas/apiError.ts`
- `packages/shared/src/index.ts`

## Tests added

- `packages/shared/src/schemas/tripRequest.test.ts`
- `packages/shared/src/schemas/itinerary.test.ts`
- `packages/shared/src/schemas/apiError.test.ts`
- Updated `packages/shared/src/index.test.ts`

## Dependencies added

- `zod` in `@japan-travel-planner/shared`

## Checks run

- `pnpm exec prettier . --check`
- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Known risks

- Date validation currently enforces the portable `YYYY-MM-DD` shape and chronological ordering for trip requests, but it does not validate calendar-specific month/day ranges beyond the string format.
- Schema enum values are intentionally small MVP sets and may need expansion once UI copy and provider integrations are designed.
- `pnpm install` continues to report the existing pnpm warning that `esbuild` build scripts are ignored unless approved. Build and tests pass.

## Ticket 6+ confirmation

Ticket 6 and later were not started. This PR does not add GitHub Actions CI, API routes, web UI changes, database/persistence code, AI generation, provider integrations, or product behavior outside shared schemas/types.