### PR TITLE
T-015 Implement API error and validation middleware

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,12 +15,13 @@
     "test": "pnpm db:generate && vitest run"
   },
   "dependencies": {
-    "@prisma/client": "^7.8.0",
     "@prisma/adapter-pg": "^7.8.0",
+    "@prisma/client": "^7.8.0",
     "cors": "^2.8.6",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
-    "pg": "^8.16.3"
+    "pg": "^8.16.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,6 +2,7 @@ import cors from "cors";
 import express from "express";
 
 import { loadApiEnv, type ApiEnvConfig } from "./config/env.js";
+import { errorHandler } from "./middleware/errorHandler.js";
 import { healthRouter } from "./routes/health.js";
 
 export type CreateAppOptions = {
@@ -19,6 +20,7 @@ export function createApp(options: CreateAppOptions = {}) {
   );
   app.use(express.json());
   app.use("/api/health", healthRouter);
+  app.use(errorHandler);
 
   return app;
 }

--- a/apps/api/src/errors/ApiError.ts
+++ b/apps/api/src/errors/ApiError.ts
@@ -1,0 +1,71 @@
+import type { ZodError } from "zod";
+
+export type ApiFieldError = {
+  path: string;
+  message: string;
+};
+
+export type ApiErrorResponse = {
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+    fieldErrors?: ApiFieldError[];
+  };
+};
+
+type ApiErrorOptions = {
+  statusCode: number;
+  code: string;
+  message: string;
+  details?: unknown;
+  fieldErrors?: ApiFieldError[] | undefined;
+};
+
+export class ApiError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+  readonly details?: unknown;
+  readonly fieldErrors?: ApiFieldError[];
+
+  constructor(options: ApiErrorOptions) {
+    super(options.message);
+    this.name = "ApiError";
+    this.statusCode = options.statusCode;
+    this.code = options.code;
+
+    if (options.details !== undefined) {
+      this.details = options.details;
+    }
+
+    if (options.fieldErrors !== undefined) {
+      this.fieldErrors = options.fieldErrors;
+    }
+  }
+}
+
+export function createApiErrorResponse(error: {
+  code: string;
+  message: string;
+  details?: unknown;
+  fieldErrors?: ApiFieldError[] | undefined;
+}): ApiErrorResponse {
+  return {
+    error: {
+      code: error.code,
+      message: error.message,
+      ...(error.details !== undefined ? { details: error.details } : {}),
+      ...(error.fieldErrors !== undefined && error.fieldErrors.length > 0
+        ? { fieldErrors: error.fieldErrors }
+        : {})
+    }
+  };
+}
+
+export function zodIssuesToFieldErrors(error: ZodError): ApiFieldError[] {
+  return error.issues.map((issue) => ({
+    path:
+      issue.path.length > 0 ? issue.path.map(String).join(".") : "requestBody",
+    message: issue.message
+  }));
+}

