### PR TITLE
Ticket 11: Add Client-Side Itinerary Editing

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -318,6 +318,19 @@ select {
   gap: 28px;
 }
 
+.itinerary-dirty-state {
+  width: max-content;
+  max-width: 100%;
+  margin: 0;
+  border: 1px solid #e8c9a4;
+  border-radius: 999px;
+  background: #fff7ed;
+  color: #8a4a0a;
+  font-size: 0.82rem;
+  font-weight: 800;
+  padding: 7px 11px;
+}
+
 .itinerary-summary {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(260px, 420px);
@@ -401,6 +414,12 @@ select {
   letter-spacing: 0;
 }
 
+.trip-day-actions {
+  display: grid;
+  gap: 10px;
+  justify-items: end;
+}
+
 .trip-day-heading span {
   flex: 0 0 auto;
   border-radius: 999px;
@@ -409,6 +428,25 @@ select {
   font-size: 0.82rem;
   font-weight: 800;
   padding: 6px 10px;
+}
+
+.trip-day-actions button,
+.activity-card-actions button,
+.activity-editor-actions button {
+  border: 1px solid #cfd9df;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #0d3b4f;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 800;
+  padding: 8px 10px;
+}
+
+.trip-day-actions button:hover,
+.activity-card-actions button:hover,
+.activity-editor-actions button:hover {
+  border-color: #0d3b4f;
 }
 
 .trip-day-date,
@@ -537,6 +575,77 @@ select {
   text-decoration: underline;
 }
 
+.activity-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  border-top: 1px solid #edf1f4;
+  padding-top: 14px;
+}
+
+.activity-card-actions button:disabled,
+.activity-editor-actions button:disabled,
+.reorder-controls button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.reorder-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.activity-editor-backdrop {
+  position: fixed;
+  z-index: 10;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgb(23 32 38 / 0.38);
+  padding: 24px;
+}
+
+.activity-editor-dialog {
+  display: grid;
+  width: min(860px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  gap: 20px;
+  overflow: auto;
+  border: 1px solid #d8e0e6;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 24px;
+  box-shadow: 0 18px 60px rgb(23 32 38 / 0.24);
+}
+
+.activity-editor-dialog h2 {
+  margin: 10px 0 0;
+  color: #172026;
+  font-size: 1.45rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.activity-editor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.activity-editor-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.activity-editor-save {
+  border-color: #0d3b4f !important;
+  background: #0d3b4f !important;
+  color: #ffffff !important;
+}
+
 .itinerary-state {
   border: 1px solid #d8e0e6;
   border-radius: 8px;
@@ -625,5 +734,25 @@ select {
   .trip-day-heading span,
   .activity-category {
     width: max-content;
+  }
+
+  .trip-day-actions {
+    justify-items: start;
+  }
+
+  .activity-card-actions,
+  .activity-editor-actions,
+  .reorder-controls {
+    display: grid;
+  }
+
+  .activity-editor-backdrop {
+    align-items: stretch;
+    padding: 12px;
+  }
+
+  .activity-editor-dialog,
+  .activity-editor-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,8 +2,11 @@ import "./App.css";
 
 import { useState } from "react";
 
-import type { Itinerary } from "../../../packages/shared/src/schemas/itinerary.js";
 import { ItineraryView } from "./features/itinerary/ItineraryView.js";
+import {
+  cloneItinerary,
+  useItineraryEditor
+} from "./features/itinerary/editing/useItineraryEditor.js";
 import { TripIntakeForm } from "./features/trip-intake/index.js";
 import { mockItinerary } from "./mocks/index.js";
 
@@ -12,8 +15,9 @@ const navigationItems = ["Planner", "Trips", "Account"];
 const mockSubmitDelayMs = 500;
 
 export function App() {
-  const [itinerary, setItinerary] = useState<Itinerary | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const itineraryEditor = useItineraryEditor(null);
+  const itinerary = itineraryEditor.itinerary;
 
   const workspacePanels = [
     {
@@ -23,7 +27,11 @@ export function App() {
     },
     {
       title: "Itinerary board",
-      status: itinerary ? "Preview ready" : "Waiting",
+      status: itineraryEditor.isDirty
+        ? "Local edits"
+        : itinerary
+          ? "Preview ready"
+          : "Waiting",
       detail: "Daily activities, timing, locations, cost levels, and notes"
     },
     {
@@ -35,10 +43,10 @@ export function App() {
 
   function handleMockSubmit() {
     setIsSubmitting(true);
-    setItinerary(null);
+    itineraryEditor.resetItinerary(null);
 
     setTimeout(() => {
-      setItinerary(mockItinerary);
+      itineraryEditor.resetItinerary(cloneItinerary(mockItinerary));
       setIsSubmitting(false);
     }, mockSubmitDelayMs);
   }
@@ -92,7 +100,13 @@ export function App() {
             <div>
               <dt>Mode</dt>
               <dd>
-                {isSubmitting ? "Loading" : itinerary ? "Preview" : "Input"}
+                {isSubmitting
+                  ? "Loading"
+                  : itineraryEditor.isDirty
+                    ? "Editing"
+                    : itinerary
+                      ? "Preview"
+                      : "Input"}
               </dd>
             </div>
           </dl>
@@ -113,7 +127,17 @@ export function App() {
             isSubmitting={isSubmitting}
             onMockSubmit={handleMockSubmit}
           />
-          <ItineraryView itinerary={itinerary} isLoading={isSubmitting} />
+          <ItineraryView
+            editing={{
+              isDirty: itineraryEditor.isDirty,
+              onAddActivity: itineraryEditor.addActivity,
+              onDeleteActivity: itineraryEditor.deleteActivity,
+              onMoveActivity: itineraryEditor.moveActivity,
+              onUpdateActivity: itineraryEditor.updateActivity
+            }}
+            itinerary={itinerary}
+            isLoading={isSubmitting}
+          />
         </section>
       </main>
     </div>

--- a/apps/web/src/features/itinerary/ActivityCard.tsx
+++ b/apps/web/src/features/itinerary/ActivityCard.tsx
@@ -3,6 +3,8 @@ import type {
   ActivityCategory,
   ActivityCostLevel
 } from "../../../../../packages/shared/src/schemas/itinerary.js";
+import { ReorderControls } from "./editing/ReorderControls.js";
+import type { ReorderDirection } from "./editing/useItineraryEditor.js";
 
 const categoryLabels: Record<ActivityCategory, string> = {
   sightseeing: "Sightseeing",
@@ -45,9 +47,19 @@ function formatTiming(activity: Activity) {
 
 export type ActivityCardProps = {
   activity: Activity;
+  editingControls?: {
+    canDelete: boolean;
+    onDelete: () => void;
+    onEdit: () => void;
+    reorder: {
+      canMoveDown: boolean;
+      canMoveUp: boolean;
+      onMove: (direction: ReorderDirection) => void;
+    };
+  } | undefined;
 };
 
-export function ActivityCard({ activity }: ActivityCardProps) {
+export function ActivityCard({ activity, editingControls }: ActivityCardProps) {
   const locationDetail =
     activity.location.address ??
     activity.location.city ??
@@ -94,6 +106,32 @@ export function ActivityCard({ activity }: ActivityCardProps) {
         >
           Open map
         </a>
+      ) : null}
+
+      {editingControls ? (
+        <div className="activity-card-actions">
+          <button
+            aria-label={`Edit ${activity.title}`}
+            onClick={editingControls.onEdit}
+            type="button"
+          >
+            Edit
+          </button>
+          <button
+            aria-label={`Delete ${activity.title}`}
+            disabled={!editingControls.canDelete}
+            onClick={editingControls.onDelete}
+            type="button"
+          >
+            Delete
+          </button>
+          <ReorderControls
+            activityTitle={activity.title}
+            canMoveDown={editingControls.reorder.canMoveDown}
+            canMoveUp={editingControls.reorder.canMoveUp}
+            onMove={editingControls.reorder.onMove}
+          />
+        </div>
       ) : null}
     </article>
   );

--- a/apps/web/src/features/itinerary/ItineraryView.test.tsx
+++ b/apps/web/src/features/itinerary/ItineraryView.test.tsx
@@ -51,4 +51,26 @@ describe("ItineraryView", () => {
     expect(html).toContain("Preparing itinerary");
     expect(html).toContain('aria-busy="true"');
   });
+
+  test("renders local editing controls and dirty state", () => {
+    const html = renderToString(
+      <ItineraryView
+        editing={{
+          isDirty: true,
+          onAddActivity: () => undefined,
+          onDeleteActivity: () => undefined,
+          onMoveActivity: () => undefined,
+          onUpdateActivity: () => undefined
+        }}
+        itinerary={mockItinerary}
+      />
+    );
+
+    expect(html).toContain("Unsaved local edits");
+    expect(html).toContain("Add activity");
+    expect(html).toContain("Edit");
+    expect(html).toContain("Delete");
+    expect(html).toContain("Move Ameyoko lunch crawl up");
+    expect(html).toContain("Move Morning walk through Ueno Park down");
+  });
 });

--- a/apps/web/src/features/itinerary/ItineraryView.tsx
+++ b/apps/web/src/features/itinerary/ItineraryView.tsx
@@ -1,14 +1,56 @@
-import type { Itinerary } from "../../../../../packages/shared/src/schemas/itinerary.js";
+import { useState } from "react";
+
+import type {
+  Activity,
+  Itinerary,
+  TripDay
+} from "../../../../../packages/shared/src/schemas/itinerary.js";
 
 import { ItinerarySummary } from "./ItinerarySummary.js";
 import { TripDayPanel } from "./TripDayPanel.js";
+import {
+  ActivityEditorDialog,
+  createDefaultActivity
+} from "./editing/ActivityEditorDialog.js";
+import type { ReorderDirection } from "./editing/useItineraryEditor.js";
 
-export type ItineraryViewProps = {
-  itinerary?: Itinerary | null;
-  isLoading?: boolean;
+export type ItineraryEditingControls = {
+  isDirty: boolean;
+  onAddActivity: (dayDate: string, activity: Activity) => void;
+  onDeleteActivity: (dayDate: string, activityId: string) => void;
+  onMoveActivity: (
+    dayDate: string,
+    activityId: string,
+    direction: ReorderDirection
+  ) => void;
+  onUpdateActivity: (
+    dayDate: string,
+    activityId: string,
+    activity: Activity
+  ) => void;
 };
 
-export function ItineraryView({ itinerary, isLoading }: ItineraryViewProps) {
+type ActivityEditorState = {
+  activity: Activity;
+  activityId?: string;
+  day: TripDay;
+  mode: "add" | "edit";
+};
+
+export type ItineraryViewProps = {
+  editing?: ItineraryEditingControls | undefined;
+  itinerary?: Itinerary | null | undefined;
+  isLoading?: boolean | undefined;
+};
+
+export function ItineraryView({
+  editing,
+  itinerary,
+  isLoading
+}: ItineraryViewProps) {
+  const [activityEditor, setActivityEditor] =
+    useState<ActivityEditorState | null>(null);
+
   if (isLoading) {
     return (
       <section className="itinerary-state" aria-busy="true">
@@ -33,15 +75,90 @@ export function ItineraryView({ itinerary, isLoading }: ItineraryViewProps) {
     left.date.localeCompare(right.date)
   );
 
+  function openAddActivity(day: TripDay) {
+    setActivityEditor({
+      activity: createDefaultActivity(day),
+      day,
+      mode: "add"
+    });
+  }
+
+  function openEditActivity(day: TripDay, activity: Activity) {
+    if (!activity.id) {
+      return;
+    }
+
+    setActivityEditor({
+      activity,
+      activityId: activity.id,
+      day,
+      mode: "edit"
+    });
+  }
+
+  function saveActivity(activity: Activity) {
+    if (!activityEditor || !editing) {
+      return;
+    }
+
+    if (activityEditor.mode === "add") {
+      editing.onAddActivity(activityEditor.day.date, activity);
+    } else if (activityEditor.activityId) {
+      editing.onUpdateActivity(
+        activityEditor.day.date,
+        activityEditor.activityId,
+        activity
+      );
+    }
+
+    setActivityEditor(null);
+  }
+
   return (
     <section className="itinerary-view" aria-labelledby="itinerary-title">
+      {editing?.isDirty ? (
+        <p className="itinerary-dirty-state" role="status">
+          Unsaved local edits
+        </p>
+      ) : null}
+
       <ItinerarySummary itinerary={{ ...itinerary, days: sortedDays }} />
 
       <div className="trip-day-list">
         {sortedDays.map((day, index) => (
-          <TripDayPanel day={day} dayNumber={index + 1} key={day.date} />
+          <TripDayPanel
+            day={day}
+            dayNumber={index + 1}
+            editing={
+              editing
+                ? {
+                    onAddActivity: () => openAddActivity(day),
+                    onDeleteActivity: (activityId) =>
+                      editing.onDeleteActivity(day.date, activityId),
+                    onEditActivity: (activity) =>
+                      openEditActivity(day, activity),
+                    onMoveActivity: (activityId, direction) =>
+                      editing.onMoveActivity(day.date, activityId, direction)
+                  }
+                : undefined
+            }
+            key={day.date}
+          />
         ))}
       </div>
+
+      {activityEditor ? (
+        <ActivityEditorDialog
+          activity={activityEditor.activity}
+          day={activityEditor.day}
+          key={`${activityEditor.mode}-${activityEditor.day.date}-${
+            activityEditor.activity.id ?? "new"
+          }`}
+          mode={activityEditor.mode}
+          onClose={() => setActivityEditor(null)}
+          onSubmit={saveActivity}
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/features/itinerary/TripDayPanel.tsx
+++ b/apps/web/src/features/itinerary/TripDayPanel.tsx
@@ -1,13 +1,25 @@
-import type { TripDay } from "../../../../../packages/shared/src/schemas/itinerary.js";
+import type {
+  Activity,
+  TripDay
+} from "../../../../../packages/shared/src/schemas/itinerary.js";
 
 import { ActivityCard } from "./ActivityCard.js";
+import type { ReorderDirection } from "./editing/useItineraryEditor.js";
+
+export type TripDayEditingControls = {
+  onAddActivity: () => void;
+  onDeleteActivity: (activityId: string) => void;
+  onEditActivity: (activity: Activity) => void;
+  onMoveActivity: (activityId: string, direction: ReorderDirection) => void;
+};
 
 export type TripDayPanelProps = {
   day: TripDay;
   dayNumber: number;
+  editing?: TripDayEditingControls | undefined;
 };
 
-export function TripDayPanel({ day, dayNumber }: TripDayPanelProps) {
+export function TripDayPanel({ day, dayNumber, editing }: TripDayPanelProps) {
   return (
     <section
       className="trip-day-panel"
@@ -20,7 +32,18 @@ export function TripDayPanel({ day, dayNumber }: TripDayPanelProps) {
             Day {dayNumber}: {day.city}
           </h3>
         </div>
-        <span>{day.activities.length} activities</span>
+        <div className="trip-day-actions">
+          <span>{day.activities.length} activities</span>
+          {editing ? (
+            <button
+              aria-label={`Add activity to Day ${dayNumber}: ${day.city}`}
+              onClick={editing.onAddActivity}
+              type="button"
+            >
+              Add activity
+            </button>
+          ) : null}
+        </div>
       </div>
 
       {day.summary ? <p className="trip-day-summary">{day.summary}</p> : null}
@@ -29,12 +52,31 @@ export function TripDayPanel({ day, dayNumber }: TripDayPanelProps) {
       ) : null}
 
       <div className="activity-list">
-        {day.activities.map((activity) => (
-          <ActivityCard
-            activity={activity}
-            key={activity.id ?? activity.title}
-          />
-        ))}
+        {day.activities.map((activity, index) => {
+          const activityId = activity.id;
+
+          return (
+            <ActivityCard
+              activity={activity}
+              editingControls={
+                editing && activityId
+                  ? {
+                      canDelete: day.activities.length > 1,
+                      onDelete: () => editing.onDeleteActivity(activityId),
+                      onEdit: () => editing.onEditActivity(activity),
+                      reorder: {
+                        canMoveDown: index < day.activities.length - 1,
+                        canMoveUp: index > 0,
+                        onMove: (direction) =>
+                          editing.onMoveActivity(activityId, direction)
+                      }
+                    }
+                  : undefined
+              }
+              key={activity.id ?? activity.title}
+            />
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/src/features/itinerary/editing/ActivityEditorDialog.test.tsx
+++ b/apps/web/src/features/itinerary/editing/ActivityEditorDialog.test.tsx
@@ -1,0 +1,58 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { mockItinerary } from "../../../mocks/index.js";
+import {
+  ActivityEditorDialog,
+  createDefaultActivity
+} from "./ActivityEditorDialog.js";
+
+const firstDay = mockItinerary.days[0];
+
+if (!firstDay) {
+  throw new Error("Expected a mock itinerary day");
+}
+
+describe("ActivityEditorDialog", () => {
+  test("renders add activity metadata fields", () => {
+    const html = renderToString(
+      <ActivityEditorDialog
+        activity={createDefaultActivity(firstDay)}
+        day={firstDay}
+        mode="add"
+        onClose={() => undefined}
+        onSubmit={() => undefined}
+      />
+    );
+
+    expect(html).toContain("Add activity to Tokyo");
+    expect(html).toContain("Title");
+    expect(html).toContain("Category");
+    expect(html).toContain("Duration minutes");
+    expect(html).toContain("Location name");
+    expect(html).toContain("Cost level");
+    expect(html).toContain("Save activity");
+  });
+
+  test("renders edit activity content", () => {
+    const activity = firstDay.activities[0];
+
+    if (!activity) {
+      throw new Error("Expected a mock activity");
+    }
+
+    const html = renderToString(
+      <ActivityEditorDialog
+        activity={activity}
+        day={firstDay}
+        mode="edit"
+        onClose={() => undefined}
+        onSubmit={() => undefined}
+      />
+    );
+
+    expect(html).toContain("Edit Morning walk through Ueno Park");
+    expect(html).toContain("Ueno Park");
+    expect(html).toContain("seasonal blossoms around Shinobazu Pond");
+  });
+});

--- a/apps/web/src/features/itinerary/editing/ActivityEditorDialog.tsx
+++ b/apps/web/src/features/itinerary/editing/ActivityEditorDialog.tsx
@@ -1,0 +1,435 @@
+import { type FormEvent, useState } from "react";
+
+import {
+  activitySchema,
+  type Activity,
+  type ActivityCategory,
+  type ActivityCostLevel,
+  type TripDay
+} from "../../../../../../packages/shared/src/schemas/itinerary.js";
+
+export type ActivityEditorMode = "add" | "edit";
+
+export type ActivityEditorDialogProps = {
+  activity: Activity;
+  day: TripDay;
+  mode: ActivityEditorMode;
+  onClose: () => void;
+  onSubmit: (activity: Activity) => void;
+};
+
+type ActivityEditorFormValues = {
+  title: string;
+  category: ActivityCategory;
+  startTime: string;
+  endTime: string;
+  timeOfDay: Activity["timing"]["timeOfDay"] | "";
+  durationMinutes: string;
+  locationName: string;
+  locationAddress: string;
+  locationCity: string;
+  mapUrl: string;
+  costLevel: ActivityCostLevel;
+  notes: string;
+};
+
+type ActivityEditorErrors = Partial<
+  Record<keyof ActivityEditorFormValues, string>
+>;
+
+const categoryOptions = [
+  { label: "Sightseeing", value: "sightseeing" },
+  { label: "Food", value: "food" },
+  { label: "Culture", value: "culture" },
+  { label: "Nature", value: "nature" },
+  { label: "Shopping", value: "shopping" },
+  { label: "Transit", value: "transit" },
+  { label: "Lodging", value: "lodging" },
+  { label: "Other", value: "other" }
+] satisfies Array<{ label: string; value: ActivityCategory }>;
+
+const costLevelOptions = [
+  { label: "Free", value: "free" },
+  { label: "Low", value: "low" },
+  { label: "Medium", value: "medium" },
+  { label: "High", value: "high" }
+] satisfies Array<{ label: string; value: ActivityCostLevel }>;
+
+const timeOfDayOptions = [
+  { label: "Flexible", value: "" },
+  { label: "Morning", value: "morning" },
+  { label: "Afternoon", value: "afternoon" },
+  { label: "Evening", value: "evening" },
+  { label: "Night", value: "night" }
+] satisfies Array<{
+  label: string;
+  value: ActivityEditorFormValues["timeOfDay"];
+}>;
+
+function toFormValues(activity: Activity): ActivityEditorFormValues {
+  return {
+    title: activity.title,
+    category: activity.category,
+    startTime: activity.timing.startTime ?? "",
+    endTime: activity.timing.endTime ?? "",
+    timeOfDay: activity.timing.timeOfDay ?? "",
+    durationMinutes: String(activity.durationMinutes),
+    locationName: activity.location.name,
+    locationAddress: activity.location.address ?? "",
+    locationCity: activity.location.city ?? "",
+    mapUrl: activity.location.mapUrl ?? "",
+    costLevel: activity.costLevel,
+    notes: activity.notes
+  };
+}
+
+function buildActivity(
+  existingActivity: Activity,
+  values: ActivityEditorFormValues
+) {
+  const location = {
+    name: values.locationName.trim(),
+    ...(values.locationAddress.trim()
+      ? { address: values.locationAddress.trim() }
+      : {}),
+    ...(values.locationCity.trim() ? { city: values.locationCity.trim() } : {}),
+    ...(values.mapUrl.trim() ? { mapUrl: values.mapUrl.trim() } : {})
+  };
+  const timing = {
+    ...(values.startTime ? { startTime: values.startTime } : {}),
+    ...(values.endTime ? { endTime: values.endTime } : {}),
+    ...(values.timeOfDay ? { timeOfDay: values.timeOfDay } : {})
+  };
+
+  return {
+    ...(existingActivity.id ? { id: existingActivity.id } : {}),
+    title: values.title.trim(),
+    category: values.category,
+    timing,
+    durationMinutes: Number(values.durationMinutes),
+    location,
+    costLevel: values.costLevel,
+    notes: values.notes.trim()
+  };
+}
+
+function getValidationErrors(activity: Activity) {
+  const result = activitySchema.safeParse(activity);
+  const errors: ActivityEditorErrors = {};
+
+  if (result.success) {
+    return errors;
+  }
+
+  for (const issue of result.error.issues) {
+    const [field, nestedField] = issue.path;
+
+    if (field === "title") {
+      errors.title = "Title is required.";
+    } else if (field === "durationMinutes") {
+      errors.durationMinutes = "Duration must be a positive number.";
+    } else if (field === "location" && nestedField === "name") {
+      errors.locationName = "Location name is required.";
+    } else if (field === "location" && nestedField === "mapUrl") {
+      errors.mapUrl = "Map URL must be a valid URL.";
+    } else if (field === "timing") {
+      errors.startTime = "Add a start time or choose a time of day.";
+    } else if (field === "notes") {
+      errors.notes = "Notes are required.";
+    }
+  }
+
+  if (!valuesHaveTiming(activity)) {
+    errors.startTime = "Add a start time or choose a time of day.";
+  }
+
+  return errors;
+}
+
+function valuesHaveTiming(activity: Activity) {
+  return Boolean(activity.timing.startTime ?? activity.timing.timeOfDay);
+}
+
+function FieldError({ message }: { message: string | undefined }) {
+  if (!message) {
+    return null;
+  }
+
+  return <p className="field-error">{message}</p>;
+}
+
+export function createDefaultActivity(day: TripDay): Activity {
+  return {
+    title: "New activity",
+    category: "sightseeing",
+    timing: {
+      timeOfDay: "afternoon"
+    },
+    durationMinutes: 60,
+    location: {
+      name: day.city,
+      city: day.city
+    },
+    costLevel: "medium",
+    notes: "Add practical notes for this stop."
+  };
+}
+
+export function ActivityEditorDialog({
+  activity,
+  day,
+  mode,
+  onClose,
+  onSubmit
+}: ActivityEditorDialogProps) {
+  const [values, setValues] = useState<ActivityEditorFormValues>(
+    toFormValues(activity)
+  );
+  const [errors, setErrors] = useState<ActivityEditorErrors>({});
+  const dialogTitle =
+    mode === "add" ? `Add activity to ${day.city}` : `Edit ${activity.title}`;
+
+  function updateField<Field extends keyof ActivityEditorFormValues>(
+    field: Field,
+    value: ActivityEditorFormValues[Field]
+  ) {
+    setValues((currentValues) => ({
+      ...currentValues,
+      [field]: value
+    }));
+
+    if (errors[field]) {
+      setErrors((currentErrors) => {
+        const nextErrors = { ...currentErrors };
+        delete nextErrors[field];
+        return nextErrors;
+      });
+    }
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const activityDraft = buildActivity(activity, values);
+    const validation = activitySchema.safeParse(activityDraft);
+
+    if (!validation.success) {
+      setErrors(getValidationErrors(activityDraft as Activity));
+      return;
+    }
+
+    onSubmit(validation.data);
+  }
+
+  return (
+    <section
+      aria-labelledby="activity-editor-title"
+      aria-modal="true"
+      className="activity-editor-backdrop"
+      role="dialog"
+    >
+      <form className="activity-editor-dialog" onSubmit={handleSubmit}>
+        <header>
+          <p className="section-kicker">Local edit</p>
+          <h2 id="activity-editor-title">{dialogTitle}</h2>
+        </header>
+
+        <div className="activity-editor-grid">
+          <div className="form-field">
+            <label htmlFor="activity-title">Title</label>
+            <input
+              aria-invalid={Boolean(errors.title)}
+              id="activity-title"
+              onChange={(event) =>
+                updateField("title", event.currentTarget.value)
+              }
+              required
+              type="text"
+              value={values.title}
+            />
+            <FieldError message={errors.title} />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="activity-category">Category</label>
+            <select
+              id="activity-category"
+              onChange={(event) =>
+                updateField(
+                  "category",
+                  event.currentTarget.value as ActivityCategory
+                )
+              }
+              value={values.category}
+            >
+              {categoryOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="activity-start-time">Start time</label>
+            <input
+              aria-invalid={Boolean(errors.startTime)}
+              id="activity-start-time"
+              onChange={(event) =>
+                updateField("startTime", event.currentTarget.value)
+              }
+              type="time"
+              value={values.startTime}
+            />
+            <FieldError message={errors.startTime} />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="activity-end-time">End time</label>
+            <input
+              id="activity-end-time"
+              onChange={(event) =>
+                updateField("endTime", event.currentTarget.value)
+              }
+              type="time"
+              value={values.endTime}
+            />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="activity-time-of-day">Time of day</label>
+            <select
+              id="activity-time-of-day"
+              onChange={(event) =>
+                updateField(
+                  "timeOfDay",
+                  event.currentTarget
+                    .value as ActivityEditorFormValues["timeOfDay"]
+                )
+              }
+              value={values.timeOfDay}
+            >
+              {timeOfDayOptions.map((option) => (
+                <option key={option.value || "flexible"} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="activity-duration">Duration minutes</label>
+            <input
+              aria-invalid={Boolean(errors.durationMinutes)}
+              id="activity-duration"
+              min="1"
+              onChange={(event) =>
+                updateField("durationMinutes", event.currentTarget.value)
+              }
+              required
+              type="number"
+              value={values.durationMinutes}
+            />
+            <FieldError message={errors.durationMinutes} />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="activity-location-name">Location name</label>
+            <input
+              aria-invalid={Boolean(errors.locationName)}
+              id="activity-location-name"
+              onChange={(event) =>
+                updateField("locationName", event.currentTarget.value)
+              }
+              required
+              type="text"
+              value={values.locationName}
+            />
+            <FieldError message={errors.locationName} />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="activity-location-city">Location city</label>
+            <input
+              id="activity-location-city"
+              onChange={(event) =>
+                updateField("locationCity", event.currentTarget.value)
+              }
+              type="text"
+              value={values.locationCity}
+            />
+          </div>
+
+          <div className="form-field form-field-wide">
+            <label htmlFor="activity-location-address">Location address</label>
+            <input
+              id="activity-location-address"
+              onChange={(event) =>
+                updateField("locationAddress", event.currentTarget.value)
+              }
+              type="text"
+              value={values.locationAddress}
+            />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="activity-map-url">Map URL</label>
+            <input
+              aria-invalid={Boolean(errors.mapUrl)}
+              id="activity-map-url"
+              onChange={(event) =>
+                updateField("mapUrl", event.currentTarget.value)
+              }
+              type="url"
+              value={values.mapUrl}
+            />
+            <FieldError message={errors.mapUrl} />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="activity-cost-level">Cost level</label>
+            <select
+              id="activity-cost-level"
+              onChange={(event) =>
+                updateField(
+                  "costLevel",
+                  event.currentTarget.value as ActivityCostLevel
+                )
+              }
+              value={values.costLevel}
+            >
+              {costLevelOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-field form-field-wide">
+            <label htmlFor="activity-notes">Notes</label>
+            <textarea
+              aria-invalid={Boolean(errors.notes)}
+              id="activity-notes"
+              onChange={(event) =>
+                updateField("notes", event.currentTarget.value)
+              }
+              rows={3}
+              value={values.notes}
+            />
+            <FieldError message={errors.notes} />
+          </div>
+        </div>
+
+        <div className="activity-editor-actions">
+          <button type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="activity-editor-save" type="submit">
+            Save activity
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/features/itinerary/editing/ReorderControls.tsx
+++ b/apps/web/src/features/itinerary/editing/ReorderControls.tsx
@@ -1,0 +1,36 @@
+import type { ReorderDirection } from "./useItineraryEditor.js";
+
+export type ReorderControlsProps = {
+  activityTitle: string;
+  canMoveDown: boolean;
+  canMoveUp: boolean;
+  onMove: (direction: ReorderDirection) => void;
+};
+
+export function ReorderControls({
+  activityTitle,
+  canMoveDown,
+  canMoveUp,
+  onMove
+}: ReorderControlsProps) {
+  return (
+    <div className="reorder-controls" aria-label={`${activityTitle} order`}>
+      <button
+        aria-label={`Move ${activityTitle} up`}
+        disabled={!canMoveUp}
+        onClick={() => onMove("up")}
+        type="button"
+      >
+        Up
+      </button>
+      <button
+        aria-label={`Move ${activityTitle} down`}
+        disabled={!canMoveDown}
+        onClick={() => onMove("down")}
+        type="button"
+      >
+        Down
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/itinerary/editing/useItineraryEditor.test.ts
+++ b/apps/web/src/features/itinerary/editing/useItineraryEditor.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "vitest";
+
+import type { Activity } from "../../../../../../packages/shared/src/schemas/itinerary.js";
+import { mockItinerary } from "../../../mocks/index.js";
+import {
+  createItineraryEditorState,
+  type ItineraryEditorState,
+  itineraryEditorReducer
+} from "./useItineraryEditor.js";
+
+function getDay(state: ItineraryEditorState, date: string) {
+  const day = state.itinerary?.days.find((candidate) => candidate.date === date);
+
+  if (!day) {
+    throw new Error(`Missing test day ${date}`);
+  }
+
+  return day;
+}
+
+function createTestActivity(overrides: Partial<Activity> = {}): Activity {
+  return {
+    title: "Neighborhood coffee stop",
+    category: "food",
+    timing: {
+      timeOfDay: "afternoon"
+    },
+    durationMinutes: 45,
+    location: {
+      name: "Local cafe",
+      city: "Tokyo"
+    },
+    costLevel: "low",
+    notes: "A flexible local break between larger activities.",
+    ...overrides
+  };
+}
+
+describe("itineraryEditorReducer", () => {
+  test("adds an activity to a day without mutating the mock fixture", () => {
+    const state = createItineraryEditorState(mockItinerary);
+    const dayBefore = getDay(state, "2026-04-06");
+    const fixtureCount = mockItinerary.days[0]?.activities.length;
+
+    const nextState = itineraryEditorReducer(state, {
+      type: "addActivity",
+      dayDate: "2026-04-06",
+      activity: createTestActivity()
+    });
+    const dayAfter = getDay(nextState, "2026-04-06");
+
+    expect(dayAfter.activities).toHaveLength(dayBefore.activities.length + 1);
+    expect(dayAfter.activities.at(-1)?.id).toBe("2026-04-06-local-13");
+    expect(nextState.isDirty).toBe(true);
+    expect(mockItinerary.days[0]?.activities.length).toBe(fixtureCount);
+  });
+
+  test("edits activity metadata within the requested day", () => {
+    const state = createItineraryEditorState(mockItinerary);
+    const original = getDay(state, "2026-04-06").activities[0];
+
+    if (!original?.id) {
+      throw new Error("Expected editable activity id");
+    }
+
+    const nextState = itineraryEditorReducer(state, {
+      type: "updateActivity",
+      dayDate: "2026-04-06",
+      activityId: original.id,
+      activity: {
+        ...original,
+        title: "Updated Ueno Park walk",
+        costLevel: "low",
+        notes: "Updated local note."
+      }
+    });
+    const updated = getDay(nextState, "2026-04-06").activities[0];
+
+    expect(updated?.title).toBe("Updated Ueno Park walk");
+    expect(updated?.costLevel).toBe("low");
+    expect(updated?.notes).toBe("Updated local note.");
+    expect(updated?.id).toBe(original.id);
+    expect(nextState.isDirty).toBe(true);
+  });
+
+  test("deletes an activity from a day", () => {
+    const state = createItineraryEditorState(mockItinerary);
+    const deletedActivity = getDay(state, "2026-04-06").activities[1];
+
+    if (!deletedActivity?.id) {
+      throw new Error("Expected editable activity id");
+    }
+
+    const nextState = itineraryEditorReducer(state, {
+      type: "deleteActivity",
+      dayDate: "2026-04-06",
+      activityId: deletedActivity.id
+    });
+    const dayAfter = getDay(nextState, "2026-04-06");
+
+    expect(dayAfter.activities.map((activity) => activity.id)).not.toContain(
+      deletedActivity.id
+    );
+    expect(dayAfter.activities).toHaveLength(3);
+    expect(nextState.isDirty).toBe(true);
+  });
+
+  test("reorders an activity within the same day", () => {
+    const state = createItineraryEditorState(mockItinerary);
+    const dayBefore = getDay(state, "2026-04-06");
+    const movedActivity = dayBefore.activities[1];
+
+    if (!movedActivity?.id) {
+      throw new Error("Expected editable activity id");
+    }
+
+    const nextState = itineraryEditorReducer(state, {
+      type: "moveActivity",
+      dayDate: "2026-04-06",
+      activityId: movedActivity.id,
+      direction: "up"
+    });
+    const dayAfter = getDay(nextState, "2026-04-06");
+
+    expect(dayAfter.activities[0]?.id).toBe(movedActivity.id);
+    expect(dayAfter.activities[1]?.id).toBe(dayBefore.activities[0]?.id);
+    expect(nextState.isDirty).toBe(true);
+  });
+
+  test("does not reorder activities across days", () => {
+    const state = createItineraryEditorState(mockItinerary);
+    const kyotoActivity = getDay(state, "2026-04-07").activities[0];
+
+    if (!kyotoActivity?.id) {
+      throw new Error("Expected editable activity id");
+    }
+
+    const nextState = itineraryEditorReducer(state, {
+      type: "moveActivity",
+      dayDate: "2026-04-06",
+      activityId: kyotoActivity.id,
+      direction: "up"
+    });
+
+    expect(getDay(nextState, "2026-04-07").activities[0]?.id).toBe(
+      kyotoActivity.id
+    );
+    expect(getDay(nextState, "2026-04-06").activities).toEqual(
+      getDay(state, "2026-04-06").activities
+    );
+    expect(nextState.isDirty).toBe(false);
+  });
+
+  test("clears dirty state when itinerary is reset", () => {
+    const state = createItineraryEditorState(mockItinerary);
+    const activity = getDay(state, "2026-04-06").activities[0];
+
+    if (!activity?.id) {
+      throw new Error("Expected editable activity id");
+    }
+
+    const dirtyState = itineraryEditorReducer(state, {
+      type: "updateActivity",
+      dayDate: "2026-04-06",
+      activityId: activity.id,
+      activity: {
+        ...activity,
+        title: "Dirty activity"
+      }
+    });
+    const resetState = itineraryEditorReducer(dirtyState, {
+      type: "reset",
+      itinerary: mockItinerary
+    });
+
+    expect(dirtyState.isDirty).toBe(true);
+    expect(resetState.isDirty).toBe(false);
+  });
+});

--- a/apps/web/src/features/itinerary/editing/useItineraryEditor.ts
+++ b/apps/web/src/features/itinerary/editing/useItineraryEditor.ts
@@ -1,0 +1,253 @@
+import { useReducer } from "react";
+
+import type {
+  Activity,
+  Itinerary
+} from "../../../../../../packages/shared/src/schemas/itinerary.js";
+
+export type ReorderDirection = "up" | "down";
+
+export type ItineraryEditorState = {
+  itinerary: Itinerary | null;
+  isDirty: boolean;
+  nextActivityNumber: number;
+};
+
+export type ItineraryEditorAction =
+  | {
+      type: "reset";
+      itinerary: Itinerary | null;
+    }
+  | {
+      type: "addActivity";
+      dayDate: string;
+      activity: Activity;
+    }
+  | {
+      type: "updateActivity";
+      dayDate: string;
+      activityId: string;
+      activity: Activity;
+    }
+  | {
+      type: "deleteActivity";
+      dayDate: string;
+      activityId: string;
+    }
+  | {
+      type: "moveActivity";
+      dayDate: string;
+      activityId: string;
+      direction: ReorderDirection;
+    };
+
+function cloneActivity(activity: Activity): Activity {
+  return {
+    ...activity,
+    location: { ...activity.location },
+    timing: { ...activity.timing }
+  };
+}
+
+export function cloneItinerary(itinerary: Itinerary): Itinerary {
+  return {
+    ...itinerary,
+    days: itinerary.days.map((day) => ({
+      ...day,
+      activities: day.activities.map(cloneActivity)
+    }))
+  };
+}
+
+function withEditableActivityIds(itinerary: Itinerary) {
+  return {
+    ...itinerary,
+    days: itinerary.days.map((day) => ({
+      ...day,
+      activities: day.activities.map((activity, index) => ({
+        ...cloneActivity(activity),
+        id: activity.id ?? `${day.date}-activity-${index + 1}`
+      }))
+    }))
+  } satisfies Itinerary;
+}
+
+export function createItineraryEditorState(
+  itinerary: Itinerary | null
+): ItineraryEditorState {
+  const editableItinerary = itinerary
+    ? withEditableActivityIds(cloneItinerary(itinerary))
+    : null;
+  const activityCount =
+    editableItinerary?.days.reduce(
+      (total, day) => total + day.activities.length,
+      0
+    ) ?? 0;
+
+  return {
+    itinerary: editableItinerary,
+    isDirty: false,
+    nextActivityNumber: activityCount + 1
+  };
+}
+
+function createLocalActivityId(dayDate: string, nextActivityNumber: number) {
+  return `${dayDate}-local-${nextActivityNumber}`;
+}
+
+function updateItineraryDay(
+  state: ItineraryEditorState,
+  dayDate: string,
+  updateDay: NonNullable<ItineraryEditorState["itinerary"]>["days"][number]
+) {
+  if (!state.itinerary) {
+    return state;
+  }
+
+  return {
+    ...state,
+    isDirty: true,
+    itinerary: {
+      ...state.itinerary,
+      days: state.itinerary.days.map((day) =>
+        day.date === dayDate ? updateDay : day
+      )
+    }
+  } satisfies ItineraryEditorState;
+}
+
+export function itineraryEditorReducer(
+  state: ItineraryEditorState,
+  action: ItineraryEditorAction
+): ItineraryEditorState {
+  if (action.type === "reset") {
+    return createItineraryEditorState(action.itinerary);
+  }
+
+  if (!state.itinerary) {
+    return state;
+  }
+
+  const day = state.itinerary.days.find(
+    (candidateDay) => candidateDay.date === action.dayDate
+  );
+
+  if (!day) {
+    return state;
+  }
+
+  if (action.type === "addActivity") {
+    const activity = cloneActivity(action.activity);
+    const nextActivity = {
+      ...activity,
+      id:
+        activity.id ??
+        createLocalActivityId(action.dayDate, state.nextActivityNumber)
+    } satisfies Activity;
+
+    return {
+      ...updateItineraryDay(state, action.dayDate, {
+        ...day,
+        activities: [...day.activities, nextActivity]
+      }),
+      nextActivityNumber: state.nextActivityNumber + 1
+    };
+  }
+
+  const activityIndex = day.activities.findIndex(
+    (activity) => activity.id === action.activityId
+  );
+
+  if (activityIndex === -1) {
+    return state;
+  }
+
+  if (action.type === "updateActivity") {
+    const nextActivities = [...day.activities];
+    nextActivities[activityIndex] = {
+      ...cloneActivity(action.activity),
+      id: action.activityId
+    };
+
+    return updateItineraryDay(state, action.dayDate, {
+      ...day,
+      activities: nextActivities
+    });
+  }
+
+  if (action.type === "deleteActivity") {
+    if (day.activities.length <= 1) {
+      return state;
+    }
+
+    return updateItineraryDay(state, action.dayDate, {
+      ...day,
+      activities: day.activities.filter(
+        (activity) => activity.id !== action.activityId
+      )
+    });
+  }
+
+  const targetIndex =
+    action.direction === "up" ? activityIndex - 1 : activityIndex + 1;
+
+  if (targetIndex < 0 || targetIndex >= day.activities.length) {
+    return state;
+  }
+
+  const nextActivities = [...day.activities];
+  const currentActivity = nextActivities[activityIndex];
+  const targetActivity = nextActivities[targetIndex];
+
+  if (!currentActivity || !targetActivity) {
+    return state;
+  }
+
+  nextActivities[activityIndex] = targetActivity;
+  nextActivities[targetIndex] = currentActivity;
+
+  return updateItineraryDay(state, action.dayDate, {
+    ...day,
+    activities: nextActivities
+  });
+}
+
+export function useItineraryEditor(initialItinerary: Itinerary | null = null) {
+  const [state, dispatch] = useReducer(
+    itineraryEditorReducer,
+    createItineraryEditorState(initialItinerary)
+  );
+
+  return {
+    itinerary: state.itinerary,
+    isDirty: state.isDirty,
+    resetItinerary: (itinerary: Itinerary | null) =>
+      dispatch({ type: "reset", itinerary }),
+    addActivity: (dayDate: string, activity: Activity) =>
+      dispatch({ type: "addActivity", dayDate, activity }),
+    updateActivity: (
+      dayDate: string,
+      activityId: string,
+      activity: Activity
+    ) =>
+      dispatch({
+        type: "updateActivity",
+        dayDate,
+        activityId,
+        activity
+      }),
+    deleteActivity: (dayDate: string, activityId: string) =>
+      dispatch({ type: "deleteActivity", dayDate, activityId }),
+    moveActivity: (
+      dayDate: string,
+      activityId: string,
+      direction: ReorderDirection
+    ) =>
+      dispatch({
+        type: "moveActivity",
+        dayDate,
+        activityId,
+        direction
+      })
+  };
+}


### PR DESCRIPTION
## Ticket scope
Implement only T-011 / Ticket 11: Add Client-Side Itinerary Editing.

## Changes made
- Added local browser-state editing for submitted mock itineraries.
- Added activity add, edit, delete, and within-day reorder controls.
- Added visible dirty state after local edits.
- Ensured editing operates on cloned editable itinerary state rather than mutating the imported mock fixture.
- Preserved the existing trip intake form and mock submit flow.
- Did not add API calls, persistence, backend behavior, AI generation, Playwright/E2E tests, or shared schema changes.

## Editing components/hooks added
- `apps/web/src/features/itinerary/editing/useItineraryEditor.ts`
- `apps/web/src/features/itinerary/editing/ActivityEditorDialog.tsx`
- `apps/web/src/features/itinerary/editing/ReorderControls.tsx`
- `apps/web/src/features/itinerary/editing/*.test.*`

## State-management approach
- Added a local reducer-backed editor hook that owns the editable itinerary, dirty state, reset behavior, and activity operations.
- `App` resets the editor after mock submit using a cloned mock itinerary.
- Reorder actions are scoped by `dayDate` and `activityId`, so an activity ID from another day is ignored instead of moved across days.
- Delete is disabled/no-op for a day with only one activity to keep local itinerary data schema-compatible.

## Tests added/updated
- Added reducer tests for add, edit, delete, reorder within a day, cross-day reorder prevention, dirty state reset, and fixture non-mutation.
- Added dialog render tests for add/edit activity metadata fields.
- Updated `ItineraryView` tests to cover editing controls and dirty state rendering.

## Checks run
- `git status` before implementation: clean on `ticket-11-client-side-itinerary-editing` at `66e08ba`, matching `main` and `origin/main`.
- `pnpm install` passed.
- `pnpm lint` attempted before and after implementation; local ESLint stalled with no diagnostics and had to be interrupted.
- `pnpm typecheck` attempted; it progressed into the web package but stalled with no diagnostics and had to be interrupted. `pnpm build` later passed, including the package TypeScript build steps.
- `pnpm test` attempted; shared tests passed, API appeared to stall, and after interrupt web tests ran/passed. Treating this as not a clean root test pass because the API step did not complete normally.
- `pnpm build` passed.
- `pnpm --filter @japan-travel-planner/web test` passed: 6 files, 22 tests.
- `pnpm --filter @japan-travel-planner/web exec eslint src` attempted; local ESLint stalled with no diagnostics and had to be interrupted.
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit` passed.
- `pnpm --filter @japan-travel-planner/web exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism` passed: 6 files, 22 tests.
- `pnpm --filter @japan-travel-planner/web exec vite build` passed.
- `git diff --check` / cached diff check passed.

## Browser/manual checks run
- Started the web app at `http://localhost:5173/`.
- Verified initial empty itinerary state before submit.
- Submitted a valid default trip request and verified the mock itinerary appears.
- Added one activity to Day 1 and verified the activity count increased and dirty state appeared.
- Edited the added activity title and verified the updated title appears.
- Deleted an existing Day 1 activity and verified it disappeared.
- Reordered an activity within Day 1 and verified the Kyoto day remained unchanged.
- Checked 390px mobile width after submit/add: no horizontal overflow, single-column planner, dirty state visible.
- Browser console errors/warnings: none.

## Known risks
- Root ESLint and root typecheck have local runner stalls in this environment. Targeted web TypeScript and build checks passed.
- Root `pnpm test` did not complete cleanly because the API Vitest step appeared to stall; web tests and shared tests passed in the observed runs.
- Editing remains browser-local only and will reset on reload until later persistence tickets.
- The activity editor keeps the form intentionally simple for Ticket 11.

## Ticket 12+ confirmation
Ticket 12 and later were not started.

---

## Final Review Before Merge - 2026-06-22 JST
- Branch sync: local `ticket-11-client-side-itinerary-editing` is clean and matches `origin/ticket-11-client-side-itinerary-editing` at `5a84aec76c52ee0dfc7f36bb2356cd6acd4d247c`.
- Base check: PR #10 is based on latest `main` / `origin/main` at `66e08babcd886dba3bcfe7ba51a56f79ca0b512d`; merge-base also matches that SHA.
- Scope review: diff is limited to the Ticket 11 web editing surface under `apps/web/src/App.*` and `apps/web/src/features/itinerary/**`.
- Out-of-scope review: no Ticket 12+ work, API calls, persistence/database code, AI generation, Playwright/E2E setup, or shared schema changes were found.
- State review: `mockItinerary` is cloned before entering editor state, reducer operations return cloned/updated local state, and tests assert the imported fixture is not mutated.
- Behavior review: add, edit, delete, reorder, dirty state, trip intake submit, and mock itinerary preview behavior were covered by tests and manual browser checks.
- Reorder review: reducer scopes reorder by `dayDate` and `activityId`; cross-day reorder attempts are ignored and covered by test.
- GitHub Actions: PR CI check `Install, lint, typecheck, test, and build` is green.
- Local validation on review: `pnpm install`, `pnpm typecheck`, `pnpm build`, web tests, targeted web `tsc`, VM-pool web Vitest, direct Vite build, and `git diff --check` passed. Local `pnpm lint` stalled at `eslint .` with no diagnostics after roughly one minute. Local root `pnpm test` passed shared tests, then appeared to stall in `apps/api` Vitest before the interrupt advanced to passing web tests; this was not treated as a clean root test signal.
- Manual browser review: verified initial empty state, valid submit, mock itinerary render, add/edit/delete/reorder within Day 1, Kyoto day unchanged during reorder, dirty state visible, no 390px horizontal overflow, and no browser console errors/warnings.

Final review result: no blocking issues found. With GitHub Actions green and the PR marked ready, this PR is safe to merge.