### PR TITLE
T-016 Implement Trip CRUD API

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,13 +4,17 @@ import express from "express";
 import { loadApiEnv, type ApiEnvConfig } from "./config/env.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { healthRouter } from "./routes/health.js";
+import { createTripsRouter } from "./routes/trips.js";
+import { createTripService, type TripService } from "./services/tripService.js";
 
 export type CreateAppOptions = {
   env?: ApiEnvConfig;
+  tripService?: TripService;
 };
 
 export function createApp(options: CreateAppOptions = {}) {
   const env = options.env ?? loadApiEnv();
+  const tripService = options.tripService ?? createTripService();
   const app = express();
 
   app.use(
@@ -20,6 +24,7 @@ export function createApp(options: CreateAppOptions = {}) {
   );
   app.use(express.json());
   app.use("/api/health", healthRouter);
+  app.use("/api/trips", createTripsRouter(tripService));
   app.use(errorHandler);
 
   return app;

--- a/apps/api/src/repositories/tripRepository.ts
+++ b/apps/api/src/repositories/tripRepository.ts
@@ -1,0 +1,452 @@
+import { prisma } from "../db/client.js";
+import type { PrismaClient } from "../generated/prisma/client.js";
+
+export type TravelPace = "relaxed" | "balanced" | "packed";
+export type TravelBudget = "budget" | "moderate" | "luxury";
+export type ActivityCategory =
+  | "sightseeing"
+  | "food"
+  | "culture"
+  | "nature"
+  | "shopping"
+  | "transit"
+  | "lodging"
+  | "other";
+export type ActivityCostLevel = "free" | "low" | "medium" | "high";
+
+export type ActivityInput = {
+  id?: string;
+  title: string;
+  category: ActivityCategory;
+  timing: {
+    startTime?: string;
+    endTime?: string;
+    timeOfDay?: "morning" | "afternoon" | "evening" | "night";
+  };
+  durationMinutes: number;
+  location: {
+    name: string;
+    address?: string;
+    city?: string;
+    latitude?: number;
+    longitude?: number;
+    mapUrl?: string;
+  };
+  costLevel: ActivityCostLevel;
+  notes: string;
+};
+
+export type TripDayInput = {
+  date: string;
+  city: string;
+  summary?: string;
+  weatherSummary?: string;
+  activities: ActivityInput[];
+};
+
+export type CreateTripInput = {
+  title: string;
+  startDate: string;
+  endDate: string;
+  cities: string[];
+  interests: string[];
+  pace: TravelPace;
+  budget: TravelBudget;
+  constraints: string[];
+  days: TripDayInput[];
+};
+
+export type UpdateTripInput = Partial<
+  Omit<CreateTripInput, "constraints" | "days">
+> & {
+  constraints?: string[];
+  days?: TripDayInput[];
+};
+
+export type ActivityResponse = ActivityInput & {
+  id: string;
+};
+
+export type TripDayResponse = {
+  id: string;
+  date: string;
+  city: string;
+  summary?: string;
+  weatherSummary?: string;
+  activities: ActivityResponse[];
+};
+
+export type TripResponse = {
+  id: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  cities: string[];
+  interests: string[];
+  pace: TravelPace;
+  budget: TravelBudget;
+  constraints: string[];
+  days: TripDayResponse[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type TripOwner = {
+  id: string;
+};
+
+export type TripRepository = {
+  findOrCreateOwner(anonymousSessionId: string): Promise<TripOwner>;
+  listTrips(ownerId: string): Promise<TripResponse[]>;
+  createTrip(ownerId: string, input: CreateTripInput): Promise<TripResponse>;
+  findTrip(ownerId: string, tripId: string): Promise<TripResponse | null>;
+  updateTrip(
+    ownerId: string,
+    tripId: string,
+    input: UpdateTripInput
+  ): Promise<TripResponse | null>;
+  deleteTrip(ownerId: string, tripId: string): Promise<boolean>;
+};
+
+type PrismaTripWithDays = {
+  id: string;
+  title: string;
+  startDate: Date;
+  endDate: Date;
+  cities: string[];
+  interests: string[];
+  pace: TravelPace;
+  budget: TravelBudget;
+  constraints: string[];
+  createdAt: Date;
+  updatedAt: Date;
+  days: Array<{
+    id: string;
+    date: Date;
+    city: string;
+    summary: string | null;
+    weatherSummary: string | null;
+    activities: Array<{
+      id: string;
+      title: string;
+      category: ActivityCategory;
+      startTime: string | null;
+      endTime: string | null;
+      timeOfDay: string | null;
+      durationMinutes: number;
+      locationName: string;
+      locationAddress: string | null;
+      locationCity: string | null;
+      latitude: number | null;
+      longitude: number | null;
+      mapUrl: string | null;
+      costLevel: ActivityCostLevel;
+      notes: string;
+    }>;
+  }>;
+};
+
+const tripWithDaysInclude = {
+  days: {
+    orderBy: {
+      orderIndex: "asc" as const
+    },
+    include: {
+      activities: {
+        orderBy: {
+          orderIndex: "asc" as const
+        }
+      }
+    }
+  }
+};
+
+function toDate(value: string) {
+  return new Date(`${value}T00:00:00.000Z`);
+}
+
+function toIsoDate(value: Date) {
+  return value.toISOString().slice(0, 10);
+}
+
+function toIsoDateTime(value: Date) {
+  return value.toISOString();
+}
+
+function buildActivityCreateData(activity: ActivityInput, orderIndex: number) {
+  return {
+    ...(activity.id !== undefined ? { id: activity.id } : {}),
+    title: activity.title,
+    category: activity.category,
+    ...(activity.timing.startTime !== undefined
+      ? { startTime: activity.timing.startTime }
+      : {}),
+    ...(activity.timing.endTime !== undefined
+      ? { endTime: activity.timing.endTime }
+      : {}),
+    ...(activity.timing.timeOfDay !== undefined
+      ? { timeOfDay: activity.timing.timeOfDay }
+      : {}),
+    durationMinutes: activity.durationMinutes,
+    locationName: activity.location.name,
+    ...(activity.location.address !== undefined
+      ? { locationAddress: activity.location.address }
+      : {}),
+    ...(activity.location.city !== undefined
+      ? { locationCity: activity.location.city }
+      : {}),
+    ...(activity.location.latitude !== undefined
+      ? { latitude: activity.location.latitude }
+      : {}),
+    ...(activity.location.longitude !== undefined
+      ? { longitude: activity.location.longitude }
+      : {}),
+    ...(activity.location.mapUrl !== undefined
+      ? { mapUrl: activity.location.mapUrl }
+      : {}),
+    costLevel: activity.costLevel,
+    notes: activity.notes,
+    orderIndex
+  };
+}
+
+function buildDayCreateData(day: TripDayInput, orderIndex: number) {
+  return {
+    date: toDate(day.date),
+    city: day.city,
+    ...(day.summary !== undefined ? { summary: day.summary } : {}),
+    ...(day.weatherSummary !== undefined
+      ? { weatherSummary: day.weatherSummary }
+      : {}),
+    orderIndex,
+    activities: {
+      create: day.activities.map((activity, activityIndex) =>
+        buildActivityCreateData(activity, activityIndex)
+      )
+    }
+  };
+}
+
+function buildTripUpdateData(input: UpdateTripInput) {
+  return {
+    ...(input.title !== undefined ? { title: input.title } : {}),
+    ...(input.startDate !== undefined
+      ? { startDate: toDate(input.startDate) }
+      : {}),
+    ...(input.endDate !== undefined ? { endDate: toDate(input.endDate) } : {}),
+    ...(input.cities !== undefined ? { cities: input.cities } : {}),
+    ...(input.interests !== undefined ? { interests: input.interests } : {}),
+    ...(input.pace !== undefined ? { pace: input.pace } : {}),
+    ...(input.budget !== undefined ? { budget: input.budget } : {}),
+    ...(input.constraints !== undefined
+      ? { constraints: input.constraints }
+      : {}),
+    ...(input.days !== undefined
+      ? {
+          days: {
+            create: input.days.map((day, dayIndex) =>
+              buildDayCreateData(day, dayIndex)
+            )
+          }
+        }
+      : {})
+  };
+}
+
+function mapTrip(trip: PrismaTripWithDays): TripResponse {
+  return {
+    id: trip.id,
+    title: trip.title,
+    startDate: toIsoDate(trip.startDate),
+    endDate: toIsoDate(trip.endDate),
+    cities: trip.cities,
+    interests: trip.interests,
+    pace: trip.pace,
+    budget: trip.budget,
+    constraints: trip.constraints,
+    createdAt: toIsoDateTime(trip.createdAt),
+    updatedAt: toIsoDateTime(trip.updatedAt),
+    days: trip.days.map((day) => ({
+      id: day.id,
+      date: toIsoDate(day.date),
+      city: day.city,
+      ...(day.summary !== null ? { summary: day.summary } : {}),
+      ...(day.weatherSummary !== null
+        ? { weatherSummary: day.weatherSummary }
+        : {}),
+      activities: day.activities.map((activity) => ({
+        id: activity.id,
+        title: activity.title,
+        category: activity.category,
+        timing: {
+          ...(activity.startTime !== null
+            ? { startTime: activity.startTime }
+            : {}),
+          ...(activity.endTime !== null ? { endTime: activity.endTime } : {}),
+          ...(activity.timeOfDay !== null
+            ? {
+                timeOfDay: activity.timeOfDay as
+                  | "morning"
+                  | "afternoon"
+                  | "evening"
+                  | "night"
+              }
+            : {})
+        },
+        durationMinutes: activity.durationMinutes,
+        location: {
+          name: activity.locationName,
+          ...(activity.locationAddress !== null
+            ? { address: activity.locationAddress }
+            : {}),
+          ...(activity.locationCity !== null
+            ? { city: activity.locationCity }
+            : {}),
+          ...(activity.latitude !== null
+            ? { latitude: activity.latitude }
+            : {}),
+          ...(activity.longitude !== null
+            ? { longitude: activity.longitude }
+            : {}),
+          ...(activity.mapUrl !== null ? { mapUrl: activity.mapUrl } : {})
+        },
+        costLevel: activity.costLevel,
+        notes: activity.notes
+      }))
+    }))
+  };
+}
+
+export function createPrismaTripRepository(
+  client: PrismaClient = prisma
+): TripRepository {
+  return {
+    async findOrCreateOwner(anonymousSessionId) {
+      const user = await client.user.upsert({
+        where: {
+          anonymousSessionId
+        },
+        update: {},
+        create: {
+          anonymousSessionId,
+          displayName: "Local Anonymous Traveler"
+        },
+        select: {
+          id: true
+        }
+      });
+
+      return user;
+    },
+
+    async listTrips(ownerId) {
+      const trips = await client.trip.findMany({
+        where: {
+          userId: ownerId
+        },
+        orderBy: {
+          startDate: "asc"
+        },
+        include: tripWithDaysInclude
+      });
+
+      return trips.map((trip) => mapTrip(trip as PrismaTripWithDays));
+    },
+
+    async createTrip(ownerId, input) {
+      const trip = await client.trip.create({
+        data: {
+          userId: ownerId,
+          title: input.title,
+          cities: input.cities,
+          startDate: toDate(input.startDate),
+          endDate: toDate(input.endDate),
+          pace: input.pace,
+          budget: input.budget,
+          interests: input.interests,
+          constraints: input.constraints,
+          days: {
+            create: input.days.map((day, dayIndex) =>
+              buildDayCreateData(day, dayIndex)
+            )
+          }
+        },
+        include: tripWithDaysInclude
+      });
+
+      return mapTrip(trip as PrismaTripWithDays);
+    },
+
+    async findTrip(ownerId, tripId) {
+      const trip = await client.trip.findFirst({
+        where: {
+          id: tripId,
+          userId: ownerId
+        },
+        include: tripWithDaysInclude
+      });
+
+      return trip === null ? null : mapTrip(trip as PrismaTripWithDays);
+    },
+
+    async updateTrip(ownerId, tripId, input) {
+      const existingTrip = await client.trip.findFirst({
+        where: {
+          id: tripId,
+          userId: ownerId
+        },
+        select: {
+          id: true
+        }
+      });
+
+      if (existingTrip === null) {
+        return null;
+      }
+
+      const trip = await client.$transaction(async (transaction) => {
+        if (input.days !== undefined) {
+          await transaction.tripDay.deleteMany({
+            where: {
+              tripId
+            }
+          });
+        }
+
+        return transaction.trip.update({
+          where: {
+            id: tripId
+          },
+          data: buildTripUpdateData(input),
+          include: tripWithDaysInclude
+        });
+      });
+
+      return mapTrip(trip as PrismaTripWithDays);
+    },
+
+    async deleteTrip(ownerId, tripId) {
+      const existingTrip = await client.trip.findFirst({
+        where: {
+          id: tripId,
+          userId: ownerId
+        },
+        select: {
+          id: true
+        }
+      });
+
+      if (existingTrip === null) {
+        return false;
+      }
+
+      await client.trip.delete({
+        where: {
+          id: tripId
+        }
+      });
+
+      return true;
+    }
+  };
+}

--- a/apps/api/src/routes/trips.test.ts
+++ b/apps/api/src/routes/trips.test.ts
@@ -1,0 +1,324 @@
+import request from "supertest";
+import { describe, expect, test } from "vitest";
+
+import { apiErrorSchema } from "../../../../packages/shared/src/schemas/apiError.js";
+
+import { createApp } from "../app.js";
+import { defaultApiEnv } from "../config/env.js";
+import type {
+  CreateTripInput,
+  TripOwner,
+  TripRepository,
+  TripResponse,
+  UpdateTripInput
+} from "../repositories/tripRepository.js";
+import { TripService } from "../services/tripService.js";
+
+const validCreateTripPayload = {
+  title: "Tokyo And Kyoto Spring Highlights",
+  startDate: "2026-04-06",
+  endDate: "2026-04-08",
+  cities: ["Tokyo", "Kyoto"],
+  interests: ["temples", "local food"],
+  pace: "balanced",
+  budget: "moderate",
+  constraints: ["Avoid late-night activities"],
+  days: [
+    {
+      date: "2026-04-06",
+      city: "Tokyo",
+      summary: "Explore old Tokyo and classic food stops.",
+      weatherSummary: "Mild spring weather.",
+      activities: [
+        {
+          title: "Senso-ji and Nakamise-dori",
+          category: "culture",
+          timing: {
+            startTime: "09:30",
+            endTime: "11:30",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 120,
+          location: {
+            name: "Senso-ji",
+            address: "2 Chome-3-1 Asakusa, Taito City, Tokyo",
+            city: "Tokyo",
+            latitude: 35.7148,
+            longitude: 139.7967,
+            mapUrl:
+              "https://www.google.com/maps/search/?api=1&query=Senso-ji%20Tokyo"
+          },
+          costLevel: "free",
+          notes: "Arrive early for lighter crowds."
+        }
+      ]
+    }
+  ]
+} satisfies CreateTripInput;
+
+class InMemoryTripRepository implements TripRepository {
+  private readonly owner: TripOwner = { id: "test-owner" };
+  private readonly tripOwners = new Map<string, string>();
+  private readonly trips = new Map<string, TripResponse>();
+  private nextTripId = 1;
+  private nextDayId = 1;
+  private nextActivityId = 1;
+
+  async findOrCreateOwner() {
+    return this.owner;
+  }
+
+  async listTrips(ownerId: string) {
+    return Array.from(this.trips.values())
+      .filter((trip) => this.tripOwners.get(trip.id) === ownerId)
+      .map((trip) => structuredClone(trip));
+  }
+
+  async createTrip(ownerId: string, input: CreateTripInput) {
+    const trip = this.tripFromInput(`trip-${this.nextTripId++}`, input);
+
+    this.trips.set(trip.id, trip);
+    this.tripOwners.set(trip.id, ownerId);
+
+    return structuredClone(trip);
+  }
+
+  async findTrip(ownerId: string, tripId: string) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return null;
+    }
+
+    const trip = this.trips.get(tripId);
+
+    return trip === undefined ? null : structuredClone(trip);
+  }
+
+  async updateTrip(ownerId: string, tripId: string, input: UpdateTripInput) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return null;
+    }
+
+    const existingTrip = this.trips.get(tripId);
+
+    if (existingTrip === undefined) {
+      return null;
+    }
+
+    const updatedTrip: TripResponse = {
+      ...structuredClone(existingTrip),
+      ...input,
+      days:
+        input.days === undefined
+          ? structuredClone(existingTrip.days)
+          : input.days.map((day) => ({
+              id: `day-${this.nextDayId++}`,
+              ...day,
+              activities: day.activities.map((activity) => ({
+                ...activity,
+                id: activity.id ?? `activity-${this.nextActivityId++}`
+              }))
+            })),
+      updatedAt: new Date("2026-01-02T00:00:00.000Z").toISOString()
+    };
+
+    this.trips.set(tripId, updatedTrip);
+
+    return structuredClone(updatedTrip);
+  }
+
+  async deleteTrip(ownerId: string, tripId: string) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return false;
+    }
+
+    this.tripOwners.delete(tripId);
+    return this.trips.delete(tripId);
+  }
+
+  private tripFromInput(id: string, input: CreateTripInput): TripResponse {
+    const timestamp = new Date("2026-01-01T00:00:00.000Z").toISOString();
+
+    return {
+      id,
+      ...structuredClone(input),
+      days: input.days.map((day) => ({
+        id: `day-${this.nextDayId++}`,
+        ...day,
+        activities: day.activities.map((activity) => ({
+          ...activity,
+          id: activity.id ?? `activity-${this.nextActivityId++}`
+        }))
+      })),
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+  }
+}
+
+function createTripsTestApp() {
+  const repository = new InMemoryTripRepository();
+
+  return createApp({
+    env: defaultApiEnv,
+    tripService: new TripService(repository)
+  });
+}
+
+function expectSharedErrorResponse(responseBody: unknown) {
+  expect(apiErrorSchema.safeParse(responseBody).success).toBe(true);
+}
+
+describe("Trip CRUD API", () => {
+  test("GET /api/trips lists trips for the placeholder owner", async () => {
+    const app = createTripsTestApp();
+
+    const response = await request(app).get("/api/trips");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      trips: []
+    });
+  });
+
+  test("POST /api/trips creates a trip with structured itinerary data", async () => {
+    const app = createTripsTestApp();
+
+    const response = await request(app)
+      .post("/api/trips")
+      .send(validCreateTripPayload);
+
+    expect(response.status).toBe(201);
+    expect(response.body.trip).toMatchObject({
+      id: "trip-1",
+      title: validCreateTripPayload.title,
+      startDate: validCreateTripPayload.startDate,
+      endDate: validCreateTripPayload.endDate,
+      cities: validCreateTripPayload.cities,
+      interests: validCreateTripPayload.interests,
+      pace: validCreateTripPayload.pace,
+      budget: validCreateTripPayload.budget,
+      constraints: validCreateTripPayload.constraints
+    });
+    expect(response.body.trip.days).toHaveLength(1);
+    expect(response.body.trip.days[0].activities[0]).toMatchObject({
+      title: "Senso-ji and Nakamise-dori",
+      location: {
+        name: "Senso-ji"
+      }
+    });
+  });
+
+  test("POST /api/trips returns structured validation errors for invalid payloads", async () => {
+    const app = createTripsTestApp();
+
+    const response = await request(app).post("/api/trips").send({
+      title: "",
+      startDate: "2026-04-08",
+      endDate: "2026-04-06",
+      cities: [],
+      interests: [],
+      pace: "balanced",
+      budget: "moderate",
+      days: []
+    });
+
+    expect(response.status).toBe(400);
+    expectSharedErrorResponse(response.body);
+    expect(response.body.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "Request validation failed."
+    });
+    expect(response.body.error.fieldErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "title"
+        }),
+        expect.objectContaining({
+          path: "endDate"
+        })
+      ])
+    );
+  });
+
+  test("GET /api/trips/:tripId returns a trip", async () => {
+    const app = createTripsTestApp();
+    const createResponse = await request(app)
+      .post("/api/trips")
+      .send(validCreateTripPayload);
+
+    const response = await request(app).get(
+      `/api/trips/${createResponse.body.trip.id}`
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.trip).toMatchObject({
+      id: createResponse.body.trip.id,
+      title: validCreateTripPayload.title
+    });
+  });
+
+  test("GET /api/trips/:tripId returns structured 404 for missing trip IDs", async () => {
+    const app = createTripsTestApp();
+
+    const response = await request(app).get("/api/trips/missing-trip");
+
+    expect(response.status).toBe(404);
+    expectSharedErrorResponse(response.body);
+    expect(response.body).toEqual({
+      error: {
+        code: "TRIP_NOT_FOUND",
+        message: "Trip was not found."
+      }
+    });
+  });
+
+  test("PATCH /api/trips/:tripId updates editable trip data", async () => {
+    const app = createTripsTestApp();
+    const createResponse = await request(app)
+      .post("/api/trips")
+      .send(validCreateTripPayload);
+
+    const response = await request(app)
+      .patch(`/api/trips/${createResponse.body.trip.id}`)
+      .send({
+        title: "Updated Spring Trip",
+        interests: ["gardens", "street food"]
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.trip).toMatchObject({
+      id: createResponse.body.trip.id,
+      title: "Updated Spring Trip",
+      interests: ["gardens", "street food"]
+    });
+  });
+
+  test("DELETE /api/trips/:tripId hard-deletes a trip", async () => {
+    const app = createTripsTestApp();
+    const createResponse = await request(app)
+      .post("/api/trips")
+      .send(validCreateTripPayload);
+
+    const deleteResponse = await request(app).delete(
+      `/api/trips/${createResponse.body.trip.id}`
+    );
+    const getResponse = await request(app).get(
+      `/api/trips/${createResponse.body.trip.id}`
+    );
+
+    expect(deleteResponse.status).toBe(204);
+    expect(getResponse.status).toBe(404);
+  });
+
+  test("GET /api/health still returns HTTP 200", async () => {
+    const app = createTripsTestApp();
+
+    const response = await request(app).get("/api/health");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: "ok",
+      service: "japan-travel-planner-api"
+    });
+  });
+});

