### PR TITLE
[codex] Ticket 7 web MVP shell

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,6 +1,6 @@
 :root {
-  color: #14213d;
-  background: #f7f8fb;
+  color: #172026;
+  background: #f4f7f9;
   font-family:
     Inter,
     ui-sans-serif,
@@ -30,28 +30,230 @@ select {
 
 .app-shell {
   display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
   min-height: 100vh;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef4f7 100%), #f4f7f9;
+}
+
+.app-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  border-right: 1px solid #d8e0e6;
+  background: #ffffff;
+  padding: 28px 24px;
+}
+
+.brand-lockup {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.brand-mark {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  flex: 0 0 auto;
   place-items: center;
+  border-radius: 8px;
+  background: #d94b3d;
+  color: #ffffff;
+  font-size: 0.9rem;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.brand-kicker,
+.brand-name,
+.section-kicker,
+.workspace-state,
+.panel-status {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+.brand-kicker {
+  color: #657480;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.brand-name {
+  margin-top: 3px;
+  color: #172026;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.primary-nav {
+  display: grid;
+  gap: 8px;
+}
+
+.primary-nav-item {
+  display: block;
+  border-radius: 6px;
+  color: #52616d;
+  font-weight: 700;
+  padding: 10px 12px;
+}
+
+.primary-nav-item[aria-current="page"] {
+  background: #edf4f6;
+  color: #0d3b4f;
+}
+
+.app-main {
+  display: grid;
+  align-content: start;
+  gap: 24px;
   padding: 32px;
 }
 
-.status-panel {
-  width: min(100%, 720px);
-  border: 1px solid #d8dee9;
+.workspace-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 340px);
+  gap: 24px;
+  align-items: stretch;
+  border: 1px solid #d8e0e6;
   border-radius: 8px;
   background: #ffffff;
   padding: 32px;
 }
 
-.status-panel h1 {
-  margin: 0 0 12px;
-  font-size: clamp(2rem, 5vw, 3.25rem);
-  line-height: 1.05;
+.section-kicker {
+  color: #be3f32;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
 }
 
-.status-panel p {
+.workspace-hero h1 {
+  margin: 10px 0 14px;
+  color: #172026;
+  font-size: 2.25rem;
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.workspace-state {
+  color: #52616d;
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.shell-status {
+  display: grid;
+  gap: 12px;
   margin: 0;
-  color: #4a5568;
+}
+
+.shell-status div {
+  border: 1px solid #dce4ea;
+  border-radius: 8px;
+  background: #f8fafb;
+  padding: 14px 16px;
+}
+
+.shell-status dt {
+  color: #657480;
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.shell-status dd {
+  margin: 4px 0 0;
+  color: #172026;
   font-size: 1rem;
+  font-weight: 800;
+}
+
+.workspace-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.workspace-panel {
+  min-height: 180px;
+  border: 1px solid #d8e0e6;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 24px;
+}
+
+.panel-status {
+  display: inline-block;
+  border-radius: 999px;
+  background: #edf4f6;
+  color: #0d3b4f;
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 5px 10px;
+}
+
+.workspace-panel h2 {
+  margin: 20px 0 10px;
+  color: #172026;
+  font-size: 1.2rem;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+.workspace-panel p:last-child {
+  margin: 0;
+  color: #52616d;
+  font-size: 0.96rem;
   line-height: 1.6;
+}
+
+@media (max-width: 820px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .app-sidebar {
+    border-right: 0;
+    border-bottom: 1px solid #d8e0e6;
+  }
+
+  .primary-nav {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .workspace-hero,
+  .workspace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .app-main {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 520px) {
+  .app-sidebar,
+  .app-main {
+    padding: 20px;
+  }
+
+  .brand-lockup {
+    align-items: flex-start;
+  }
+
+  .primary-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-hero,
+  .workspace-panel {
+    padding: 20px;
+  }
+
+  .workspace-hero h1 {
+    font-size: 1.9rem;
+  }
 }

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -4,10 +4,13 @@ import { describe, expect, test } from "vitest";
 import { App } from "./App";
 
 describe("App", () => {
-  test("renders the project shell", () => {
+  test("renders the responsive web MVP shell", () => {
     const html = renderToString(<App />);
 
-    expect(html).toContain("Japan Travel Planner AI");
-    expect(html).toContain("web MVP shell");
+    expect(html).toContain("Japan Travel Planner");
+    expect(html).toContain("Japan trip workspace");
+    expect(html).toContain("No trip selected");
+    expect(html).toContain("React + Vite");
+    expect(html).toContain("localhost:5173");
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,15 +1,86 @@
 import "./App.css";
 
+const navigationItems = ["Planner", "Trips", "Account"];
+
+const workspacePanels = [
+  {
+    title: "Trip setup",
+    status: "No trip selected",
+    detail: "Dates, cities, pace, budget, and interests"
+  },
+  {
+    title: "Itinerary board",
+    status: "Empty",
+    detail: "Daily activities and travel notes"
+  },
+  {
+    title: "Travel context",
+    status: "Pending trip",
+    detail: "Map links, weather, and local context"
+  }
+];
+
 export function App() {
   return (
-    <main className="app-shell">
-      <section className="status-panel" aria-labelledby="app-title">
-        <h1 id="app-title">Japan Travel Planner AI</h1>
-        <p>
-          The web MVP shell is running. Trip intake, itinerary generation, and
-          editing will be added in later implementation tickets.
-        </p>
-      </section>
-    </main>
+    <div className="app-shell">
+      <aside className="app-sidebar" aria-label="Workspace navigation">
+        <div className="brand-lockup">
+          <div className="brand-mark" aria-hidden="true">
+            JP
+          </div>
+          <div>
+            <p className="brand-kicker">Japan Travel Planner</p>
+            <p className="brand-name">AI Workspace</p>
+          </div>
+        </div>
+
+        <nav className="primary-nav" aria-label="Primary navigation">
+          {navigationItems.map((item, index) => (
+            <span
+              aria-current={index === 0 ? "page" : undefined}
+              className="primary-nav-item"
+              key={item}
+            >
+              {item}
+            </span>
+          ))}
+        </nav>
+      </aside>
+
+      <main className="app-main" aria-labelledby="workspace-title">
+        <section className="workspace-hero">
+          <div>
+            <p className="section-kicker">Web MVP Shell</p>
+            <h1 id="workspace-title">Japan trip workspace</h1>
+            <p className="workspace-state">No trip selected</p>
+          </div>
+
+          <dl className="shell-status" aria-label="Shell status">
+            <div>
+              <dt>Frontend</dt>
+              <dd>React + Vite</dd>
+            </div>
+            <div>
+              <dt>Local URL</dt>
+              <dd>localhost:5173</dd>
+            </div>
+            <div>
+              <dt>Backend</dt>
+              <dd>Not required</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="workspace-grid" aria-label="Planner areas">
+          {workspacePanels.map((panel) => (
+            <article className="workspace-panel" key={panel.title}>
+              <p className="panel-status">{panel.status}</p>
+              <h2>{panel.title}</h2>
+              <p>{panel.detail}</p>
+            </article>
+          ))}
+        </section>
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Ticket scope

Implement T-007 / Ticket 7: Scaffold React + Vite Web App.

This keeps the existing React + Vite web package and upgrades only the static MVP shell needed for the ticket.

## Existing criteria already satisfied

- `apps/web` already existed as a React + Vite package.
- `apps/web/vite.config.ts` already configured Vite on port `5173`.
- `apps/web/src/main.tsx` already mounted React into `#root`.
- The existing app had no backend/API calls.
- A basic web render smoke test already existed.

## Gaps fixed

- Replaced the centered placeholder panel with a static web MVP workspace shell.
- Added sidebar navigation, a main workspace area, shell status, and planner area panels.
- Added responsive desktop/mobile CSS without adding app behavior or API calls.
- Updated the smoke test to assert the rendered shell content.

## Files changed

- `apps/web/src/App.tsx`
- `apps/web/src/App.css`
- `apps/web/src/App.test.tsx`

## Tests/checks run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm exec prettier --check apps/web/src/App.tsx apps/web/src/App.css apps/web/src/App.test.tsx`
- `pnpm dev --filter web` verified `http://localhost:5173` returns HTTP 200
- Browser verification at 1280x720 and 390x844 confirmed the app renders with no horizontal overflow

## Known risks

- The existing root `pnpm dev --filter web` command starts both the web and API dev scripts because of the root `dev` script wiring, but the web shell itself is static and does not require backend availability.
- `pnpm install` reports the existing ignored `esbuild` build-script warning locally; it does not block install or checks.

## Ticket boundary confirmation

Ticket 8+ was not started. No trip intake form, mock itinerary data, API calls, shared schema changes, persistence, or business logic were added.