### PR TITLE
T-017: Add anonymous session ownership

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/japan_travel_planner_
 GOOGLE_MAPS_API_KEY=
 WEATHER_API_KEY=
 RAKUTEN_API_KEY=
-JWT_SECRET=
+# Signs the HTTP-only anonymous session cookie used for private trip editing.
+JWT_SECRET=replace-with-a-long-random-session-secret
 WEB_ORIGIN=http://localhost:5173
 API_PORT=3001

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,30 +1,38 @@
 import cors from "cors";
-import express from "express";
+import express, { type RequestHandler } from "express";
 
 import { loadApiEnv, type ApiEnvConfig } from "./config/env.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { createSessionMiddleware } from "./middleware/session.js";
 import { healthRouter } from "./routes/health.js";
 import { createTripsRouter } from "./routes/trips.js";
 import { createTripService, type TripService } from "./services/tripService.js";
 
 export type CreateAppOptions = {
   env?: ApiEnvConfig;
+  sessionMiddleware?: RequestHandler;
   tripService?: TripService;
 };
 
 export function createApp(options: CreateAppOptions = {}) {
   const env = options.env ?? loadApiEnv();
+  const sessionMiddleware =
+    options.sessionMiddleware ??
+    createSessionMiddleware({
+      secret: env.jwtSecret
+    });
   const tripService = options.tripService ?? createTripService();
   const app = express();
 
   app.use(
     cors({
+      credentials: true,
       origin: env.webOrigin
     })
   );
   app.use(express.json());
   app.use("/api/health", healthRouter);
-  app.use("/api/trips", createTripsRouter(tripService));
+  app.use("/api/trips", sessionMiddleware, createTripsRouter(tripService));
   app.use(errorHandler);
 
   return app;

--- a/apps/api/src/auth/sessionCookie.ts
+++ b/apps/api/src/auth/sessionCookie.ts
@@ -1,0 +1,106 @@
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+export const anonymousSessionCookieName = "jtp_session";
+export const anonymousSessionCookieMaxAgeSeconds = 60 * 60 * 24 * 180;
+
+// MVP ownership uses an opaque anonymous session ID signed into an HTTP-only cookie.
+// Public share links should use separate read-only tokens instead of this edit session.
+export type AnonymousSessionCookieOptions = {
+  cookieName?: string;
+  maxAgeSeconds?: number;
+  sameSite?: "Lax" | "Strict" | "None";
+  secure?: boolean;
+};
+
+export function createAnonymousSessionId() {
+  return randomUUID();
+}
+
+function signSessionId(sessionId: string, secret: string) {
+  return createHmac("sha256", secret).update(sessionId).digest("base64url");
+}
+
+export function createSignedSessionValue(sessionId: string, secret: string) {
+  return `${sessionId}.${signSessionId(sessionId, secret)}`;
+}
+
+export function verifySignedSessionValue(value: string, secret: string) {
+  const separatorIndex = value.lastIndexOf(".");
+
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+    return null;
+  }
+
+  const sessionId = value.slice(0, separatorIndex);
+  const signature = value.slice(separatorIndex + 1);
+  const expectedSignature = signSessionId(sessionId, secret);
+  const signatureBuffer = Buffer.from(signature);
+  const expectedSignatureBuffer = Buffer.from(expectedSignature);
+
+  if (signatureBuffer.length !== expectedSignatureBuffer.length) {
+    return null;
+  }
+
+  if (!timingSafeEqual(signatureBuffer, expectedSignatureBuffer)) {
+    return null;
+  }
+
+  return sessionId;
+}
+
+export function readCookie(
+  cookieHeader: string | undefined,
+  cookieName = anonymousSessionCookieName
+) {
+  if (cookieHeader === undefined) {
+    return undefined;
+  }
+
+  for (const cookie of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = cookie.trim().split("=");
+
+    if (rawName === cookieName) {
+      return rawValueParts.join("=");
+    }
+  }
+
+  return undefined;
+}
+
+export function readSignedSessionCookie(
+  cookieHeader: string | undefined,
+  secret: string,
+  cookieName = anonymousSessionCookieName
+) {
+  const signedValue = readCookie(cookieHeader, cookieName);
+
+  if (signedValue === undefined) {
+    return null;
+  }
+
+  return verifySignedSessionValue(signedValue, secret);
+}
+
+export function serializeSignedSessionCookie(
+  sessionId: string,
+  secret: string,
+  options: AnonymousSessionCookieOptions = {}
+) {
+  const cookieName = options.cookieName ?? anonymousSessionCookieName;
+  const maxAgeSeconds =
+    options.maxAgeSeconds ?? anonymousSessionCookieMaxAgeSeconds;
+  const sameSite = options.sameSite ?? "Lax";
+  const attributes = [
+    `${cookieName}=${createSignedSessionValue(sessionId, secret)}`,
+    "Path=/",
+    `Max-Age=${maxAgeSeconds}`,
+    "HttpOnly",
+    `SameSite=${sameSite}`
+  ];
+
+  if (options.secure === true) {
+    attributes.push("Secure");
+  }
+
+  return attributes.join("; ");
+}

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -11,11 +11,13 @@ describe("loadApiEnv", () => {
     expect(
       loadApiEnv({
         API_PORT: "4001",
-        WEB_ORIGIN: "https://planner.example.com"
+        WEB_ORIGIN: "https://planner.example.com",
+        JWT_SECRET: "test-session-secret-value"
       })
     ).toEqual({
       apiPort: 4001,
-      webOrigin: "https://planner.example.com"
+      webOrigin: "https://planner.example.com",
+      jwtSecret: "test-session-secret-value"
     });
   });
 