--- a/apps/api/src/routes/trips.ts
+++ b/apps/api/src/routes/trips.ts
@@ -1,0 +1,199 @@
+import { Router, type RequestHandler } from "express";
+import { z } from "zod";
+
+import { ApiError } from "../errors/ApiError.js";
+import { validateRequest } from "../middleware/validateRequest.js";
+import type {
+  CreateTripInput,
+  UpdateTripInput
+} from "../repositories/tripRepository.js";
+import type { TripService } from "../services/tripService.js";
+
+const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+const travelPaceSchema = z.enum(["relaxed", "balanced", "packed"]);
+const travelBudgetSchema = z.enum(["budget", "moderate", "luxury"]);
+const activityCategorySchema = z.enum([
+  "sightseeing",
+  "food",
+  "culture",
+  "nature",
+  "shopping",
+  "transit",
+  "lodging",
+  "other"
+]);
+const activityCostLevelSchema = z.enum(["free", "low", "medium", "high"]);
+
+const activityTimingSchema = z
+  .object({
+    startTime: z
+      .string()
+      .regex(/^([01]\d|2[0-3]):[0-5]\d$/)
+      .optional(),
+    endTime: z
+      .string()
+      .regex(/^([01]\d|2[0-3]):[0-5]\d$/)
+      .optional(),
+    timeOfDay: z.enum(["morning", "afternoon", "evening", "night"]).optional()
+  })
+  .strict()
+  .refine(
+    (timing) => Boolean(timing.startTime ?? timing.timeOfDay),
+    "Provide either startTime or timeOfDay."
+  );
+
+const activityLocationSchema = z
+  .object({
+    name: z.string().min(1),
+    address: z.string().min(1).optional(),
+    city: z.string().min(1).optional(),
+    latitude: z.number().min(-90).max(90).optional(),
+    longitude: z.number().min(-180).max(180).optional(),
+    mapUrl: z.string().url().optional()
+  })
+  .strict();
+
+const activityInputSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    title: z.string().min(1),
+    category: activityCategorySchema,
+    timing: activityTimingSchema,
+    durationMinutes: z.number().int().positive(),
+    location: activityLocationSchema,
+    costLevel: activityCostLevelSchema,
+    notes: z.string()
+  })
+  .strict();
+
+const tripDayInputSchema = z
+  .object({
+    date: isoDateSchema,
+    city: z.string().min(1),
+    summary: z.string().optional(),
+    weatherSummary: z.string().optional(),
+    activities: z.array(activityInputSchema).min(1)
+  })
+  .strict();
+
+const tripCreateBodySchema = z
+  .object({
+    title: z.string().min(1),
+    startDate: isoDateSchema,
+    endDate: isoDateSchema,
+    cities: z.array(z.string().min(1)).min(1),
+    interests: z.array(z.string().min(1)).min(1),
+    pace: travelPaceSchema,
+    budget: travelBudgetSchema,
+    constraints: z.array(z.string().min(1)).default([]),
+    days: z.array(tripDayInputSchema).min(1)
+  })
+  .strict()
+  .refine((trip) => trip.startDate <= trip.endDate, {
+    message: "endDate must be on or after startDate.",
+    path: ["endDate"]
+  });
+
+const tripUpdateBodySchema = z
+  .object({
+    title: z.string().min(1).optional(),
+    startDate: isoDateSchema.optional(),
+    endDate: isoDateSchema.optional(),
+    cities: z.array(z.string().min(1)).min(1).optional(),
+    interests: z.array(z.string().min(1)).min(1).optional(),
+    pace: travelPaceSchema.optional(),
+    budget: travelBudgetSchema.optional(),
+    constraints: z.array(z.string().min(1)).optional(),
+    days: z.array(tripDayInputSchema).min(1).optional()
+  })
+  .strict()
+  .refine((trip) => Object.keys(trip).length > 0, {
+    message: "Provide at least one editable trip field.",
+    path: ["requestBody"]
+  })
+  .refine(
+    (trip) =>
+      trip.startDate === undefined ||
+      trip.endDate === undefined ||
+      trip.startDate <= trip.endDate,
+    {
+      message: "endDate must be on or after startDate.",
+      path: ["endDate"]
+    }
+  );
+
+function asyncHandler(handler: RequestHandler): RequestHandler {
+  return (request, response, next) => {
+    Promise.resolve(handler(request, response, next)).catch(next);
+  };
+}
+
+function getTripId(value: string | string[] | undefined) {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+
+  throw new ApiError({
+    statusCode: 400,
+    code: "INVALID_TRIP_ID",
+    message: "Trip ID is required."
+  });
+}
+
+export function createTripsRouter(tripService: TripService) {
+  const router = Router();
+
+  router.get(
+    "/",
+    asyncHandler(async (_request, response) => {
+      const trips = await tripService.listTrips();
+
+      response.status(200).json({ trips });
+    })
+  );
+
+  router.post(
+    "/",
+    validateRequest(tripCreateBodySchema),
+    asyncHandler(async (request, response) => {
+      const trip = await tripService.createTrip(
+        request.body as CreateTripInput
+      );
+
+      response.status(201).json({ trip });
+    })
+  );
+
+  router.get(
+    "/:tripId",
+    asyncHandler(async (request, response) => {
+      const trip = await tripService.getTrip(getTripId(request.params.tripId));
+
+      response.status(200).json({ trip });
+    })
+  );
+
+  router.patch(
+    "/:tripId",
+    validateRequest(tripUpdateBodySchema),
+    asyncHandler(async (request, response) => {
+      const trip = await tripService.updateTrip(
+        getTripId(request.params.tripId),
+        request.body as UpdateTripInput
+      );
+
+      response.status(200).json({ trip });
+    })
+  );
+
+  router.delete(
+    "/:tripId",
+    asyncHandler(async (request, response) => {
+      await tripService.deleteTrip(getTripId(request.params.tripId));
+
+      response.status(204).send();
+    })
+  );
+
+  return router;
+}

