### PR TITLE
Ticket 12: Add Web MVP E2E Mock Flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,9 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @japan-travel-planner/web exec playwright install --with-deps chromium
+
+      - name: E2E
+        run: pnpm --filter @japan-travel-planner/web test:e2e

--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+
+test("traveler can plan and edit a mock itinerary", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "No itinerary yet" })
+  ).toBeVisible();
+
+  await page.getByLabel("Start date").fill("2026-04-06");
+  await page.getByLabel("End date").fill("2026-04-08");
+  await page.getByLabel("Cities").fill("Tokyo, Kyoto");
+  await page
+    .getByLabel("Interests")
+    .fill("spring flowers, temples, local food");
+  await page.getByLabel("Travel pace").selectOption("balanced");
+  await page.getByLabel("Budget").selectOption("moderate");
+  await page
+    .getByLabel("Constraints")
+    .fill("Prefer rail-friendly days and relaxed meals.");
+
+  await page.getByRole("button", { name: "Generate mock itinerary" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Preparing itinerary" })
+  ).toBeVisible();
+  await expect(
+    page
+      .getByLabel("Shell status")
+      .getByText("Tokyo And Kyoto Spring Highlights")
+  ).toBeVisible();
+
+  const dayOne = page.getByRole("region", { name: "Day 1: Tokyo" });
+  await expect(dayOne).toBeVisible();
+  await expect(
+    dayOne.getByRole("heading", { name: "Morning walk through Ueno Park" })
+  ).toBeVisible();
+
+  await page
+    .getByRole("button", { name: "Edit Morning walk through Ueno Park" })
+    .click();
+
+  const dialog = page.getByRole("dialog", {
+    name: "Edit Morning walk through Ueno Park"
+  });
+  await expect(dialog).toBeVisible();
+
+  const editedTitle = "Morning walk through Ueno Park and Shinobazu Pond";
+  await dialog.getByLabel("Title").fill(editedTitle);
+  await dialog.getByRole("button", { name: "Save activity" }).click();
+
+  await expect(
+    dayOne.getByRole("heading", { name: editedTitle })
+  ).toBeVisible();
+  await expect(page.getByText("Unsaved local edits")).toBeVisible();
+
+  await dayOne
+    .getByRole("button", { name: `Move ${editedTitle} down` })
+    .click();
+  await expect(dayOne.getByRole("heading", { level: 4 })).toHaveText([
+    "Ameyoko lunch crawl",
+    editedTitle,
+    "Senso-ji and Nakamise-dori",
+    "Tokyo Skytree sunset viewpoint"
+  ]);
+
+  const dayTwo = page.getByRole("region", { name: "Day 2: Kyoto" });
+  await expect(dayTwo.getByRole("heading", { level: 4 })).toHaveText([
+    "Tokaido Shinkansen to Kyoto",
+    "Kiyomizu-dera temple visit",
+    "Nishiki Market snack break",
+    "Gion and Shirakawa evening walk"
+  ]);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,13 +8,15 @@
     "build": "rm -rf dist && tsc -p tsconfig.json --noEmit && vite build",
     "preview": "vite preview --host 0.0.0.0",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000
+  },
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "on-first-retry"
+  },
+  webServer: {
+    command: "pnpm dev",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    url: "http://127.0.0.1:5173"
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format": "prettier . --write",
     "build": "pnpm --filter @japan-travel-planner/shared build && pnpm --filter @japan-travel-planner/api build && pnpm --filter @japan-travel-planner/web build",
     "typecheck": "pnpm --filter @japan-travel-planner/shared typecheck && pnpm --filter @japan-travel-planner/api typecheck && pnpm --filter @japan-travel-planner/web typecheck",
-    "test": "pnpm --filter @japan-travel-planner/shared test && pnpm --filter @japan-travel-planner/api test && pnpm --filter @japan-travel-planner/web test"
+    "test": "pnpm --filter @japan-travel-planner/shared test && pnpm --filter @japan-travel-planner/api test && pnpm --filter @japan-travel-planner/web test",
+    "test:e2e": "pnpm --filter @japan-travel-planner/web test:e2e"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.0
+        version: 1.61.0
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -329,6 +332,11 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -821,6 +829,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1081,6 +1094,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -1527,6 +1550,10 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.133.0': {}
+
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -2068,6 +2095,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2275,6 +2305,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.15:
     dependencies:


### PR DESCRIPTION
## Ticket scope

T-012 only: add an E2E test for the current Web MVP mock flow using the existing trip intake form, mock itinerary, and client-side itinerary editing UI. No Ticket 13+ work was started.

## Changes made

- Added Playwright config for the Vite web app.
- Added a Web MVP E2E spec that submits a valid trip request, verifies the mock itinerary, edits one activity, verifies dirty state, and reorders within Day 1 while confirming Day 2 remains unchanged.
- Added web-level and root E2E scripts.
- Added the Playwright test dependency to the web package.
- Wired E2E into CI after the existing build step.

## E2E framework/config added

- `apps/web/playwright.config.ts` starts the Vite dev server and runs Chromium.
- `apps/web/e2e/trip-planning.spec.ts` uses accessible labels, roles, headings, and button names.

## E2E flow covered

1. Opens the web app.
2. Verifies the initial empty itinerary state.
3. Fills and submits the trip intake form.
4. Verifies the mock itinerary appears.
5. Verifies expected itinerary content.
6. Edits the Ueno activity title.
7. Verifies the edited activity appears.
8. Verifies the dirty state appears.
9. Reorders the edited activity within Day 1 and confirms Kyoto Day 2 remains unchanged.

## Test scripts added/updated

- `apps/web/package.json`: `test:e2e` -> `playwright test`
- `package.json`: `test:e2e` -> `pnpm --filter @japan-travel-planner/web test:e2e`

## CI wiring

E2E is wired into CI now. The workflow installs Playwright Chromium with `pnpm --filter @japan-travel-planner/web exec playwright install --with-deps chromium`, then runs `pnpm --filter @japan-travel-planner/web test:e2e`.

## Checks run

- `pnpm install` passed; existing pnpm warning: ignored build scripts for `esbuild`.
- `pnpm --filter @japan-travel-planner/web exec playwright install chromium` passed locally and downloaded Chromium/FFmpeg/headless shell to the local Playwright cache.
- `pnpm typecheck` passed.
- `pnpm build` passed.
- `pnpm --filter @japan-travel-planner/web test` passed: 6 files, 22 tests.
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit` passed.
- `pnpm --filter @japan-travel-planner/web exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism` passed: 6 files, 22 tests.
- `pnpm --filter @japan-travel-planner/web exec vite build` passed.
- `pnpm --filter @japan-travel-planner/web test:e2e` passed: 1 Chromium test.
- `pnpm test:e2e` passed: 1 Chromium test.
- `git diff --check` passed.
- Focused Prettier check on touched files passed.

## Browser/manual checks run

- Started the web app at `http://localhost:5173`.
- Confirmed the initial empty itinerary state before submit.
- Submitted a valid trip request.
- Confirmed the mock itinerary appears.
- Edited one activity title.
- Confirmed the edited title appears.
- Confirmed dirty state appears.
- Reordered within Day 1 and confirmed Kyoto Day 2 remains unchanged.
- Checked 390px mobile width: `scrollWidth` equals `clientWidth` and no horizontal overflow was detected.

## Known risks

- Local `pnpm lint` stalled at `eslint .` after about 60 seconds and was interrupted. Targeted ESLint on the two new TypeScript files also stalled; ESLint on an existing `apps/web/src/App.tsx` file stalled too, so no tooling changes were made for this Ticket 12 PR.
- Local root `pnpm test` reached shared tests successfully, then stalled during `apps/api` at `vitest run`; targeted `pnpm --filter @japan-travel-planner/api test` also stalled. Web tests and E2E checks passed.
- Playwright requires browser installation locally; I used `pnpm --filter @japan-travel-planner/web exec playwright install chromium`. CI uses the Linux `--with-deps chromium` install step.

## Ticket 13+ confirmation

Ticket 13 and later were not started. No API routes, database/persistence code, AI generation, or shared schema changes were added.

## Final Review Result

- Reviewed after remote merge: PR #11 is already merged into `main` as merge commit `8ba4609`.
- Current branch confirmed locally: `ticket-12-web-mvp-e2e-mock-flow`.
- Remote `origin/main` contains the PR head commit `25d7234`; the PR is integrated into latest main.
- T-012 acceptance criteria are covered: the E2E test verifies empty state, form fill, mock submit, mock itinerary display, activity edit, dirty state, and Day 1 reorder while confirming Day 2 remains unchanged.
- Scope check passed: no Ticket 13+ work, no API routes, no database/persistence code, no AI generation, and no shared schema changes.
- Playwright config is minimal and scoped to `apps/web`; the test uses accessible selectors where practical.
- CI is green, including the Playwright Chromium install and E2E step.
- Local validation passed: `pnpm install`, `pnpm typecheck`, `pnpm build`, web Vitest, web `tsc --noEmit`, serialized web Vitest, web Vite build, web E2E, root `test:e2e`, and `git diff --check`.
- Manual browser check passed: empty state, valid submit, mock itinerary, edit, dirty state, Day 1 reorder, and no 390px horizontal overflow.

Result: no blocking issues found. Safe to keep merged; Ticket 13 was not started.