@@ -35,5 +37,21 @@ describe("loadApiEnv", () => {
         WEB_ORIGIN: "localhost:5173"
       })
     ).toThrow("Invalid WEB_ORIGIN");
+  });
+
+  test("fails clearly for too-short JWT_SECRET", () => {
+    expect(() =>
+      loadApiEnv({
+        JWT_SECRET: "short"
+      })
+    ).toThrow("Invalid JWT_SECRET");
+  });
+
+  test("fails clearly when JWT_SECRET is missing in production", () => {
+    expect(() =>
+      loadApiEnv({
+        NODE_ENV: "production"
+      })
+    ).toThrow("Invalid JWT_SECRET");
   });
 });

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,16 +1,22 @@
 export type ApiEnvConfig = {
   apiPort: number;
   webOrigin: string;
+  jwtSecret: string;
 };
+
+const localDevelopmentJwtSecret = "local-development-session-secret-change-me";
 
 export const defaultApiEnv = {
   apiPort: 3001,
-  webOrigin: "http://localhost:5173"
+  webOrigin: "http://localhost:5173",
+  jwtSecret: localDevelopmentJwtSecret
 } satisfies ApiEnvConfig;
 
 type ApiEnvSource = {
   API_PORT?: string | undefined;
   WEB_ORIGIN?: string | undefined;
+  JWT_SECRET?: string | undefined;
+  NODE_ENV?: string | undefined;
 };
 
 function parseApiPort(value: string | undefined) {
@@ -49,9 +55,31 @@ function parseWebOrigin(value: string | undefined) {
   }
 }
 
+function parseJwtSecret(
+  value: string | undefined,
+  nodeEnv: string | undefined
+) {
+  const rawSecret = value?.trim();
+
+  if (rawSecret !== undefined && rawSecret.length > 0) {
+    if (rawSecret.length < 16) {
+      throw new Error("Invalid JWT_SECRET: expected at least 16 characters.");
+    }
+
+    return rawSecret;
+  }
+
+  if (nodeEnv === "production") {
+    throw new Error("Invalid JWT_SECRET: required when NODE_ENV=production.");
+  }
+
+  return defaultApiEnv.jwtSecret;
+}
+
 export function loadApiEnv(env: ApiEnvSource = process.env): ApiEnvConfig {
   return {
     apiPort: parseApiPort(env.API_PORT),
-    webOrigin: parseWebOrigin(env.WEB_ORIGIN)
+    webOrigin: parseWebOrigin(env.WEB_ORIGIN),
+    jwtSecret: parseJwtSecret(env.JWT_SECRET, env.NODE_ENV)
   };
 }