--- a/apps/api/src/services/tripService.ts
+++ b/apps/api/src/services/tripService.ts
@@ -1,0 +1,88 @@
+import { ApiError } from "../errors/ApiError.js";
+import {
+  createPrismaTripRepository,
+  type CreateTripInput,
+  type TripRepository,
+  type UpdateTripInput
+} from "../repositories/tripRepository.js";
+
+export const localAnonymousSessionId = "local-anonymous-traveler";
+
+export class TripService {
+  constructor(
+    private readonly repository: TripRepository,
+    private readonly anonymousSessionId = localAnonymousSessionId
+  ) {}
+
+  private async getOwnerId() {
+    const owner = await this.repository.findOrCreateOwner(
+      this.anonymousSessionId
+    );
+
+    return owner.id;
+  }
+
+  async listTrips() {
+    return this.repository.listTrips(await this.getOwnerId());
+  }
+
+  async createTrip(input: CreateTripInput) {
+    return this.repository.createTrip(await this.getOwnerId(), input);
+  }
+
+  async getTrip(tripId: string) {
+    const trip = await this.repository.findTrip(
+      await this.getOwnerId(),
+      tripId
+    );
+
+    if (trip === null) {
+      throw new ApiError({
+        statusCode: 404,
+        code: "TRIP_NOT_FOUND",
+        message: "Trip was not found."
+      });
+    }
+
+    return trip;
+  }
+
+  async updateTrip(tripId: string, input: UpdateTripInput) {
+    const trip = await this.repository.updateTrip(
+      await this.getOwnerId(),
+      tripId,
+      input
+    );
+
+    if (trip === null) {
+      throw new ApiError({
+        statusCode: 404,
+        code: "TRIP_NOT_FOUND",
+        message: "Trip was not found."
+      });
+    }
+
+    return trip;
+  }
+
+  async deleteTrip(tripId: string) {
+    const deleted = await this.repository.deleteTrip(
+      await this.getOwnerId(),
+      tripId
+    );
+
+    if (!deleted) {
+      throw new ApiError({
+        statusCode: 404,
+        code: "TRIP_NOT_FOUND",
+        message: "Trip was not found."
+      });
+    }
+  }
+}
+
+export function createTripService(
+  repository: TripRepository = createPrismaTripRepository()
+) {
+  return new TripService(repository);
+}


