### PR TITLE
Ticket 8: Build Trip Intake Form With Mock Submit

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -210,6 +210,109 @@ select {
   line-height: 1.6;
 }
 
+.planner-workspace {
+  display: grid;
+  grid-template-columns: minmax(280px, 420px) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.trip-intake-form {
+  display: grid;
+  gap: 22px;
+  border: 1px solid #d8e0e6;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 24px;
+}
+
+.trip-intake-header h2 {
+  margin: 10px 0;
+  color: #172026;
+  font-size: 1.45rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.trip-intake-header p:last-child {
+  margin: 0;
+  color: #52616d;
+  font-size: 0.96rem;
+  line-height: 1.55;
+}
+
+.trip-intake-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.form-field {
+  display: grid;
+  gap: 7px;
+}
+
+.form-field-wide {
+  grid-column: 1 / -1;
+}
+
+.form-field label {
+  color: #172026;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid #cfd9df;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #172026;
+  padding: 10px 11px;
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.form-field input:focus,
+.form-field select:focus,
+.form-field textarea:focus {
+  border-color: #0d3b4f;
+  outline: 3px solid #dbecef;
+}
+
+.form-field [aria-invalid="true"] {
+  border-color: #be3f32;
+}
+
+.field-error {
+  margin: 0;
+  color: #be3f32;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.trip-intake-submit {
+  width: 100%;
+  border: 0;
+  border-radius: 6px;
+  background: #0d3b4f;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 12px 16px;
+}
+
+.trip-intake-submit:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
 .itinerary-view {
   display: grid;
   gap: 28px;
@@ -464,6 +567,7 @@ select {
 
   .workspace-hero,
   .workspace-grid,
+  .planner-workspace,
   .itinerary-summary,
   .activity-list {
     grid-template-columns: 1fr;
@@ -494,10 +598,15 @@ select {
 
   .workspace-hero,
   .workspace-panel,
+  .trip-intake-form,
   .itinerary-summary,
   .activity-card,
   .itinerary-state {
     padding: 20px;
+  }
+
+  .trip-intake-grid {
+    grid-template-columns: 1fr;
   }
 
   .workspace-hero h1 {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -4,13 +4,14 @@ import { describe, expect, test } from "vitest";
 import { App } from "./App";
 
 describe("App", () => {
-  test("renders the responsive itinerary preview shell", () => {
+  test("renders the responsive trip planner shell", () => {
     const html = renderToString(<App />);
 
     expect(html).toContain("Japan Travel Planner");
-    expect(html).toContain("Japan trip itinerary");
-    expect(html).toContain("Tokyo And Kyoto Spring Highlights");
-    expect(html).toContain("Morning walk through Ueno Park");
-    expect(html).toContain("Preview");
+    expect(html).toContain("Japan trip planner");
+    expect(html).toContain("Plan your Japan route");
+    expect(html).toContain("Generate mock itinerary");
+    expect(html).toContain("No itinerary yet");
+    expect(html).toContain("Input");
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,29 +1,48 @@
 import "./App.css";
 
+import { useState } from "react";
+
+import type { Itinerary } from "../../../packages/shared/src/schemas/itinerary.js";
 import { ItineraryView } from "./features/itinerary/ItineraryView.js";
+import { TripIntakeForm } from "./features/trip-intake/index.js";
 import { mockItinerary } from "./mocks/index.js";
 
 const navigationItems = ["Planner", "Trips", "Account"];
 
-const workspacePanels = [
-  {
-    title: "Trip setup",
-    status: "Next ticket",
-    detail: "Dates, cities, pace, budget, and interests"
-  },
-  {
-    title: "Itinerary board",
-    status: "Preview ready",
-    detail: "Daily activities, timing, locations, cost levels, and notes"
-  },
-  {
-    title: "Travel context",
-    status: "Mock context",
-    detail: "Map links, weather, and local context"
-  }
-];
+const mockSubmitDelayMs = 500;
 
 export function App() {
+  const [itinerary, setItinerary] = useState<Itinerary | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const workspacePanels = [
+    {
+      title: "Trip setup",
+      status: isSubmitting ? "Submitting" : "Ready",
+      detail: "Dates, cities, pace, budget, and interests"
+    },
+    {
+      title: "Itinerary board",
+      status: itinerary ? "Preview ready" : "Waiting",
+      detail: "Daily activities, timing, locations, cost levels, and notes"
+    },
+    {
+      title: "Travel context",
+      status: "Mock context",
+      detail: "Map links, weather, and local context"
+    }
+  ];
+
+  function handleMockSubmit() {
+    setIsSubmitting(true);
+    setItinerary(null);
+
+    setTimeout(() => {
+      setItinerary(mockItinerary);
+      setIsSubmitting(false);
+    }, mockSubmitDelayMs);
+  }
+
   return (
     <div className="app-shell">
       <aside className="app-sidebar" aria-label="Workspace navigation">
@@ -54,25 +73,27 @@ export function App() {
         <section className="workspace-hero">
           <div>
             <p className="section-kicker">Web MVP Preview</p>
-            <h1 id="workspace-title">Japan trip itinerary</h1>
+            <h1 id="workspace-title">Japan trip planner</h1>
             <p className="workspace-state">
-              A balanced Tokyo and Kyoto spring route with temples, markets,
-              viewpoints, and easy walking windows.
+              Build a request from dates, cities, interests, pace, budget, and
+              constraints before previewing a structured mock itinerary.
             </p>
           </div>
 
           <dl className="shell-status" aria-label="Shell status">
             <div>
               <dt>Trip</dt>
-              <dd>{mockItinerary.title}</dd>
+              <dd>{itinerary?.title ?? "Not generated"}</dd>
             </div>
             <div>
               <dt>Days</dt>
-              <dd>{mockItinerary.days.length}</dd>
+              <dd>{itinerary?.days.length ?? 0}</dd>
             </div>
             <div>
               <dt>Mode</dt>
-              <dd>Preview</dd>
+              <dd>
+                {isSubmitting ? "Loading" : itinerary ? "Preview" : "Input"}
+              </dd>
             </div>
           </dl>
         </section>
@@ -87,7 +108,13 @@ export function App() {
           ))}
         </section>
 
-        <ItineraryView itinerary={mockItinerary} />
+        <section className="planner-workspace" aria-label="Trip planner">
+          <TripIntakeForm
+            isSubmitting={isSubmitting}
+            onMockSubmit={handleMockSubmit}
+          />
+          <ItineraryView itinerary={itinerary} isLoading={isSubmitting} />
+        </section>
       </main>
     </div>
   );

--- a/apps/web/src/features/trip-intake/TripIntakeForm.tsx
+++ b/apps/web/src/features/trip-intake/TripIntakeForm.tsx
@@ -1,0 +1,253 @@
+import { type FormEvent, useState } from "react";
+
+import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
+import {
+  tripIntakeInitialValues,
+  validateTripIntake,
+  type TripIntakeErrors,
+  type TripIntakeField,
+  type TripIntakeFormValues
+} from "./formState.js";
+
+export type TripIntakeFormProps = {
+  initialValues?: TripIntakeFormValues;
+  isSubmitting?: boolean;
+  onMockSubmit: (request: TripRequest) => void;
+};
+
+const fieldIds = {
+  startDate: "trip-start-date",
+  endDate: "trip-end-date",
+  cities: "trip-cities",
+  interests: "trip-interests",
+  pace: "trip-pace",
+  budget: "trip-budget",
+  constraints: "trip-constraints"
+} satisfies Record<TripIntakeField, string>;
+
+function FieldError({
+  errors,
+  field
+}: {
+  errors: TripIntakeErrors;
+  field: TripIntakeField;
+}) {
+  const message = errors[field];
+
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <p className="field-error" id={`${fieldIds[field]}-error`}>
+      {message}
+    </p>
+  );
+}
+
+export function TripIntakeForm({
+  initialValues = tripIntakeInitialValues,
+  isSubmitting = false,
+  onMockSubmit
+}: TripIntakeFormProps) {
+  const [values, setValues] = useState<TripIntakeFormValues>(initialValues);
+  const [errors, setErrors] = useState<TripIntakeErrors>({});
+
+  function updateField<Field extends TripIntakeField>(
+    field: Field,
+    value: TripIntakeFormValues[Field]
+  ) {
+    setValues((currentValues) => ({
+      ...currentValues,
+      [field]: value
+    }));
+
+    if (errors[field]) {
+      setErrors((currentErrors) => {
+        const nextErrors = { ...currentErrors };
+        delete nextErrors[field];
+        return nextErrors;
+      });
+    }
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const validation = validateTripIntake(values);
+    setErrors(validation.errors);
+
+    if (validation.success) {
+      onMockSubmit(validation.request);
+    }
+  }
+
+  return (
+    <form
+      aria-labelledby="trip-intake-title"
+      className="trip-intake-form"
+      noValidate
+      onSubmit={handleSubmit}
+    >
+      <header className="trip-intake-header">
+        <p className="section-kicker">Trip setup</p>
+        <h2 id="trip-intake-title">Plan your Japan route</h2>
+        <p>
+          Set the travel frame, then preview the structured mock itinerary for
+          this MVP.
+        </p>
+      </header>
+
+      <div className="trip-intake-grid">
+        <div className="form-field">
+          <label htmlFor={fieldIds.startDate}>Start date</label>
+          <input
+            aria-describedby={
+              errors.startDate ? `${fieldIds.startDate}-error` : undefined
+            }
+            aria-invalid={Boolean(errors.startDate)}
+            id={fieldIds.startDate}
+            name="startDate"
+            onChange={(event) =>
+              updateField("startDate", event.currentTarget.value)
+            }
+            required
+            type="date"
+            value={values.startDate}
+          />
+          <FieldError errors={errors} field="startDate" />
+        </div>
+
+        <div className="form-field">
+          <label htmlFor={fieldIds.endDate}>End date</label>
+          <input
+            aria-describedby={
+              errors.endDate ? `${fieldIds.endDate}-error` : undefined
+            }
+            aria-invalid={Boolean(errors.endDate)}
+            id={fieldIds.endDate}
+            name="endDate"
+            onChange={(event) =>
+              updateField("endDate", event.currentTarget.value)
+            }
+            required
+            type="date"
+            value={values.endDate}
+          />
+          <FieldError errors={errors} field="endDate" />
+        </div>
+
+        <div className="form-field">
+          <label htmlFor={fieldIds.cities}>Cities</label>
+          <input
+            aria-describedby={
+              errors.cities ? `${fieldIds.cities}-error` : undefined
+            }
+            aria-invalid={Boolean(errors.cities)}
+            id={fieldIds.cities}
+            name="cities"
+            onChange={(event) =>
+              updateField("cities", event.currentTarget.value)
+            }
+            required
+            type="text"
+            value={values.cities}
+          />
+          <FieldError errors={errors} field="cities" />
+        </div>
+
+        <div className="form-field">
+          <label htmlFor={fieldIds.interests}>Interests</label>
+          <input
+            aria-describedby={
+              errors.interests ? `${fieldIds.interests}-error` : undefined
+            }
+            aria-invalid={Boolean(errors.interests)}
+            id={fieldIds.interests}
+            name="interests"
+            onChange={(event) =>
+              updateField("interests", event.currentTarget.value)
+            }
+            required
+            type="text"
+            value={values.interests}
+          />
+          <FieldError errors={errors} field="interests" />
+        </div>
+
+        <div className="form-field">
+          <label htmlFor={fieldIds.pace}>Travel pace</label>
+          <select
+            aria-describedby={
+              errors.pace ? `${fieldIds.pace}-error` : undefined
+            }
+            aria-invalid={Boolean(errors.pace)}
+            id={fieldIds.pace}
+            name="pace"
+            onChange={(event) =>
+              updateField(
+                "pace",
+                event.currentTarget.value as TripIntakeFormValues["pace"]
+              )
+            }
+            required
+            value={values.pace}
+          >
+            <option value="">Select pace</option>
+            <option value="relaxed">Relaxed</option>
+            <option value="balanced">Balanced</option>
+            <option value="packed">Packed</option>
+          </select>
+          <FieldError errors={errors} field="pace" />
+        </div>
+
+        <div className="form-field">
+          <label htmlFor={fieldIds.budget}>Budget</label>
+          <select
+            aria-describedby={
+              errors.budget ? `${fieldIds.budget}-error` : undefined
+            }
+            aria-invalid={Boolean(errors.budget)}
+            id={fieldIds.budget}
+            name="budget"
+            onChange={(event) =>
+              updateField(
+                "budget",
+                event.currentTarget.value as TripIntakeFormValues["budget"]
+              )
+            }
+            required
+            value={values.budget}
+          >
+            <option value="">Select budget</option>
+            <option value="budget">Budget</option>
+            <option value="moderate">Moderate</option>
+            <option value="luxury">Luxury</option>
+          </select>
+          <FieldError errors={errors} field="budget" />
+        </div>
+
+        <div className="form-field form-field-wide">
+          <label htmlFor={fieldIds.constraints}>Constraints</label>
+          <textarea
+            id={fieldIds.constraints}
+            name="constraints"
+            onChange={(event) =>
+              updateField("constraints", event.currentTarget.value)
+            }
+            rows={3}
+            value={values.constraints}
+          />
+        </div>
+      </div>
+
+      <button
+        className="trip-intake-submit"
+        disabled={isSubmitting}
+        type="submit"
+      >
+        {isSubmitting ? "Preparing preview" : "Generate mock itinerary"}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/src/features/trip-intake/formState.ts
+++ b/apps/web/src/features/trip-intake/formState.ts
@@ -1,0 +1,204 @@
+import type { Itinerary } from "../../../../../packages/shared/src/schemas/itinerary.js";
+import {
+  tripRequestSchema,
+  type TravelBudget,
+  type TravelPace,
+  type TripRequest
+} from "../../../../../packages/shared/src/schemas/tripRequest.js";
+import { mockItinerary, mockTripRequest } from "../../mocks/index.js";
+
+export type TripIntakeFormValues = {
+  startDate: string;
+  endDate: string;
+  cities: string;
+  interests: string;
+  pace: TravelPace | "";
+  budget: TravelBudget | "";
+  constraints: string;
+};
+
+export type TripIntakeField = keyof TripIntakeFormValues;
+
+export type TripIntakeErrors = Partial<Record<TripIntakeField, string>>;
+
+export type TripIntakeValidationResult =
+  | {
+      success: true;
+      request: TripRequest;
+      errors: TripIntakeErrors;
+    }
+  | {
+      success: false;
+      errors: TripIntakeErrors;
+    };
+
+export type TripIntakeSubmitResult =
+  | {
+      status: "success";
+      request: TripRequest;
+      itinerary: Itinerary;
+    }
+  | {
+      status: "error";
+      errors: TripIntakeErrors;
+    };
+
+export const emptyTripIntakeValues = {
+  startDate: "",
+  endDate: "",
+  cities: "",
+  interests: "",
+  pace: "",
+  budget: "",
+  constraints: ""
+} satisfies TripIntakeFormValues;
+
+export const tripIntakeInitialValues = {
+  startDate: mockTripRequest.startDate,
+  endDate: mockTripRequest.endDate,
+  cities: mockTripRequest.cities.join(", "),
+  interests: mockTripRequest.interests.join(", "),
+  pace: mockTripRequest.pace,
+  budget: mockTripRequest.budget,
+  constraints: mockTripRequest.constraints.join("\n")
+} satisfies TripIntakeFormValues;
+
+const fieldLabels = {
+  startDate: "Start date",
+  endDate: "End date",
+  cities: "Cities",
+  interests: "Interests",
+  pace: "Travel pace",
+  budget: "Budget",
+  constraints: "Constraints"
+} satisfies Record<TripIntakeField, string>;
+
+function parseList(value: string) {
+  return value
+    .split(/[,\n]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function toTripRequestInput(values: TripIntakeFormValues) {
+  return {
+    startDate: values.startDate.trim(),
+    endDate: values.endDate.trim(),
+    cities: parseList(values.cities),
+    interests: parseList(values.interests),
+    pace: values.pace,
+    budget: values.budget,
+    constraints: parseList(values.constraints)
+  };
+}
+
+function getIssueMessage(field: TripIntakeField, message: string) {
+  if (message === "endDate must be on or after startDate.") {
+    return "End date must be on or after the start date.";
+  }
+
+  if (field === "startDate" || field === "endDate") {
+    return `${fieldLabels[field]} must use YYYY-MM-DD.`;
+  }
+
+  if (field === "cities") {
+    return "Add at least one city.";
+  }
+
+  if (field === "interests") {
+    return "Add at least one interest.";
+  }
+
+  if (field === "pace") {
+    return "Choose a travel pace.";
+  }
+
+  if (field === "budget") {
+    return "Choose a budget.";
+  }
+
+  return message;
+}
+
+function isTripIntakeField(value: PropertyKey): value is TripIntakeField {
+  return value in fieldLabels;
+}
+
+function getRequiredErrors(values: TripIntakeFormValues) {
+  const errors: TripIntakeErrors = {};
+
+  if (!values.startDate.trim()) {
+    errors.startDate = "Start date is required.";
+  }
+
+  if (!values.endDate.trim()) {
+    errors.endDate = "End date is required.";
+  }
+
+  if (parseList(values.cities).length === 0) {
+    errors.cities = "Add at least one city.";
+  }
+
+  if (parseList(values.interests).length === 0) {
+    errors.interests = "Add at least one interest.";
+  }
+
+  if (!values.pace) {
+    errors.pace = "Choose a travel pace.";
+  }
+
+  if (!values.budget) {
+    errors.budget = "Choose a budget.";
+  }
+
+  return errors;
+}
+
+export function validateTripIntake(
+  values: TripIntakeFormValues
+): TripIntakeValidationResult {
+  const errors = getRequiredErrors(values);
+  const parsed = tripRequestSchema.safeParse(toTripRequestInput(values));
+
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      const [field] = issue.path;
+
+      if (field !== undefined && isTripIntakeField(field) && !errors[field]) {
+        errors[field] = getIssueMessage(field, issue.message);
+      }
+    }
+  }
+
+  if (Object.keys(errors).length > 0 || !parsed.success) {
+    return {
+      success: false,
+      errors
+    };
+  }
+
+  return {
+    success: true,
+    request: parsed.data,
+    errors: {}
+  };
+}
+
+export function submitTripIntake(
+  values: TripIntakeFormValues
+): TripIntakeSubmitResult {
+  const validation = validateTripIntake(values);
+
+  if (!validation.success) {
+    return {
+      status: "error",
+      errors: validation.errors
+    };
+  }
+
+  return {
+    status: "success",
+    request: validation.request,
+    itinerary: mockItinerary
+  };
+}

--- a/apps/web/src/features/trip-intake/index.ts
+++ b/apps/web/src/features/trip-intake/index.ts
@@ -1,0 +1,15 @@
+export { TripIntakeForm } from "./TripIntakeForm.js";
+export type { TripIntakeFormProps } from "./TripIntakeForm.js";
+export {
+  emptyTripIntakeValues,
+  submitTripIntake,
+  tripIntakeInitialValues,
+  validateTripIntake
+} from "./formState.js";
+export type {
+  TripIntakeErrors,
+  TripIntakeField,
+  TripIntakeFormValues,
+  TripIntakeSubmitResult,
+  TripIntakeValidationResult
+} from "./formState.js";

--- a/apps/web/src/features/trip-intake/tripIntakeForm.test.tsx
+++ b/apps/web/src/features/trip-intake/tripIntakeForm.test.tsx
@@ -1,0 +1,87 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { ItineraryView } from "../itinerary/ItineraryView.js";
+import { mockTripRequest } from "../../mocks/index.js";
+import { TripIntakeForm } from "./TripIntakeForm.js";
+import {
+  emptyTripIntakeValues,
+  submitTripIntake,
+  tripIntakeInitialValues,
+  validateTripIntake
+} from "./formState.js";
+
+describe("TripIntakeForm", () => {
+  test("renders the required trip request fields", () => {
+    const html = renderToString(
+      <TripIntakeForm onMockSubmit={() => undefined} />
+    );
+
+    expect(html).toContain("Start date");
+    expect(html).toContain("End date");
+    expect(html).toContain("Cities");
+    expect(html).toContain("Interests");
+    expect(html).toContain("Travel pace");
+    expect(html).toContain("Budget");
+    expect(html).toContain("Constraints");
+  });
+
+  test("returns required field errors", () => {
+    const result = validateTripIntake(emptyTripIntakeValues);
+
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.errors).toMatchObject({
+        startDate: "Start date is required.",
+        endDate: "End date is required.",
+        cities: "Add at least one city.",
+        interests: "Add at least one interest.",
+        pace: "Choose a travel pace.",
+        budget: "Choose a budget."
+      });
+    }
+  });
+
+  test("returns validation errors for invalid date ranges", () => {
+    const result = validateTripIntake({
+      ...tripIntakeInitialValues,
+      startDate: "2026-04-09",
+      endDate: "2026-04-08"
+    });
+
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.errors.endDate).toBe(
+        "End date must be on or after the start date."
+      );
+    }
+  });
+
+  test("creates a schema-valid request for valid submissions", () => {
+    const result = submitTripIntake(tripIntakeInitialValues);
+
+    expect(result.status).toBe("success");
+
+    if (result.status === "success") {
+      expect(result.request).toEqual(mockTripRequest);
+      expect(result.itinerary.title).toBe("Tokyo And Kyoto Spring Highlights");
+    }
+  });
+
+  test("supports rendering the mock itinerary after submit", () => {
+    const result = submitTripIntake(tripIntakeInitialValues);
+
+    expect(result.status).toBe("success");
+
+    if (result.status === "success") {
+      const html = renderToString(
+        <ItineraryView itinerary={result.itinerary} />
+      );
+
+      expect(html).toContain("Tokyo And Kyoto Spring Highlights");
+      expect(html).toContain("Morning walk through Ueno Park");
+    }
+  });
+});


### PR DESCRIPTION
## Ticket scope
Implement only T-008 / Ticket 8: Build Trip Intake Form With Mock Submit.

## Changes made
- Added a web trip-intake form that captures date range, cities, interests, pace, budget, and constraints.
- Wired the app shell so itinerary results are empty before submit, loading during mock submit, and populated with the existing mock itinerary after submit.
- Preserved the existing itinerary results components and did not add API calls, persistence, editing, or AI generation.
- Updated the App smoke test for the new initial form/empty-state shell.

## Components/state added
- `apps/web/src/features/trip-intake/TripIntakeForm.tsx`
- `apps/web/src/features/trip-intake/formState.ts`
- `apps/web/src/features/trip-intake/index.ts`
- `apps/web/src/features/trip-intake/tripIntakeForm.test.tsx`

## Validation approach
- Uses the existing shared `tripRequestSchema` through a small form-state helper.
- Converts comma/newline-separated cities, interests, and constraints into schema-compatible arrays.
- Provides field-level required and invalid-date-range errors.

## Mock submit behavior
- The form defaults to the existing `mockTripRequest` values as a sensible example.
- A valid submit shows a local loading state, clears the preview area, then displays the existing `mockItinerary` fixture.
- The mock submit intentionally does not call an API or generate AI output.

## Tests added/updated
- Added trip intake tests for required fields, required validation errors, invalid date range validation, valid submit, and mock itinerary render after submit.
- Updated the App smoke test to assert the form and empty itinerary state.

## Checks run
- `pnpm install` passed.
- `pnpm lint` was attempted, but local ESLint stalled with no diagnostics after multiple polls; targeted `pnpm --filter @japan-travel-planner/web exec eslint src` stalled the same way.
- `pnpm typecheck` was attempted, but local TypeScript package checks stalled; direct web typecheck also stalled for over five minutes with no diagnostics.
- `pnpm test` failed before reaching web tests because Vitest default fork workers timed out in existing shared-package tests.
- `pnpm build` was attempted, but the scripted TypeScript build stalled in package build steps.
- `pnpm --filter @japan-travel-planner/web test` was attempted with the default Vitest fork pool and stalled.
- `pnpm --filter @japan-travel-planner/web exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism` passed: 4 files, 13 tests.
- `pnpm --filter @japan-travel-planner/shared exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism` passed: 4 files, 11 tests.
- `pnpm --filter @japan-travel-planner/web exec vite build` passed.
- `git diff --check` passed.

## Browser/manual checks run
- Started the web app at `http://localhost:5173/`.
- Verified desktop initial state: form present, itinerary empty state visible, mock itinerary absent before submit.
- Submitted a valid trip request and verified loading state before mock itinerary appears.
- Verified submitted itinerary title and first activity render.
- Checked 390px mobile viewport: single-column planner layout, no horizontal overflow, empty state before submit, itinerary after submit.

## Known risks
- The local default Vitest fork runner and TypeScript/ESLint scripts appear to have existing process-runner stalls in this environment. I did not change tooling configuration because that is outside Ticket 8.
- The mock itinerary is static and does not vary by edited form inputs; this is intentional for Ticket 8 until later API/AI work.

## Ticket 11+ confirmation
Ticket 11 and later were not started.