### PR TITLE
Ticket 13: Scaffold Express API App

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,18 +4,22 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/server.ts",
+    "dev": "pnpm build && node dist/server.js",
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
+    "cors": "^2.8.6",
     "express": "^5.2.1"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/node": "^25.9.3",
+    "@types/supertest": "^7.2.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,50 +1,37 @@
-import { createServer, type Server } from "node:http";
+import request from "supertest";
+import { describe, expect, test } from "vitest";
 
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { tripRequestSchema } from "../../../packages/shared/src/schemas/tripRequest.js";
 
 import { createApp } from "./app.js";
-
-let server: Server;
-let baseUrl: string;
-
-beforeAll(async () => {
-  server = createServer(createApp());
-
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === "string") {
-    throw new Error("Expected server to listen on a TCP port.");
-  }
-
-  baseUrl = `http://127.0.0.1:${address.port}`;
-});
-
-afterAll(async () => {
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-
-      resolve();
-    });
-  });
-});
+import { defaultApiEnv } from "./config/env.js";
 
 describe("API health endpoint", () => {
   test("returns an ok response", async () => {
-    const response = await fetch(`${baseUrl}/api/health`);
-    const body = await response.json();
+    const response = await request(createApp({ env: defaultApiEnv })).get(
+      "/api/health"
+    );
 
     expect(response.status).toBe(200);
-    expect(body).toEqual({
+    expect(response.body).toEqual({
       status: "ok",
       service: "japan-travel-planner-api"
     });
+  });
+});
+
+describe("shared schema access", () => {
+  test("can validate a trip request with a shared schema", () => {
+    const result = tripRequestSchema.safeParse({
+      startDate: "2026-04-06",
+      endDate: "2026-04-08",
+      cities: ["Tokyo", "Kyoto"],
+      interests: ["temples", "local food"],
+      pace: "balanced",
+      budget: "moderate",
+      constraints: ["Avoid late-night activities"]
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,16 +1,24 @@
+import cors from "cors";
 import express from "express";
 
-export function createApp() {
+import { loadApiEnv, type ApiEnvConfig } from "./config/env.js";
+import { healthRouter } from "./routes/health.js";
+
+export type CreateAppOptions = {
+  env?: ApiEnvConfig;
+};
+
+export function createApp(options: CreateAppOptions = {}) {
+  const env = options.env ?? loadApiEnv();
   const app = express();
 
+  app.use(
+    cors({
+      origin: env.webOrigin
+    })
+  );
   app.use(express.json());
-
-  app.get("/api/health", (_request, response) => {
-    response.status(200).json({
-      status: "ok",
-      service: "japan-travel-planner-api"
-    });
-  });
+  app.use("/api/health", healthRouter);
 
   return app;
 }

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+
+import { defaultApiEnv, loadApiEnv } from "./env.js";
+
+describe("loadApiEnv", () => {
+  test("returns default local API config", () => {
+    expect(loadApiEnv({})).toEqual(defaultApiEnv);
+  });
+
+  test("parses explicit API config", () => {
+    expect(
+      loadApiEnv({
+        API_PORT: "4001",
+        WEB_ORIGIN: "https://planner.example.com"
+      })
+    ).toEqual({
+      apiPort: 4001,
+      webOrigin: "https://planner.example.com"
+    });
+  });
+
+  test("fails clearly for invalid API_PORT", () => {
+    expect(() =>
+      loadApiEnv({
+        API_PORT: "not-a-port",
+        WEB_ORIGIN: "http://localhost:5173"
+      })
+    ).toThrow("Invalid API_PORT");
+  });
+
+  test("fails clearly for invalid WEB_ORIGIN", () => {
+    expect(() =>
+      loadApiEnv({
+        API_PORT: "3001",
+        WEB_ORIGIN: "localhost:5173"
+      })
+    ).toThrow("Invalid WEB_ORIGIN");
+  });
+});

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,0 +1,57 @@
+export type ApiEnvConfig = {
+  apiPort: number;
+  webOrigin: string;
+};
+
+export const defaultApiEnv = {
+  apiPort: 3001,
+  webOrigin: "http://localhost:5173"
+} satisfies ApiEnvConfig;
+
+type ApiEnvSource = {
+  API_PORT?: string | undefined;
+  WEB_ORIGIN?: string | undefined;
+};
+
+function parseApiPort(value: string | undefined) {
+  const rawPort = value?.trim() || String(defaultApiEnv.apiPort);
+
+  if (!/^\d+$/.test(rawPort)) {
+    throw new Error(
+      "Invalid API_PORT: expected an integer between 1 and 65535."
+    );
+  }
+
+  const apiPort = Number(rawPort);
+
+  if (!Number.isSafeInteger(apiPort) || apiPort < 1 || apiPort > 65535) {
+    throw new Error(
+      "Invalid API_PORT: expected an integer between 1 and 65535."
+    );
+  }
+
+  return apiPort;
+}
+
+function parseWebOrigin(value: string | undefined) {
+  const rawOrigin = value?.trim() || defaultApiEnv.webOrigin;
+
+  try {
+    const origin = new URL(rawOrigin);
+
+    if (origin.protocol !== "http:" && origin.protocol !== "https:") {
+      throw new Error("Expected http or https protocol.");
+    }
+
+    return origin.origin;
+  } catch {
+    throw new Error("Invalid WEB_ORIGIN: expected an absolute http(s) URL.");
+  }
+}
+
+export function loadApiEnv(env: ApiEnvSource = process.env): ApiEnvConfig {
+  return {
+    apiPort: parseApiPort(env.API_PORT),
+    webOrigin: parseWebOrigin(env.WEB_ORIGIN)
+  };
+}

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+
+export const healthRouter = Router();
+
+healthRouter.get("/", (_request, response) => {
+  response.status(200).json({
+    status: "ok",
+    service: "japan-travel-planner-api"
+  });
+});

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,8 +1,17 @@
 import { createApp } from "./app.js";
+import { loadApiEnv } from "./config/env.js";
 
-const port = Number.parseInt(process.env.API_PORT ?? "3001", 10);
-const app = createApp();
+try {
+  const env = loadApiEnv();
+  const app = createApp({ env });
 
-app.listen(port, () => {
-  console.log(`API server listening at http://localhost:${port}`);
-});
+  app.listen(env.apiPort, () => {
+    console.log(`API server listening at http://localhost:${env.apiPort}`);
+  });
+} catch (error) {
+  const message =
+    error instanceof Error ? error.message : "Invalid API configuration.";
+
+  console.error(message);
+  process.exit(1);
+}

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../packages/config/tsconfig/node.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "../.."
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,16 +26,28 @@ importers:
 
   apps/api:
     dependencies:
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
       express:
         specifier: ^5.2.1
         version: 5.2.1
     devDependencies:
+      '@types/cors':
+        specifier: ^2.8.19
+        version: 2.8.19
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3
+      '@types/supertest':
+        specifier: ^7.2.0
+        version: 7.2.0
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -330,8 +342,15 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
   '@playwright/test@1.61.0':
     resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
@@ -445,6 +464,12 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -465,6 +490,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
@@ -488,6 +516,12 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/superagent@8.1.10':
+    resolution: {integrity: sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==}
+
+  '@types/supertest@7.2.0':
+    resolution: {integrity: sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==}
 
   '@typescript-eslint/eslint-plugin@8.61.0':
     resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
@@ -607,9 +641,15 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -639,6 +679,13 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -662,6 +709,13 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -681,6 +735,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -688,6 +746,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -713,6 +774,10 @@ packages:
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.28.1:
@@ -793,6 +858,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -820,6 +888,14 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -864,6 +940,10 @@ packages:
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
@@ -1016,13 +1096,30 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1042,6 +1139,10 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1218,6 +1319,14 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.2.2:
+    resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
+    engines: {node: '>=14.18.0'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1549,7 +1658,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@noble/hashes@1.8.0': {}
+
   '@oxc-project/types@0.133.0': {}
+
+  '@paralleldrive/cuid2@2.3.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@playwright/test@1.61.0':
     dependencies:
@@ -1627,6 +1742,12 @@ snapshots:
     dependencies:
       '@types/node': 25.9.3
 
+  '@types/cookiejar@2.1.5': {}
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.9.3
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
@@ -1649,6 +1770,8 @@ snapshots:
   '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/methods@1.1.4': {}
 
   '@types/node@25.9.3':
     dependencies:
@@ -1674,6 +1797,18 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 25.9.3
+
+  '@types/superagent@8.1.10':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 25.9.3
+      form-data: 4.0.6
+
+  '@types/supertest@7.2.0':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.10
 
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)':
     dependencies:
@@ -1830,7 +1965,11 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  asap@2.0.6: {}
+
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
 
   balanced-match@4.0.4: {}
 
@@ -1866,6 +2005,12 @@ snapshots:
 
   chai@6.2.2: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  component-emitter@1.3.1: {}
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
@@ -1877,6 +2022,13 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookiejar@2.1.4: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1892,9 +2044,16 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   detect-libc@2.1.2: {}
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   dunder-proto@1.0.1:
     dependencies:
@@ -1915,6 +2074,13 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -2060,6 +2226,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2090,6 +2258,20 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.3.1
+      dezalgo: 1.0.4
+      once: 1.4.0
 
   forwarded@0.2.0: {}
 
@@ -2130,6 +2312,10 @@ snapshots:
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.4:
     dependencies:
@@ -2245,11 +2431,21 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mime@2.6.0: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -2262,6 +2458,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -2458,6 +2656,28 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@4.1.0: {}
+
+  superagent@10.3.0:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.3
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.6
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.15.2
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.2.2:
+    dependencies:
+      cookie-signature: 1.2.2
+      methods: 1.1.2
+      superagent: 10.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Ticket scope

T-013 only: scaffold the Express API foundation for Phase 2. This PR adds a minimal Express app, health route, environment config validation, shared schema import smoke coverage, and API tests. Ticket 14 and later were not started.

## Changes made

- Extracted `GET /api/health` into a route module.
- Added API environment config validation for `API_PORT` and `WEB_ORIGIN` with local defaults matching `.env.example`.
- Updated the Express app factory so Supertest can exercise the app without opening a network port.
- Added CORS using the configured `WEB_ORIGIN`.
- Updated the API dev script to build and run the compiled server so `pnpm dev:api` reliably starts on port 3001 in this local environment.
- Added Supertest-based health endpoint coverage.
- Added tests for default/valid/invalid environment config.
- Added a shared schema import smoke test using `tripRequestSchema`.

## API files added/updated

- `apps/api/src/app.ts`
- `apps/api/src/server.ts`
- `apps/api/src/routes/health.ts`
- `apps/api/src/config/env.ts`
- `apps/api/src/app.test.ts`
- `apps/api/src/config/env.test.ts`
- `apps/api/package.json`
- `apps/api/tsconfig.json`
- `apps/api/tsconfig.build.json`
- `pnpm-lock.yaml`

## Env validation approach

`loadApiEnv` reads `API_PORT` and `WEB_ORIGIN`, applies defaults of `3001` and `http://localhost:5173`, validates that the port is an integer from 1 to 65535, and validates that the origin is an absolute `http` or `https` URL. Invalid config throws a clear error before the server listens.

## Health route behavior

`GET /api/health` returns HTTP 200 JSON:

```json
{"status":"ok","service":"japan-travel-planner-api"}
```

## Shared schema import check

`apps/api/src/app.test.ts` imports `tripRequestSchema` from the shared package source and validates a sample trip request. API typecheck uses a wider typecheck `rootDir`, while API build keeps `rootDir: "src"` so compiled output stays scoped to the API app.

## Tests added/updated

- Supertest health check test.
- Env config defaults/valid config/invalid `API_PORT`/invalid `WEB_ORIGIN` tests.
- Shared schema import smoke test.

## Checks run

- `pnpm install` passed; existing warning about ignored `esbuild` build scripts remains.
- `pnpm lint` stalled locally at `eslint .` after about 60 seconds and was interrupted. No tooling changes were made because this is the known local runner issue and not a Ticket 13 bug.
- `pnpm typecheck` passed.
- `pnpm test` passed: shared 4 files / 11 tests, API 2 files / 6 tests, web 6 files / 22 tests.
- `pnpm build` passed.
- `pnpm --filter @japan-travel-planner/api test` passed: 2 files / 6 tests.
- `pnpm --filter @japan-travel-planner/api typecheck` passed.
- `pnpm --filter @japan-travel-planner/api build` passed.
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism` passed: 2 files / 6 tests.
- `pnpm --filter @japan-travel-planner/web test:e2e` passed: 1 Chromium test.
- `git diff --check` passed.
- Focused Prettier check on touched API files passed.

## Manual API checks run

- `pnpm dev:api` starts the API and logs `API server listening at http://localhost:3001`.
- `curl -i --max-time 5 http://localhost:3001/api/health` returned HTTP 200 and JSON status `ok`.
- Response includes `Access-Control-Allow-Origin: http://localhost:5173`.
- `API_PORT=not-a-port WEB_ORIGIN=http://localhost:5173 pnpm --filter @japan-travel-planner/api dev` fails clearly with `Invalid API_PORT: expected an integer between 1 and 65535.`

## Known risks

- Local `pnpm lint` still stalls at `eslint .`; GitHub Actions should remain the main signal for root lint until that local runner issue is addressed in a dedicated tooling ticket.
- The API `dev` script now builds then runs `node dist/server.js` because `tsx watch src/server.ts` did not open port 3001 in this environment. This is reliable but does not provide watch-mode reloads.

## Ticket 14+ confirmation

Ticket 14 and later were not started. This PR does not add Prisma, database migrations, persistence code, trip creation/generation routes, auth, AI generation, or web app behavior changes.