### PR DESCRIPTION
## Ticket scope

Implements T-016 / Ticket 16: Implement Trip CRUD API.

This PR adds API-only Trip CRUD routes, a service layer, a Prisma-backed repository, validation, and API route tests. Ticket 17 and later work was not started.

## Changes made

- Mounted `/api/trips` in the Express app before the existing error handler.
- Added Trip CRUD route handlers for list, create, read, update, and delete.
- Added a service layer that owns the placeholder local anonymous owner strategy for Ticket 16.
- Added a Prisma repository that maps between Prisma records and stable API response objects.
- Added route-level Zod validation using the existing `validateRequest` middleware.
- Added API route tests using an injected in-memory repository so CRUD behavior can be tested without a live local PostgreSQL instance.

## Routes added

- `GET /api/trips`
- `POST /api/trips`
- `GET /api/trips/:tripId`
- `PATCH /api/trips/:tripId`
- `DELETE /api/trips/:tripId`

## Service/repository structure

- `apps/api/src/services/tripService.ts`
  - Resolves the placeholder owner via `local-anonymous-traveler`.
  - Converts missing trip results into structured `TRIP_NOT_FOUND` errors.
  - Does not add auth/session middleware, cookies, or JWT behavior.
- `apps/api/src/repositories/tripRepository.ts`
  - Uses the Prisma client from Ticket 14 by default.
  - Creates/reuses a local anonymous `User` record for the placeholder owner strategy.
  - Creates, reads, updates, and hard-deletes `Trip` records with nested `TripDay` and `Activity` records.
  - Maps DB rows into stable JSON response objects and does not expose raw Prisma details.

