### PR TITLE
[codex] Ticket 10 itinerary results layout

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -210,6 +210,244 @@ select {
   line-height: 1.6;
 }
 
+.itinerary-view {
+  display: grid;
+  gap: 28px;
+}
+
+.itinerary-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 420px);
+  gap: 24px;
+  align-items: stretch;
+  border: 1px solid #d8e0e6;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 28px;
+}
+
+.itinerary-summary h2,
+.itinerary-state h2 {
+  margin: 10px 0 10px;
+  color: #172026;
+  font-size: 1.7rem;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.itinerary-date-range {
+  margin: 0;
+  color: #52616d;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.itinerary-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.itinerary-stats div {
+  border: 1px solid #dce4ea;
+  border-radius: 8px;
+  background: #f8fafb;
+  padding: 14px;
+}
+
+.itinerary-stats dt {
+  color: #657480;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.itinerary-stats dd {
+  margin: 5px 0 0;
+  color: #172026;
+  font-size: 1.05rem;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
+.trip-day-list {
+  display: grid;
+  gap: 32px;
+}
+
+.trip-day-panel {
+  display: grid;
+  gap: 18px;
+}
+
+.trip-day-heading {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+  border-top: 1px solid #cfd9df;
+  padding-top: 22px;
+}
+
+.trip-day-heading h3 {
+  margin: 6px 0 0;
+  color: #172026;
+  font-size: 1.35rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.trip-day-heading span {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #edf4f6;
+  color: #0d3b4f;
+  font-size: 0.82rem;
+  font-weight: 800;
+  padding: 6px 10px;
+}
+
+.trip-day-date,
+.trip-day-summary,
+.trip-day-weather {
+  margin: 0;
+}
+
+.trip-day-date {
+  color: #be3f32;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.trip-day-summary,
+.trip-day-weather {
+  max-width: 860px;
+  color: #52616d;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.trip-day-weather {
+  border-left: 3px solid #d94b3d;
+  padding-left: 12px;
+}
+
+.activity-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.activity-card {
+  display: grid;
+  gap: 16px;
+  border: 1px solid #d8e0e6;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 20px;
+}
+
+.activity-card-header {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.activity-card h4 {
+  margin: 6px 0 0;
+  color: #172026;
+  font-size: 1.05rem;
+  line-height: 1.3;
+  letter-spacing: 0;
+}
+
+.activity-time {
+  margin: 0;
+  color: #be3f32;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.activity-category {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #f2f6f8;
+  color: #52616d;
+  font-size: 0.75rem;
+  font-weight: 800;
+  padding: 5px 9px;
+}
+
+.activity-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.activity-meta div {
+  min-width: 0;
+}
+
+.activity-meta dt {
+  color: #657480;
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.activity-meta dd {
+  display: grid;
+  gap: 3px;
+  margin: 4px 0 0;
+  color: #172026;
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.activity-meta small {
+  color: #657480;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.activity-notes {
+  margin: 0;
+  color: #52616d;
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.activity-map-link {
+  width: max-content;
+  color: #0d3b4f;
+  font-size: 0.9rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.activity-map-link:hover {
+  text-decoration: underline;
+}
+
+.itinerary-state {
+  border: 1px solid #d8e0e6;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 28px;
+}
+
+.itinerary-state p:last-child {
+  margin: 0;
+  color: #52616d;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
 @media (max-width: 820px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -225,12 +463,18 @@ select {
   }
 
   .workspace-hero,
-  .workspace-grid {
+  .workspace-grid,
+  .itinerary-summary,
+  .activity-list {
     grid-template-columns: 1fr;
   }
 
   .app-main {
     padding: 24px;
+  }
+
+  .activity-meta {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -249,11 +493,28 @@ select {
   }
 
   .workspace-hero,
-  .workspace-panel {
+  .workspace-panel,
+  .itinerary-summary,
+  .activity-card,
+  .itinerary-state {
     padding: 20px;
   }
 
   .workspace-hero h1 {
     font-size: 1.9rem;
+  }
+
+  .itinerary-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .trip-day-heading,
+  .activity-card-header {
+    display: grid;
+  }
+
+  .trip-day-heading span,
+  .activity-category {
+    width: max-content;
   }
 }

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -4,13 +4,13 @@ import { describe, expect, test } from "vitest";
 import { App } from "./App";
 
 describe("App", () => {
-  test("renders the responsive web MVP shell", () => {
+  test("renders the responsive itinerary preview shell", () => {
     const html = renderToString(<App />);
 
     expect(html).toContain("Japan Travel Planner");
-    expect(html).toContain("Japan trip workspace");
-    expect(html).toContain("No trip selected");
-    expect(html).toContain("React + Vite");
-    expect(html).toContain("localhost:5173");
+    expect(html).toContain("Japan trip itinerary");
+    expect(html).toContain("Tokyo And Kyoto Spring Highlights");
+    expect(html).toContain("Morning walk through Ueno Park");
+    expect(html).toContain("Preview");
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,21 +1,24 @@
 import "./App.css";
 
+import { ItineraryView } from "./features/itinerary/ItineraryView.js";
+import { mockItinerary } from "./mocks/index.js";
+
 const navigationItems = ["Planner", "Trips", "Account"];
 
 const workspacePanels = [
   {
     title: "Trip setup",
-    status: "No trip selected",
+    status: "Next ticket",
     detail: "Dates, cities, pace, budget, and interests"
   },
   {
     title: "Itinerary board",
-    status: "Empty",
-    detail: "Daily activities and travel notes"
+    status: "Preview ready",
+    detail: "Daily activities, timing, locations, cost levels, and notes"
   },
   {
     title: "Travel context",
-    status: "Pending trip",
+    status: "Mock context",
     detail: "Map links, weather, and local context"
   }
 ];
@@ -50,23 +53,26 @@ export function App() {
       <main className="app-main" aria-labelledby="workspace-title">
         <section className="workspace-hero">
           <div>
-            <p className="section-kicker">Web MVP Shell</p>
-            <h1 id="workspace-title">Japan trip workspace</h1>
-            <p className="workspace-state">No trip selected</p>
+            <p className="section-kicker">Web MVP Preview</p>
+            <h1 id="workspace-title">Japan trip itinerary</h1>
+            <p className="workspace-state">
+              A balanced Tokyo and Kyoto spring route with temples, markets,
+              viewpoints, and easy walking windows.
+            </p>
           </div>
 
           <dl className="shell-status" aria-label="Shell status">
             <div>
-              <dt>Frontend</dt>
-              <dd>React + Vite</dd>
+              <dt>Trip</dt>
+              <dd>{mockItinerary.title}</dd>
             </div>
             <div>
-              <dt>Local URL</dt>
-              <dd>localhost:5173</dd>
+              <dt>Days</dt>
+              <dd>{mockItinerary.days.length}</dd>
             </div>
             <div>
-              <dt>Backend</dt>
-              <dd>Not required</dd>
+              <dt>Mode</dt>
+              <dd>Preview</dd>
             </div>
           </dl>
         </section>
@@ -80,6 +86,8 @@ export function App() {
             </article>
           ))}
         </section>
+
+        <ItineraryView itinerary={mockItinerary} />
       </main>
     </div>
   );

--- a/apps/web/src/features/itinerary/ActivityCard.tsx
+++ b/apps/web/src/features/itinerary/ActivityCard.tsx
@@ -1,0 +1,100 @@
+import type {
+  Activity,
+  ActivityCategory,
+  ActivityCostLevel
+} from "../../../../../packages/shared/src/schemas/itinerary.js";
+
+const categoryLabels: Record<ActivityCategory, string> = {
+  sightseeing: "Sightseeing",
+  food: "Food",
+  culture: "Culture",
+  nature: "Nature",
+  shopping: "Shopping",
+  transit: "Transit",
+  lodging: "Lodging",
+  other: "Other"
+};
+
+const costLevelLabels: Record<ActivityCostLevel, string> = {
+  free: "Free",
+  low: "Low",
+  medium: "Medium",
+  high: "High"
+};
+
+const timeOfDayLabels = {
+  morning: "Morning",
+  afternoon: "Afternoon",
+  evening: "Evening",
+  night: "Night"
+};
+
+function formatTiming(activity: Activity) {
+  const { endTime, startTime, timeOfDay } = activity.timing;
+
+  if (startTime && endTime) {
+    return `${startTime}-${endTime}`;
+  }
+
+  if (startTime) {
+    return startTime;
+  }
+
+  return timeOfDay ? timeOfDayLabels[timeOfDay] : "Flexible";
+}
+
+export type ActivityCardProps = {
+  activity: Activity;
+};
+
+export function ActivityCard({ activity }: ActivityCardProps) {
+  const locationDetail =
+    activity.location.address ??
+    activity.location.city ??
+    activity.location.name;
+
+  return (
+    <article className="activity-card">
+      <div className="activity-card-header">
+        <div>
+          <p className="activity-time">{formatTiming(activity)}</p>
+          <h4>{activity.title}</h4>
+        </div>
+        <span className="activity-category">
+          {categoryLabels[activity.category]}
+        </span>
+      </div>
+
+      <dl className="activity-meta" aria-label={`${activity.title} details`}>
+        <div>
+          <dt>Duration</dt>
+          <dd>{activity.durationMinutes} min</dd>
+        </div>
+        <div>
+          <dt>Location</dt>
+          <dd>
+            <span>{activity.location.name}</span>
+            <small>{locationDetail}</small>
+          </dd>
+        </div>
+        <div>
+          <dt>Cost</dt>
+          <dd>{costLevelLabels[activity.costLevel]}</dd>
+        </div>
+      </dl>
+
+      <p className="activity-notes">{activity.notes}</p>
+
+      {activity.location.mapUrl ? (
+        <a
+          className="activity-map-link"
+          href={activity.location.mapUrl}
+          rel="noreferrer"
+          target="_blank"
+        >
+          Open map
+        </a>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/src/features/itinerary/ItinerarySummary.tsx
+++ b/apps/web/src/features/itinerary/ItinerarySummary.tsx
@@ -1,0 +1,40 @@
+import type { Itinerary } from "../../../../../packages/shared/src/schemas/itinerary.js";
+
+export type ItinerarySummaryProps = {
+  itinerary: Itinerary;
+};
+
+export function ItinerarySummary({ itinerary }: ItinerarySummaryProps) {
+  const activityCount = itinerary.days.reduce(
+    (total, day) => total + day.activities.length,
+    0
+  );
+  const cities = Array.from(new Set(itinerary.days.map((day) => day.city)));
+
+  return (
+    <section className="itinerary-summary" aria-labelledby="itinerary-title">
+      <div>
+        <p className="section-kicker">Mock Itinerary</p>
+        <h2 id="itinerary-title">{itinerary.title}</h2>
+        <p className="itinerary-date-range">
+          {itinerary.startDate} to {itinerary.endDate}
+        </p>
+      </div>
+
+      <dl className="itinerary-stats" aria-label="Itinerary summary">
+        <div>
+          <dt>Days</dt>
+          <dd>{itinerary.days.length}</dd>
+        </div>
+        <div>
+          <dt>Activities</dt>
+          <dd>{activityCount}</dd>
+        </div>
+        <div>
+          <dt>Cities</dt>
+          <dd>{cities.join(", ")}</dd>
+        </div>
+      </dl>
+    </section>
+  );
+}

--- a/apps/web/src/features/itinerary/ItineraryView.test.tsx
+++ b/apps/web/src/features/itinerary/ItineraryView.test.tsx
@@ -1,0 +1,54 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { mockItinerary } from "../../mocks/index.js";
+import { ItineraryView } from "./ItineraryView.js";
+
+describe("ItineraryView", () => {
+  test("renders days in chronological order", () => {
+    const reversedItinerary = {
+      ...mockItinerary,
+      days: [...mockItinerary.days].reverse()
+    };
+
+    const html = renderToString(
+      <ItineraryView itinerary={reversedItinerary} />
+    );
+
+    expect(html.indexOf('id="trip-day-2026-04-06"')).toBeLessThan(
+      html.indexOf('id="trip-day-2026-04-07"')
+    );
+    expect(html.indexOf('id="trip-day-2026-04-07"')).toBeLessThan(
+      html.indexOf('id="trip-day-2026-04-08"')
+    );
+  });
+
+  test("renders activity details", () => {
+    const html = renderToString(<ItineraryView itinerary={mockItinerary} />);
+    const normalizedHtml = html.replaceAll("<!-- -->", "");
+
+    expect(normalizedHtml).toContain("Morning walk through Ueno Park");
+    expect(normalizedHtml).toContain("09:00-10:30");
+    expect(normalizedHtml).toContain("90 min");
+    expect(normalizedHtml).toContain("Ueno Park");
+    expect(normalizedHtml).toContain("Free");
+    expect(normalizedHtml).toContain("Nature");
+    expect(normalizedHtml).toContain("seasonal blossoms around Shinobazu Pond");
+  });
+
+  test("renders an empty state", () => {
+    const html = renderToString(<ItineraryView itinerary={null} />);
+
+    expect(html).toContain("No itinerary yet");
+    expect(html).toContain("ready for generated or mock trip data");
+  });
+
+  test("renders a loading state", () => {
+    const html = renderToString(
+      <ItineraryView itinerary={mockItinerary} isLoading />
+    );
+
+    expect(html).toContain("Preparing itinerary");
+    expect(html).toContain('aria-busy="true"');
+  });
+});

--- a/apps/web/src/features/itinerary/ItineraryView.tsx
+++ b/apps/web/src/features/itinerary/ItineraryView.tsx
@@ -1,0 +1,47 @@
+import type { Itinerary } from "../../../../../packages/shared/src/schemas/itinerary.js";
+
+import { ItinerarySummary } from "./ItinerarySummary.js";
+import { TripDayPanel } from "./TripDayPanel.js";
+
+export type ItineraryViewProps = {
+  itinerary?: Itinerary | null;
+  isLoading?: boolean;
+};
+
+export function ItineraryView({ itinerary, isLoading }: ItineraryViewProps) {
+  if (isLoading) {
+    return (
+      <section className="itinerary-state" aria-busy="true">
+        <p className="section-kicker">Loading</p>
+        <h2>Preparing itinerary</h2>
+        <p>Trip results will appear here when the itinerary data is ready.</p>
+      </section>
+    );
+  }
+
+  if (!itinerary || itinerary.days.length === 0) {
+    return (
+      <section className="itinerary-state">
+        <p className="section-kicker">Empty</p>
+        <h2>No itinerary yet</h2>
+        <p>The itinerary board is ready for generated or mock trip data.</p>
+      </section>
+    );
+  }
+
+  const sortedDays = [...itinerary.days].sort((left, right) =>
+    left.date.localeCompare(right.date)
+  );
+
+  return (
+    <section className="itinerary-view" aria-labelledby="itinerary-title">
+      <ItinerarySummary itinerary={{ ...itinerary, days: sortedDays }} />
+
+      <div className="trip-day-list">
+        {sortedDays.map((day, index) => (
+          <TripDayPanel day={day} dayNumber={index + 1} key={day.date} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/itinerary/TripDayPanel.tsx
+++ b/apps/web/src/features/itinerary/TripDayPanel.tsx
@@ -1,0 +1,41 @@
+import type { TripDay } from "../../../../../packages/shared/src/schemas/itinerary.js";
+
+import { ActivityCard } from "./ActivityCard.js";
+
+export type TripDayPanelProps = {
+  day: TripDay;
+  dayNumber: number;
+};
+
+export function TripDayPanel({ day, dayNumber }: TripDayPanelProps) {
+  return (
+    <section
+      className="trip-day-panel"
+      aria-labelledby={`trip-day-${day.date}`}
+    >
+      <div className="trip-day-heading">
+        <div>
+          <p className="trip-day-date">{day.date}</p>
+          <h3 id={`trip-day-${day.date}`}>
+            Day {dayNumber}: {day.city}
+          </h3>
+        </div>
+        <span>{day.activities.length} activities</span>
+      </div>
+
+      {day.summary ? <p className="trip-day-summary">{day.summary}</p> : null}
+      {day.weatherSummary ? (
+        <p className="trip-day-weather">{day.weatherSummary}</p>
+      ) : null}
+
+      <div className="activity-list">
+        {day.activities.map((activity) => (
+          <ActivityCard
+            activity={activity}
+            key={activity.id ?? activity.title}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Ticket scope

Implement T-010 / Ticket 10: Build Itinerary Results Layout.

## Changes made

- Added a presentational itinerary results view powered by the existing Ticket 9 mock itinerary fixture.
- Rendered itinerary summary, chronological day sections, and activity cards.
- Included static empty and loading states for later wiring.
- Updated the web app shell to show the mock itinerary preview.
- Added responsive CSS for desktop and mobile layouts.

## Components added

- `apps/web/src/features/itinerary/ItineraryView.tsx`
- `apps/web/src/features/itinerary/ItinerarySummary.tsx`
- `apps/web/src/features/itinerary/TripDayPanel.tsx`
- `apps/web/src/features/itinerary/ActivityCard.tsx`

## Tests added

- `apps/web/src/features/itinerary/ItineraryView.test.tsx`
  - Days render in chronological order.
  - Activity metadata renders: title, timing, duration, location, cost, category, and notes.
  - Empty state renders.
  - Loading state renders.
- Updated `apps/web/src/App.test.tsx` for the itinerary preview shell.

## Checks run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm exec prettier --check apps/web/src/App.tsx apps/web/src/App.css apps/web/src/App.test.tsx apps/web/src/features/itinerary/*.tsx`
- Browser desktop check at `1280x720`: rendered 3 days, 12 activities, 12 map links, with no horizontal overflow.

## Known risks

- The original workspace checkout had local runtime hangs when running Vitest/TypeScript, so the validated commit was made from a fresh clone at `/Users/yuxuan/Documents/japan-travel-planner-ai-ticket10`. The original workspace was synced, branched, and then cleaned after transferring the patch.
- The in-app browser session became unavailable while attempting a mobile viewport check, so mobile responsiveness is covered by CSS implementation and tests, but not by a completed browser mobile run in this session.
- `pnpm install` reports the existing ignored `esbuild` build-script warning locally; it does not block install or checks.

## Ticket boundary confirmation

Ticket 8, Ticket 11, and later tickets were not started. No trip intake form, editing behavior, API calls, persistence/database code, or AI generation were added.