--- a/apps/api/src/middleware/errorHandler.test.ts
+++ b/apps/api/src/middleware/errorHandler.test.ts
@@ -1,0 +1,170 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, test } from "vitest";
+import { z } from "zod";
+
+import { apiErrorSchema } from "../../../../packages/shared/src/schemas/apiError.js";
+import { ApiError } from "../errors/ApiError.js";
+
+import { errorHandler } from "./errorHandler.js";
+import { validateRequest } from "./validateRequest.js";
+
+const testBodySchema = z
+  .object({
+    name: z.string().min(1),
+    count: z.number().int().positive()
+  })
+  .strict();
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+function createMiddlewareTestApp() {
+  const app = express();
+
+  app.use(express.json());
+  app.post(
+    "/test/validated",
+    validateRequest(testBodySchema),
+    (request, response) => {
+      response.status(201).json({
+        body: request.body
+      });
+    }
+  );
+  app.get("/test/known-error", () => {
+    throw new ApiError({
+      statusCode: 409,
+      code: "KNOWN_CONFLICT",
+      message: "Known conflict."
+    });
+  });
+  app.get("/test/unexpected-error", () => {
+    throw new Error("Sensitive database connection string leaked.");
+  });
+  app.use(errorHandler);
+
+  return app;
+}
+
+function expectSharedErrorResponse(responseBody: unknown) {
+  const result = apiErrorSchema.safeParse(responseBody);
+
+  expect(result.success).toBe(true);
+}
+
+describe("validateRequest", () => {
+  test("returns structured validation errors for invalid request bodies", async () => {
+    const response = await request(createMiddlewareTestApp())
+      .post("/test/validated")
+      .send({
+        name: "",
+        count: 0
+      });
+
+    expect(response.status).toBe(400);
+    expectSharedErrorResponse(response.body);
+    expect(response.body).toMatchObject({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Request validation failed."
+      }
+    });
+    expect(response.body.error.fieldErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "name"
+        }),
+        expect.objectContaining({
+          path: "count"
+        })
+      ])
+    );
+  });
+
+  test("passes valid request bodies through to the next handler", async () => {
+    const response = await request(createMiddlewareTestApp())
+      .post("/test/validated")
+      .send({
+        name: "Tokyo food walk",
+        count: 2
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      body: {
+        name: "Tokyo food walk",
+        count: 2
+      }
+    });
+  });
+});
+
+describe("errorHandler", () => {
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+      return;
+    }
+
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test("returns structured responses for known API errors", async () => {
+    const response = await request(createMiddlewareTestApp()).get(
+      "/test/known-error"
+    );
+
+    expect(response.status).toBe(409);
+    expectSharedErrorResponse(response.body);
+    expect(response.body).toEqual({
+      error: {
+        code: "KNOWN_CONFLICT",
+        message: "Known conflict."
+      }
+    });
+  });
+
+  test("returns safe structured responses for unexpected errors", async () => {
+    const response = await request(createMiddlewareTestApp()).get(
+      "/test/unexpected-error"
+    );
+
+    expect(response.status).toBe(500);
+    expectSharedErrorResponse(response.body);
+    expect(response.body).toEqual({
+      error: {
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Unexpected server error."
+      }
+    });
+  });
+
+  test("does not expose stack traces in non-development mode", async () => {
+    process.env.NODE_ENV = "production";
+
+    const response = await request(createMiddlewareTestApp()).get(
+      "/test/unexpected-error"
+    );
+    const serializedBody = JSON.stringify(response.body);
+
+    expect(response.status).toBe(500);
+    expect(serializedBody).not.toContain("Sensitive database");
+    expect(serializedBody).not.toContain("stack");
+  });
+
+  test("returns structured errors for invalid JSON bodies", async () => {
+    const response = await request(createMiddlewareTestApp())
+      .post("/test/validated")
+      .set("Content-Type", "application/json")
+      .send("{ invalid json");
+
+    expect(response.status).toBe(400);
+    expectSharedErrorResponse(response.body);
+    expect(response.body).toEqual({
+      error: {
+        code: "INVALID_JSON",
+        message: "Request body must be valid JSON."
+      }
+    });
+  });
+});

--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -1,0 +1,64 @@
+import type { ErrorRequestHandler } from "express";
+import { ZodError } from "zod";
+
+import {
+  ApiError,
+  createApiErrorResponse,
+  zodIssuesToFieldErrors
+} from "../errors/ApiError.js";
+
+function isJsonBodySyntaxError(error: unknown) {
+  return error instanceof SyntaxError && "body" in error;
+}
+
+export const errorHandler: ErrorRequestHandler = (
+  error,
+  _request,
+  response,
+  next
+) => {
+  if (response.headersSent) {
+    next(error);
+    return;
+  }
+
+  if (error instanceof ApiError) {
+    response.status(error.statusCode).json(
+      createApiErrorResponse({
+        code: error.code,
+        message: error.message,
+        details: error.details,
+        fieldErrors: error.fieldErrors
+      })
+    );
+    return;
+  }
+
+  if (error instanceof ZodError) {
+    response.status(400).json(
+      createApiErrorResponse({
+        code: "VALIDATION_ERROR",
+        message: "Request validation failed.",
+        fieldErrors: zodIssuesToFieldErrors(error)
+      })
+    );
+    return;
+  }
+
+  if (isJsonBodySyntaxError(error)) {
+    response.status(400).json(
+      createApiErrorResponse({
+        code: "INVALID_JSON",
+        message: "Request body must be valid JSON."
+      })
+    );
+    return;
+  }
+
+  response.status(500).json(
+    createApiErrorResponse({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Unexpected server error."
+    })
+  );
+};