## Validation approach

- `POST /api/trips` validates trip-level fields plus structured `days` and `activities`.
- `PATCH /api/trips/:tripId` validates partial editable fields and optional replacement `days`.
- Schemas are API-local but aligned with the existing shared trip request and itinerary shapes.
- No shared schema changes were needed.

## Error handling behavior

- Validation failures return structured HTTP 400 responses through the existing `validateRequest` error format.
- Unknown trip IDs return structured HTTP 404 responses:

```json
{
  "error": {
    "code": "TRIP_NOT_FOUND",
    "message": "Trip was not found."
  }
}
```

- Unexpected repository/database errors continue through the existing safe 500 error handler.

## Database/testing strategy

- Runtime/default implementation uses Prisma and `DATABASE_URL`.
- Local PostgreSQL was not available on `localhost:5432`, so DB-backed CRUD integration tests were not run locally.
- API CRUD tests use an injected in-memory `TripRepository` to exercise routes, service behavior, validation, 404 handling, and delete behavior without pretending local DB integration passed.
- Prisma schema validation and client generation were run locally.

## Tests added/updated

- Added `apps/api/src/routes/trips.test.ts` covering:
  - `GET /api/trips`
  - `POST /api/trips` valid payload
  - `POST /api/trips` invalid payload
  - `GET /api/trips/:tripId`
  - missing trip ID returning 404
  - `PATCH /api/trips/:tripId`
  - `DELETE /api/trips/:tripId`
  - `GET /api/health` regression

