### PR TITLE
[codex] Ticket 6 GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: Install, lint, typecheck, test, and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Node 24 is the active LTS line as of June 2026.
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Ticket scope

Implement T-006 / Ticket 6: Add GitHub Actions CI.

## Changes made

- Added `.github/workflows/ci.yml`.
- Configured a single CI job on Ubuntu.
- Set least-privilege workflow permissions with `contents: read`.
- Set up pnpm `10.14.0`, matching the root `packageManager` field.
- Set up Node `24`, chosen as the active LTS line for this repo's CI runtime.

## CI triggers

- Pull requests targeting `main`.
- Pushes to `main`.

## Commands run in CI

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Local checks run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Known risks

- CI has not run on GitHub yet in this branch until this PR's workflow is picked up by Actions.
- `pnpm install` reports the existing ignored `esbuild` build-script warning locally; it does not block install or checks.

## Ticket boundary confirmation

Ticket 7+ was not started. No app source code, shared schemas, business logic, or README/package changes were made.