--- a/apps/api/src/middleware/session.ts
+++ b/apps/api/src/middleware/session.ts
@@ -1,0 +1,76 @@
+import type { Request, RequestHandler } from "express";
+
+import {
+  createAnonymousSessionId,
+  readSignedSessionCookie,
+  serializeSignedSessionCookie,
+  type AnonymousSessionCookieOptions
+} from "../auth/sessionCookie.js";
+import { ApiError } from "../errors/ApiError.js";
+
+export type AnonymousSession = {
+  id: string;
+  isNew: boolean;
+};
+
+type AnonymousSessionRequest = Request & {
+  anonymousSession?: AnonymousSession;
+};
+
+export type SessionMiddlewareOptions = AnonymousSessionCookieOptions & {
+  secret: string;
+};
+
+export function createSessionMiddleware(
+  options: SessionMiddlewareOptions
+): RequestHandler {
+  const secret = options.secret.trim();
+
+  if (secret.length === 0) {
+    throw new Error("Anonymous session secret is required.");
+  }
+
+  return (request, response, next) => {
+    const sessionRequest = request as AnonymousSessionRequest;
+    const sessionId = readSignedSessionCookie(
+      request.headers.cookie,
+      secret,
+      options.cookieName
+    );
+
+    if (sessionId !== null) {
+      sessionRequest.anonymousSession = {
+        id: sessionId,
+        isNew: false
+      };
+      next();
+      return;
+    }
+
+    const newSessionId = createAnonymousSessionId();
+
+    sessionRequest.anonymousSession = {
+      id: newSessionId,
+      isNew: true
+    };
+    response.setHeader(
+      "Set-Cookie",
+      serializeSignedSessionCookie(newSessionId, secret, options)
+    );
+    next();
+  };
+}
+
+export function requireAnonymousSession(request: Request) {
+  const sessionRequest = request as AnonymousSessionRequest;
+
+  if (sessionRequest.anonymousSession === undefined) {
+    throw new ApiError({
+      statusCode: 500,
+      code: "SESSION_UNAVAILABLE",
+      message: "Anonymous session was not initialized."
+    });
+  }
+
+  return sessionRequest.anonymousSession;
+}

--- a/apps/api/src/routes/trips.test.ts
+++ b/apps/api/src/routes/trips.test.ts
@@ -1,9 +1,10 @@
-import request from "supertest";
+import request, { type Response } from "supertest";
 import { describe, expect, test } from "vitest";
 
 import { apiErrorSchema } from "../../../../packages/shared/src/schemas/apiError.js";
 
 import { createApp } from "../app.js";
+import { anonymousSessionCookieName } from "../auth/sessionCookie.js";
 import { defaultApiEnv } from "../config/env.js";
 import type {
   CreateTripInput,
@@ -56,16 +57,55 @@ const validCreateTripPayload = {
   ]
 } satisfies CreateTripInput;
 