## Checks run

- `pnpm install` ✅
- `pnpm --filter @japan-travel-planner/api typecheck` ✅
- `pnpm --filter @japan-travel-planner/api test` ✅
- `pnpm --filter @japan-travel-planner/api build` ✅
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅
- `pnpm build` ✅
- `pnpm --filter @japan-travel-planner/api exec prisma validate` ✅
- `pnpm --filter @japan-travel-planner/api exec prisma generate` ✅
- `pnpm --filter @japan-travel-planner/web test:e2e` ✅
- `git diff --check` ✅

## Local lint note

- `pnpm lint` stalled locally at `eslint .` after printing the root lint banner for about 60 seconds, with no diagnostics.
- Targeted lint also stalled at `eslint apps/api/src/app.ts apps/api/src/routes/trips.ts apps/api/src/routes/trips.test.ts apps/api/src/services/tripService.ts apps/api/src/repositories/tripRepository.ts`, with no diagnostics.
- No tooling changes were made because this matches the known local ESLint stall pattern and there was no concrete Ticket 16 tooling bug.
- GitHub Actions should be used as the primary lint signal for this PR.

## Manual API checks run

- Started API with `pnpm dev:api` ✅
- `GET http://localhost:3001/api/health` returned HTTP 200 with `{ "status": "ok", "service": "japan-travel-planner-api" }` ✅
- Confirmed no web app behavior changed ✅
- Confirmed only Trip CRUD API routes were added; no AI, auth/session, maps, weather, or provider routes were added ✅
- Local PostgreSQL was not available, so manual DB-backed CRUD flow was not completed. A single `GET /api/trips` probe returned the safe structured 500 response from the existing error handler because the DB was unavailable.

## Known risks

- Real DB CRUD behavior still needs verification against a migrated PostgreSQL database when `DATABASE_URL` is available.
- Placeholder owner strategy is intentionally local and temporary; Ticket 17 should replace it with the MVP anonymous session strategy.
- `PATCH` replaces nested days when `days` is provided, rather than doing fine-grained activity diffing.
- Delete uses hard delete because the current Prisma schema has no archive/status field.

## Ticket boundary confirmation

Ticket 17 and later tickets were not started. This PR does not connect the web app to the API, add auth/session middleware, implement AI generation, add weather/maps/provider integrations, or modify Prisma/shared schemas.