--- a/apps/api/src/middleware/validateRequest.ts
+++ b/apps/api/src/middleware/validateRequest.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from "express";
+import type { ZodType } from "zod";
+
+import {
+  createApiErrorResponse,
+  zodIssuesToFieldErrors
+} from "../errors/ApiError.js";
+
+export function validateRequest(schema: ZodType): RequestHandler {
+  return (request, response, next) => {
+    const result = schema.safeParse(request.body);
+
+    if (!result.success) {
+      response.status(400).json(
+        createApiErrorResponse({
+          code: "VALIDATION_ERROR",
+          message: "Request validation failed.",
+          fieldErrors: zodIssuesToFieldErrors(result.error)
+        })
+      );
+      return;
+    }
+
+    request.body = result.data;
+    next();
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       pg:
         specifier: ^8.16.3
         version: 8.22.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/cors':
         specifier: ^2.8.19


### PR DESCRIPTION
## Ticket scope

Implements T-015 / Ticket 15: Implement API Error And Validation Middleware.

This PR standardizes request body validation and safe API error responses before Trip CRUD routes are added. Ticket 16 and later work was not started.

## Changes made

- Added `validateRequest` middleware for Zod request body validation.
- Added centralized Express `errorHandler` middleware and mounted it after current routes.
- Added an `ApiError` class plus response helpers for known HTTP errors and shared error-shaped responses.
- Added API middleware tests using test-only routes for validation pass/fail, known errors, unexpected errors, invalid JSON, and non-development stack-safety.
- Added a direct API dependency on `zod` because the API middleware now accepts Zod schemas at runtime.

## Middleware/errors added

- `apps/api/src/middleware/validateRequest.ts`
- `apps/api/src/middleware/errorHandler.ts`
- `apps/api/src/errors/ApiError.ts`

## Validation approach

- `validateRequest(schema)` calls `schema.safeParse(request.body)`.
- Valid bodies replace `request.body` with parsed data and continue to the next handler.
- Invalid bodies return HTTP 400 immediately with `VALIDATION_ERROR`, a stable message, and field-level issues.
- Test-only routes exercise the middleware; no production validation or Trip CRUD route was added.

## Error response format

Responses use this structure and are tested against the shared schema:

```json
{
  "error": {
    "code": "VALIDATION_ERROR",
    "message": "Request validation failed.",
    "fieldErrors": [
      {
        "path": "name",
        "message": "Too small: expected string to have >=1 characters"
      }
    ]
  }
}
```

Unexpected errors return HTTP 500 with:

```json
{
  "error": {
    "code": "INTERNAL_SERVER_ERROR",
    "message": "Unexpected server error."
  }
}
```

Invalid JSON bodies return HTTP 400 with `INVALID_JSON`.

## Shared API error schema compatibility

- No shared schema changes were needed.
- Middleware tests import `apiErrorSchema` and verify structured error responses validate against it.
- API production source uses a local structural type to avoid importing shared source files outside the API build root.

## Tests added/updated

- Added `apps/api/src/middleware/errorHandler.test.ts` covering:
  - invalid request body returns structured validation errors
  - valid request body passes through
  - known `ApiError` responses
  - unexpected error responses
  - non-development mode does not leak stack traces or sensitive messages
  - invalid JSON body responses
- Existing `GET /api/health` regression test remains passing.

## Checks run

- `pnpm install` ✅
- `pnpm --filter @japan-travel-planner/api typecheck` ✅
- `pnpm --filter @japan-travel-planner/api test` ✅
- `pnpm --filter @japan-travel-planner/api build` ✅
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅
- `pnpm build` ✅
- `pnpm --filter @japan-travel-planner/web test:e2e` ✅
- `git diff --check` ✅

## Local lint note

- `pnpm lint` stalled locally at `eslint .` after printing the root lint banner for about 60 seconds, with no diagnostics.
- Targeted lint also stalled at `eslint apps/api/src/app.ts apps/api/src/errors apps/api/src/middleware` after about 30 seconds, with no diagnostics.
- No tooling changes were made because this matches the known local ESLint stall pattern and there was no concrete Ticket 15 tooling bug.
- GitHub Actions should be used as the primary lint signal for this PR.

## Manual API checks run

- Started API with `pnpm dev:api` ✅
- `curl -i http://localhost:3001/api/health` returned HTTP 200 with `{ "status": "ok", "service": "japan-travel-planner-api" }` ✅
- Confirmed no production validation route was added ✅
- Confirmed no Trip CRUD routes were added; API source still mounts only `/api/health` plus the error handler ✅

## Known risks

- Local ESLint stalls in this environment; CI lint should be the final signal.
- Development-mode debug details are intentionally not included yet; responses stay safe and minimal in all modes.
- Future route-level validation will need to choose and pass the appropriate Zod schema to `validateRequest`.

## Ticket boundary confirmation

Ticket 16 and later tickets were not started. This PR does not add Trip CRUD routes, trip services/repositories, AI generation, auth/session middleware, web behavior changes, Prisma schema/migration changes, or shared schema changes.