+function getSetCookieHeaders(response: Response) {
+  const setCookie = response.headers["set-cookie"];
+
+  if (Array.isArray(setCookie)) {
+    return setCookie;
+  }
+
+  if (typeof setCookie === "string") {
+    return [setCookie];
+  }
+
+  return [];
+}
+
+function expectAnonymousSessionCookie(response: Response) {
+  const sessionCookie = getSetCookieHeaders(response).find((cookie) =>
+    cookie.startsWith(`${anonymousSessionCookieName}=`)
+  );
+
+  expect(sessionCookie).toBeDefined();
+  expect(sessionCookie).toContain("HttpOnly");
+  expect(sessionCookie).toContain("SameSite=Lax");
+
+  return sessionCookie;
+}
+
 class InMemoryTripRepository implements TripRepository {
-  private readonly owner: TripOwner = { id: "test-owner" };
+  private readonly owners = new Map<string, TripOwner>();
   private readonly tripOwners = new Map<string, string>();
   private readonly trips = new Map<string, TripResponse>();
+  private nextOwnerId = 1;
   private nextTripId = 1;
   private nextDayId = 1;
   private nextActivityId = 1;
 
-  async findOrCreateOwner() {
-    return this.owner;
+  async findOrCreateOwner(anonymousSessionId: string) {
+    const existingOwner = this.owners.get(anonymousSessionId);
+
+    if (existingOwner !== undefined) {
+      return existingOwner;
+    }
+
+    const owner = {
+      id: `owner-${this.nextOwnerId++}`
+    };
+
+    this.owners.set(anonymousSessionId, owner);
+
+    return owner;
   }
 
   async listTrips(ownerId: string) {
@@ -169,7 +209,7 @@ function expectSharedErrorResponse(responseBody: unknown) {
 }
 
 describe("Trip CRUD API", () => {
-  test("GET /api/trips lists trips for the placeholder owner", async () => {
+  test("GET /api/trips lists trips for the current anonymous session", async () => {
     const app = createTripsTestApp();
 
     const response = await request(app).get("/api/trips");
@@ -178,6 +218,71 @@ describe("Trip CRUD API", () => {
     expect(response.body).toEqual({
       trips: []
     });
+  });
+
+  test("POST /api/trips without a session creates an HTTP-only anonymous session cookie", async () => {
+    const app = createTripsTestApp();
+
+    const response = await request(app)
+      .post("/api/trips")
+      .send(validCreateTripPayload);
+
+    expect(response.status).toBe(201);
+    expectAnonymousSessionCookie(response);
+  });
+
+  test("subsequent requests with the same cookie reuse the same owner session", async () => {
+    const app = createTripsTestApp();
+    const traveler = request.agent(app);
+
+    const createResponse = await traveler
+      .post("/api/trips")
+      .send(validCreateTripPayload);
+    const listResponse = await traveler.get("/api/trips");
+
+    expect(createResponse.status).toBe(201);
+    expectAnonymousSessionCookie(createResponse);
+    expect(listResponse.status).toBe(200);
+    expect(getSetCookieHeaders(listResponse)).toEqual([]);
+    expect(listResponse.body.trips).toEqual([
+      expect.objectContaining({
+        id: createResponse.body.trip.id,
+        title: validCreateTripPayload.title
+      })
+    ]);
+  });
+
+  test("GET /api/trips only lists trips for the current anonymous session", async () => {
+    const app = createTripsTestApp();
+    const travelerA = request.agent(app);
+    const travelerB = request.agent(app);
+
+    const createAResponse = await travelerA
+      .post("/api/trips")
+      .send(validCreateTripPayload);
+    const createBResponse = await travelerB.post("/api/trips").send({
+      ...validCreateTripPayload,
+      title: "Kyoto Garden Weekend",
+      cities: ["Kyoto"]
+    });
+
+    const listAResponse = await travelerA.get("/api/trips");
+    const listBResponse = await travelerB.get("/api/trips");
+
+    expect(createAResponse.status).toBe(201);
+    expect(createBResponse.status).toBe(201);
+    expect(listAResponse.body.trips).toEqual([
+      expect.objectContaining({
+        id: createAResponse.body.trip.id,
+        title: validCreateTripPayload.title
+      })
+    ]);
+    expect(listBResponse.body.trips).toEqual([
+      expect.objectContaining({
+        id: createBResponse.body.trip.id,
+        title: "Kyoto Garden Weekend"
+      })
+    ]);
   });
 
   test("POST /api/trips creates a trip with structured itinerary data", async () => {
@@ -242,11 +347,12 @@ describe("Trip CRUD API", () => {
 
   test("GET /api/trips/:tripId returns a trip", async () => {
     const app = createTripsTestApp();
-    const createResponse = await request(app)
+    const traveler = request.agent(app);
+    const createResponse = await traveler
       .post("/api/trips")
       .send(validCreateTripPayload);
 
-    const response = await request(app).get(
+    const response = await traveler.get(
       `/api/trips/${createResponse.body.trip.id}`
     );
 
@@ -274,11 +380,12 @@ describe("Trip CRUD API", () => {
 
   test("PATCH /api/trips/:tripId updates editable trip data", async () => {
     const app = createTripsTestApp();
-    const createResponse = await request(app)
+    const traveler = request.agent(app);
+    const createResponse = await traveler
       .post("/api/trips")
       .send(validCreateTripPayload);
 
-    const response = await request(app)
+    const response = await traveler
       .patch(`/api/trips/${createResponse.body.trip.id}`)
       .send({
         title: "Updated Spring Trip",
@@ -295,19 +402,45 @@ describe("Trip CRUD API", () => {
 
   test("DELETE /api/trips/:tripId hard-deletes a trip", async () => {
     const app = createTripsTestApp();
-    const createResponse = await request(app)
+    const traveler = request.agent(app);
+    const createResponse = await traveler
       .post("/api/trips")
       .send(validCreateTripPayload);
 
-    const deleteResponse = await request(app).delete(
+    const deleteResponse = await traveler.delete(
       `/api/trips/${createResponse.body.trip.id}`
     );
-    const getResponse = await request(app).get(
+    const getResponse = await traveler.get(
       `/api/trips/${createResponse.body.trip.id}`
     );
 
     expect(deleteResponse.status).toBe(204);
     expect(getResponse.status).toBe(404);
+  });
+
+  test("GET/PATCH/DELETE cannot access another anonymous session's trip", async () => {
+    const app = createTripsTestApp();
+    const owner = request.agent(app);
+    const otherTraveler = request.agent(app);
+    const createResponse = await owner
+      .post("/api/trips")
+      .send(validCreateTripPayload);
+    const tripId = createResponse.body.trip.id;
+
+    const getResponse = await otherTraveler.get(`/api/trips/${tripId}`);
+    const patchResponse = await otherTraveler
+      .patch(`/api/trips/${tripId}`)
+      .send({
+        title: "Cross-owner edit attempt"
+      });
+    const deleteResponse = await otherTraveler.delete(`/api/trips/${tripId}`);
+    const ownerGetResponse = await owner.get(`/api/trips/${tripId}`);
+
+    expect(getResponse.status).toBe(404);
+    expect(patchResponse.status).toBe(404);
+    expect(deleteResponse.status).toBe(404);
+    expect(ownerGetResponse.status).toBe(200);
+    expect(ownerGetResponse.body.trip.title).toBe(validCreateTripPayload.title);
   });
 
   test("GET /api/health still returns HTTP 200", async () => {
@@ -320,5 +453,6 @@ describe("Trip CRUD API", () => {
       status: "ok",
       service: "japan-travel-planner-api"
     });
+    expect(getSetCookieHeaders(response)).toEqual([]);
   });
 });

--- a/apps/api/src/routes/trips.ts
+++ b/apps/api/src/routes/trips.ts
@@ -2,6 +2,7 @@ import { Router, type RequestHandler } from "express";
 import { z } from "zod";
 
 import { ApiError } from "../errors/ApiError.js";
+import { requireAnonymousSession } from "../middleware/session.js";
 import { validateRequest } from "../middleware/validateRequest.js";
 import type {
   CreateTripInput,
@@ -145,8 +146,9 @@ export function createTripsRouter(tripService: TripService) {
 
   router.get(
     "/",
-    asyncHandler(async (_request, response) => {
-      const trips = await tripService.listTrips();
+    asyncHandler(async (request, response) => {
+      const session = requireAnonymousSession(request);
+      const trips = await tripService.listTrips(session.id);
 
       response.status(200).json({ trips });
     })
@@ -156,7 +158,9 @@ export function createTripsRouter(tripService: TripService) {
     "/",
     validateRequest(tripCreateBodySchema),
     asyncHandler(async (request, response) => {
+      const session = requireAnonymousSession(request);
       const trip = await tripService.createTrip(
+        session.id,
         request.body as CreateTripInput
       );
 
@@ -167,7 +171,11 @@ export function createTripsRouter(tripService: TripService) {
   router.get(
     "/:tripId",
     asyncHandler(async (request, response) => {
-      const trip = await tripService.getTrip(getTripId(request.params.tripId));
+      const session = requireAnonymousSession(request);
+      const trip = await tripService.getTrip(
+        session.id,
+        getTripId(request.params.tripId)
+      );
 
       response.status(200).json({ trip });
     })
@@ -177,7 +185,9 @@ export function createTripsRouter(tripService: TripService) {
     "/:tripId",
     validateRequest(tripUpdateBodySchema),
     asyncHandler(async (request, response) => {
+      const session = requireAnonymousSession(request);
       const trip = await tripService.updateTrip(
+        session.id,
         getTripId(request.params.tripId),
         request.body as UpdateTripInput
       );
@@ -189,7 +199,12 @@ export function createTripsRouter(tripService: TripService) {
   router.delete(
     "/:tripId",
     asyncHandler(async (request, response) => {
-      await tripService.deleteTrip(getTripId(request.params.tripId));
+      const session = requireAnonymousSession(request);
+
+      await tripService.deleteTrip(
+        session.id,
+        getTripId(request.params.tripId)
+      );
 
       response.status(204).send();
     })

--- a/apps/api/src/services/tripService.ts
+++ b/apps/api/src/services/tripService.ts
@@ -6,33 +6,29 @@ import {
   type UpdateTripInput
 } from "../repositories/tripRepository.js";
 
-export const localAnonymousSessionId = "local-anonymous-traveler";
-
 export class TripService {
-  constructor(
-    private readonly repository: TripRepository,
-    private readonly anonymousSessionId = localAnonymousSessionId
-  ) {}
+  constructor(private readonly repository: TripRepository) {}
 
-  private async getOwnerId() {
-    const owner = await this.repository.findOrCreateOwner(
-      this.anonymousSessionId
-    );
+  private async getOwnerId(anonymousSessionId: string) {
+    const owner = await this.repository.findOrCreateOwner(anonymousSessionId);
 
     return owner.id;
   }
 
-  async listTrips() {
-    return this.repository.listTrips(await this.getOwnerId());
+  async listTrips(anonymousSessionId: string) {
+    return this.repository.listTrips(await this.getOwnerId(anonymousSessionId));
   }
 
-  async createTrip(input: CreateTripInput) {
-    return this.repository.createTrip(await this.getOwnerId(), input);
+  async createTrip(anonymousSessionId: string, input: CreateTripInput) {
+    return this.repository.createTrip(
+      await this.getOwnerId(anonymousSessionId),
+      input
+    );
   }
 
-  async getTrip(tripId: string) {
+  async getTrip(anonymousSessionId: string, tripId: string) {
     const trip = await this.repository.findTrip(
-      await this.getOwnerId(),
+      await this.getOwnerId(anonymousSessionId),
       tripId
     );
 
@@ -47,9 +43,13 @@ export class TripService {
     return trip;
   }
 
-  async updateTrip(tripId: string, input: UpdateTripInput) {
+  async updateTrip(
+    anonymousSessionId: string,
+    tripId: string,
+    input: UpdateTripInput
+  ) {
     const trip = await this.repository.updateTrip(
-      await this.getOwnerId(),
+      await this.getOwnerId(anonymousSessionId),
       tripId,
       input
     );
@@ -65,9 +65,9 @@ export class TripService {
     return trip;
   }
 
-  async deleteTrip(tripId: string) {
+  async deleteTrip(anonymousSessionId: string, tripId: string) {
     const deleted = await this.repository.deleteTrip(
-      await this.getOwnerId(),
+      await this.getOwnerId(anonymousSessionId),
       tripId
     );
 


### PR DESCRIPTION
## Ticket scope

Implement T-017 / Ticket 17: MVP anonymous session ownership for API trip CRUD. This keeps trips tied to an anonymous owner/session without adding full accounts, login, OAuth, magic links, AI generation, provider integrations, or web API wiring.

## Changes made

- Added signed anonymous session cookie helpers under `apps/api/src/auth/sessionCookie.ts`.
- Added trip-route session middleware under `apps/api/src/middleware/session.ts`.
- Mounted session middleware only for `/api/trips`, leaving `/api/health` public.
- Updated trip routes and service methods to resolve ownership from the current anonymous session instead of the old placeholder owner.
- Enabled CORS credentials for future cookie-based web requests.
- Documented the session secret in `.env.example`.

## Auth/session strategy

- The API uses an opaque anonymous session ID signed with `JWT_SECRET` and stored in an HTTP-only cookie named `jtp_session`.
- Missing or invalid trip-route cookies create a new anonymous session cookie.
- Valid cookies are reused and map to the existing `User.anonymousSessionId` owner through the repository.
- Public share links remain separate from private edit-session ownership.

## Env validation approach

- `JWT_SECRET` is parsed through API env config.
- Local development uses a clearly named default secret if `JWT_SECRET` is not provided.
- Too-short secrets fail clearly.
- Missing `JWT_SECRET` fails clearly when `NODE_ENV=production`.

## Ownership enforcement

- Trip CRUD routes require the anonymous session middleware.
- The service now passes the session ID into `findOrCreateOwner` for every trip operation.
- The existing repository owner filters continue to scope list/get/patch/delete by owner ID.
- Cross-owner private trip access returns the existing structured 404 response.

## Tests added/updated

- Added tests for first request creating an HTTP-only session cookie.
- Added tests for subsequent same-cookie requests reusing the same owner/session.
- Added tests that trip lists are scoped to the current anonymous session.
- Added tests that GET/PATCH/DELETE cannot access another session's trip.
- Updated CRUD regression tests to use a persistent Supertest agent when reopening the same trip.
- Added env tests for explicit, too-short, and production-missing `JWT_SECRET` behavior.
- Confirmed health remains public and does not set a session cookie.

## Checks run

- `pnpm install`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec tsc --noEmit`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `pnpm exec prettier --check apps/api/src/auth/sessionCookie.ts apps/api/src/middleware/session.ts apps/api/src/config/env.ts apps/api/src/config/env.test.ts apps/api/src/app.ts apps/api/src/routes/trips.ts apps/api/src/routes/trips.test.ts apps/api/src/services/tripService.ts`
- `git diff --check`

## Manual API checks run

- Started API with `pnpm dev:api` and confirmed it listens on `http://localhost:3001`.
- Curled `http://localhost:3001/api/health` and confirmed HTTP 200 with `{ "status": "ok", "service": "japan-travel-planner-api" }`.
- Confirmed health did not set a session cookie.
- Confirmed production startup without `JWT_SECRET` fails clearly with `Invalid JWT_SECRET: required when NODE_ENV=production.`
- Local Postgres was not available on `localhost:5432`, so DB-backed manual trip CRUD was not claimed; trip ownership behavior is covered by injected in-memory Supertest tests.

## Known risks

- Local `pnpm lint` stalled at `eslint .` after 90 seconds with no diagnostics; a targeted ESLint run on touched files also stalled, so no tooling changes were made in this Ticket 17 PR.
- Cookie `Secure` is not enabled by default for local development; production deployment should decide secure-cookie behavior when HTTPS/proxy settings are finalized.

## Ticket 18+ confirmation

Ticket 18 and later tickets were not started. This PR does not connect the web app to the API, add AI generation, add provider integrations, add auth accounts/login, change shared schemas, or modify the web app behavior.
