### PR TITLE
T-018: Connect web app to trip API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ RAKUTEN_API_KEY=
 JWT_SECRET=replace-with-a-long-random-session-secret
 WEB_ORIGIN=http://localhost:5173
 API_PORT=3001
+VITE_API_BASE_URL=http://localhost:3001
+VITE_TRIP_DATA_MODE=api

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     trace: "on-first-retry"
   },
   webServer: {
-    command: "pnpm dev",
+    command: "VITE_TRIP_DATA_MODE=mock pnpm dev",
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
     url: "http://127.0.0.1:5173"

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -217,6 +217,11 @@ select {
   align-items: start;
 }
 
+.planner-sidebar-panel {
+  display: grid;
+  gap: 16px;
+}
+
 .trip-intake-form {
   display: grid;
   gap: 22px;
@@ -297,9 +302,18 @@ select {
   line-height: 1.35;
 }
 
-.trip-intake-submit {
+.trip-intake-actions {
+  display: grid;
+  gap: 10px;
+}
+
+.trip-intake-submit,
+.trip-intake-secondary,
+.trip-reopen-button,
+.storage-actions button,
+.mode-toggle button {
   width: 100%;
-  border: 0;
+  border: 1px solid #0d3b4f;
   border-radius: 6px;
   background: #0d3b4f;
   color: #ffffff;
@@ -308,9 +322,88 @@ select {
   padding: 12px 16px;
 }
 
-.trip-intake-submit:disabled {
+.trip-intake-secondary,
+.storage-actions button,
+.mode-toggle button {
+  background: #ffffff;
+  color: #0d3b4f;
+}
+
+.mode-toggle button[aria-pressed="true"] {
+  background: #0d3b4f;
+  color: #ffffff;
+}
+
+.trip-intake-submit:disabled,
+.trip-intake-secondary:disabled,
+.trip-reopen-button:disabled,
+.storage-actions button:disabled,
+.mode-toggle button:disabled {
   cursor: wait;
   opacity: 0.72;
+}
+
+.trip-storage-panel {
+  display: grid;
+  gap: 16px;
+  border: 1px solid #d8e0e6;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 24px;
+}
+
+.trip-storage-panel h2 {
+  margin: 10px 0 0;
+  color: #172026;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.mode-toggle,
+.storage-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.storage-status,
+.storage-error {
+  margin: 0;
+  border-radius: 6px;
+  font-size: 0.88rem;
+  font-weight: 800;
+  line-height: 1.4;
+  padding: 10px 12px;
+}
+
+.storage-status {
+  background: #edf4f6;
+  color: #0d3b4f;
+}
+
+.storage-error {
+  border: 1px solid #efb6ae;
+  background: #fff1ef;
+  color: #9d3027;
+}
+
+.saved-trip-select {
+  display: grid;
+  gap: 7px;
+  color: #172026;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.saved-trip-select select {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid #cfd9df;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #172026;
+  padding: 10px 11px;
 }
 
 .itinerary-view {
@@ -742,8 +835,11 @@ select {
 
   .activity-card-actions,
   .activity-editor-actions,
-  .reorder-controls {
+  .mode-toggle,
+  .reorder-controls,
+  .storage-actions {
     display: grid;
+    grid-template-columns: 1fr;
   }
 
   .activity-editor-backdrop {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -10,8 +10,11 @@ describe("App", () => {
     expect(html).toContain("Japan Travel Planner");
     expect(html).toContain("Japan trip planner");
     expect(html).toContain("Plan your Japan route");
-    expect(html).toContain("Generate mock itinerary");
+    expect(html).toContain("Create saved itinerary");
+    expect(html).toContain("Use mock preview");
+    expect(html).toContain("Save and reopen");
+    expect(html).toContain("Refresh saved trips");
     expect(html).toContain("No itinerary yet");
-    expect(html).toContain("Input");
+    expect(html).toContain("API");
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,22 +2,49 @@ import "./App.css";
 
 import { useState } from "react";
 
+import type { TripRequest } from "../../../packages/shared/src/schemas/tripRequest.js";
 import { ItineraryView } from "./features/itinerary/ItineraryView.js";
 import {
   cloneItinerary,
   useItineraryEditor
 } from "./features/itinerary/editing/useItineraryEditor.js";
 import { TripIntakeForm } from "./features/trip-intake/index.js";
+import {
+  getDefaultTripDataMode,
+  useTrips,
+  type TripDataMode
+} from "./features/trips/useTrips.js";
 import { mockItinerary } from "./mocks/index.js";
 
 const navigationItems = ["Planner", "Trips", "Account"];
 
 const mockSubmitDelayMs = 500;
 
+function isApiBusy(status: ReturnType<typeof useTrips>["status"]) {
+  return (
+    status === "creating" ||
+    status === "loading" ||
+    status === "reopening" ||
+    status === "saving"
+  );
+}
+
 export function App() {
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [activeRequest, setActiveRequest] = useState<TripRequest | null>(null);
+  const [dataMode, setDataMode] = useState<TripDataMode>(
+    getDefaultTripDataMode
+  );
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [isMockSubmitting, setIsMockSubmitting] = useState(false);
   const itineraryEditor = useItineraryEditor(null);
   const itinerary = itineraryEditor.itinerary;
+  const trips = useTrips();
+  const apiBusy = isApiBusy(trips.status);
+  const isSubmitting =
+    isMockSubmitting ||
+    trips.status === "creating" ||
+    trips.status === "saving";
+  const storageMessage = localError ?? trips.errorMessage;
 
   const workspacePanels = [
     {
@@ -35,20 +62,107 @@ export function App() {
       detail: "Daily activities, timing, locations, cost levels, and notes"
     },
     {
-      title: "Travel context",
-      status: "Mock context",
-      detail: "Map links, weather, and local context"
+      title: "Trip storage",
+      status:
+        dataMode === "mock"
+          ? "Mock mode"
+          : trips.status === "saved"
+            ? "Saved"
+            : "API ready",
+      detail: "Anonymous session cookies, saved trips, and reopen controls"
     }
   ];
 
-  function handleMockSubmit() {
-    setIsSubmitting(true);
+  function resetToItinerary(nextItinerary: typeof itinerary) {
+    itineraryEditor.resetItinerary(
+      nextItinerary ? cloneItinerary(nextItinerary) : null
+    );
+  }
+
+  function handleMockSubmit(request: TripRequest) {
+    setActiveRequest(request);
+    setLocalError(null);
+    trips.clearError();
+    setIsMockSubmitting(true);
     itineraryEditor.resetItinerary(null);
 
     setTimeout(() => {
-      itineraryEditor.resetItinerary(cloneItinerary(mockItinerary));
-      setIsSubmitting(false);
+      resetToItinerary(mockItinerary);
+      setIsMockSubmitting(false);
     }, mockSubmitDelayMs);
+  }
+
+  async function handleTripSubmit(request: TripRequest) {
+    if (dataMode === "mock") {
+      handleMockSubmit(request);
+      return;
+    }
+
+    setActiveRequest(request);
+    setLocalError(null);
+    resetToItinerary(null);
+
+    const result = await trips.createTripFromRequest(
+      request,
+      cloneItinerary(mockItinerary)
+    );
+
+    if (result) {
+      setActiveRequest(result.request);
+      resetToItinerary(result.itinerary);
+    }
+  }
+
+  async function handleSaveItinerary() {
+    if (!itinerary) {
+      setLocalError("Create or reopen an itinerary before saving.");
+      return;
+    }
+
+    if (!activeRequest) {
+      setLocalError("Trip request details are required before saving.");
+      return;
+    }
+
+    setLocalError(null);
+
+    const result = await trips.saveTrip(
+      trips.selectedTripId,
+      activeRequest,
+      itinerary
+    );
+
+    if (result) {
+      setActiveRequest(result.request);
+      resetToItinerary(result.itinerary);
+    }
+  }
+
+  async function handleReopenTrip() {
+    if (!trips.selectedTripId) {
+      setLocalError("Select a saved trip to reopen.");
+      return;
+    }
+
+    setLocalError(null);
+
+    const result = await trips.reopenTrip(trips.selectedTripId);
+
+    if (result) {
+      setActiveRequest(result.request);
+      resetToItinerary(result.itinerary);
+    }
+  }
+
+  async function handleLoadSavedTrips() {
+    setLocalError(null);
+    await trips.loadSavedTrips();
+  }
+
+  function handleModeChange(nextMode: TripDataMode) {
+    setDataMode(nextMode);
+    setLocalError(null);
+    trips.clearError();
   }
 
   return (
@@ -84,7 +198,7 @@ export function App() {
             <h1 id="workspace-title">Japan trip planner</h1>
             <p className="workspace-state">
               Build a request from dates, cities, interests, pace, budget, and
-              constraints before previewing a structured mock itinerary.
+              constraints before saving or previewing a structured itinerary.
             </p>
           </div>
 
@@ -99,15 +213,7 @@ export function App() {
             </div>
             <div>
               <dt>Mode</dt>
-              <dd>
-                {isSubmitting
-                  ? "Loading"
-                  : itineraryEditor.isDirty
-                    ? "Editing"
-                    : itinerary
-                      ? "Preview"
-                      : "Input"}
-              </dd>
+              <dd>{dataMode === "api" ? "API" : "Mock"}</dd>
             </div>
           </dl>
         </section>
@@ -123,10 +229,115 @@ export function App() {
         </section>
 
         <section className="planner-workspace" aria-label="Trip planner">
-          <TripIntakeForm
-            isSubmitting={isSubmitting}
-            onMockSubmit={handleMockSubmit}
-          />
+          <div className="planner-sidebar-panel">
+            <TripIntakeForm
+              isSubmitting={isSubmitting}
+              onSubmitTrip={handleTripSubmit}
+              submitLabel={
+                dataMode === "api"
+                  ? "Create saved itinerary"
+                  : "Generate mock itinerary"
+              }
+              {...(dataMode === "api"
+                ? {
+                    mockSubmitLabel: "Use mock preview",
+                    onMockSubmit: handleMockSubmit
+                  }
+                : {})}
+            />
+
+            <section
+              aria-labelledby="trip-storage-title"
+              className="trip-storage-panel"
+            >
+              <header>
+                <p className="section-kicker">Trip storage</p>
+                <h2 id="trip-storage-title">Save and reopen</h2>
+              </header>
+
+              <div className="mode-toggle" aria-label="Trip data mode">
+                <button
+                  aria-pressed={dataMode === "api"}
+                  onClick={() => handleModeChange("api")}
+                  type="button"
+                >
+                  API
+                </button>
+                <button
+                  aria-pressed={dataMode === "mock"}
+                  onClick={() => handleModeChange("mock")}
+                  type="button"
+                >
+                  Mock
+                </button>
+              </div>
+
+              <p className="storage-status" role="status">
+                {apiBusy
+                  ? "Working"
+                  : trips.status === "saved"
+                    ? "Saved"
+                    : itineraryEditor.isDirty
+                      ? "Local edits pending"
+                      : dataMode === "mock"
+                        ? "Mock mode"
+                        : "Ready"}
+              </p>
+
+              {storageMessage ? (
+                <p className="storage-error" role="alert">
+                  {storageMessage}
+                </p>
+              ) : null}
+
+              <div className="storage-actions">
+                <button
+                  disabled={dataMode === "mock" || apiBusy || !itinerary}
+                  onClick={handleSaveItinerary}
+                  type="button"
+                >
+                  Save itinerary
+                </button>
+                <button
+                  disabled={dataMode === "mock" || apiBusy}
+                  onClick={handleLoadSavedTrips}
+                  type="button"
+                >
+                  Refresh saved trips
+                </button>
+              </div>
+
+              <label className="saved-trip-select">
+                Saved trips
+                <select
+                  disabled={dataMode === "mock" || apiBusy}
+                  onChange={(event) =>
+                    trips.selectTrip(event.currentTarget.value || null)
+                  }
+                  value={trips.selectedTripId ?? ""}
+                >
+                  <option value="">Select a saved trip</option>
+                  {trips.savedTrips.map((trip) => (
+                    <option key={trip.id} value={trip.id}>
+                      {trip.title}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <button
+                className="trip-reopen-button"
+                disabled={
+                  dataMode === "mock" || apiBusy || !trips.selectedTripId
+                }
+                onClick={handleReopenTrip}
+                type="button"
+              >
+                Reopen trip
+              </button>
+            </section>
+          </div>
+
           <ItineraryView
             editing={{
               isDirty: itineraryEditor.isDirty,

--- a/apps/web/src/features/trip-intake/TripIntakeForm.tsx
+++ b/apps/web/src/features/trip-intake/TripIntakeForm.tsx
@@ -12,7 +12,10 @@ import {
 export type TripIntakeFormProps = {
   initialValues?: TripIntakeFormValues;
   isSubmitting?: boolean;
-  onMockSubmit: (request: TripRequest) => void;
+  mockSubmitLabel?: string;
+  onMockSubmit?: (request: TripRequest) => void;
+  onSubmitTrip: (request: TripRequest) => void;
+  submitLabel?: string;
 };
 
 const fieldIds = {
@@ -48,7 +51,10 @@ function FieldError({
 export function TripIntakeForm({
   initialValues = tripIntakeInitialValues,
   isSubmitting = false,
-  onMockSubmit
+  mockSubmitLabel,
+  onMockSubmit,
+  onSubmitTrip,
+  submitLabel = "Create saved itinerary"
 }: TripIntakeFormProps) {
   const [values, setValues] = useState<TripIntakeFormValues>(initialValues);
   const [errors, setErrors] = useState<TripIntakeErrors>({});
@@ -71,15 +77,18 @@ export function TripIntakeForm({
     }
   }
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-
+  function submitValidated(onSubmit: (request: TripRequest) => void) {
     const validation = validateTripIntake(values);
     setErrors(validation.errors);
 
     if (validation.success) {
-      onMockSubmit(validation.request);
+      onSubmit(validation.request);
     }
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    submitValidated(onSubmitTrip);
   }
 
   return (
@@ -93,8 +102,8 @@ export function TripIntakeForm({
         <p className="section-kicker">Trip setup</p>
         <h2 id="trip-intake-title">Plan your Japan route</h2>
         <p>
-          Set the travel frame, then preview the structured mock itinerary for
-          this MVP.
+          Set the travel frame, then create or preview the structured itinerary
+          for this MVP.
         </p>
       </header>
 
@@ -241,13 +250,25 @@ export function TripIntakeForm({
         </div>
       </div>
 
-      <button
-        className="trip-intake-submit"
-        disabled={isSubmitting}
-        type="submit"
-      >
-        {isSubmitting ? "Preparing preview" : "Generate mock itinerary"}
-      </button>
+      <div className="trip-intake-actions">
+        <button
+          className="trip-intake-submit"
+          disabled={isSubmitting}
+          type="submit"
+        >
+          {isSubmitting ? "Preparing itinerary" : submitLabel}
+        </button>
+        {onMockSubmit && mockSubmitLabel ? (
+          <button
+            className="trip-intake-secondary"
+            disabled={isSubmitting}
+            onClick={() => submitValidated(onMockSubmit)}
+            type="button"
+          >
+            {mockSubmitLabel}
+          </button>
+        ) : null}
+      </div>
     </form>
   );
 }

--- a/apps/web/src/features/trip-intake/tripIntakeForm.test.tsx
+++ b/apps/web/src/features/trip-intake/tripIntakeForm.test.tsx
@@ -14,7 +14,7 @@ import {
 describe("TripIntakeForm", () => {
   test("renders the required trip request fields", () => {
     const html = renderToString(
-      <TripIntakeForm onMockSubmit={() => undefined} />
+      <TripIntakeForm onSubmitTrip={() => undefined} />
     );
 
     expect(html).toContain("Start date");
@@ -24,6 +24,19 @@ describe("TripIntakeForm", () => {
     expect(html).toContain("Travel pace");
     expect(html).toContain("Budget");
     expect(html).toContain("Constraints");
+  });
+
+  test("renders an optional mock preview action", () => {
+    const html = renderToString(
+      <TripIntakeForm
+        mockSubmitLabel="Use mock preview"
+        onMockSubmit={() => undefined}
+        onSubmitTrip={() => undefined}
+      />
+    );
+
+    expect(html).toContain("Create saved itinerary");
+    expect(html).toContain("Use mock preview");
   });
 
   test("returns required field errors", () => {

--- a/apps/web/src/features/trips/useTrips.test.ts
+++ b/apps/web/src/features/trips/useTrips.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  TripApiClientError,
+  type TripApiClient
+} from "../../lib/api/client.js";
+import type { TripRecord } from "../../lib/api/types.js";
+import { mockItinerary, mockTripRequest } from "../../mocks/index.js";
+import {
+  createSavedTrip,
+  getTripErrorMessage,
+  reopenSavedTrip,
+  saveTrip
+} from "./useTrips.js";
+
+function createTripRecord(overrides: Partial<TripRecord> = {}): TripRecord {
+  return {
+    id: "trip-1",
+    title: mockItinerary.title,
+    startDate: mockTripRequest.startDate,
+    endDate: mockTripRequest.endDate,
+    cities: [...mockTripRequest.cities],
+    interests: [...mockTripRequest.interests],
+    pace: mockTripRequest.pace,
+    budget: mockTripRequest.budget,
+    constraints: [...mockTripRequest.constraints],
+    days: mockItinerary.days.map((day, dayIndex) => ({
+      id: `day-${dayIndex + 1}`,
+      ...day,
+      activities: day.activities.map((activity, activityIndex) => ({
+        ...activity,
+        id: activity.id ?? `activity-${activityIndex + 1}`
+      }))
+    })),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+function createMockClient(trip = createTripRecord()): TripApiClient {
+  return {
+    createTrip: vi.fn(async () => trip),
+    getTrip: vi.fn(async () => trip),
+    listTrips: vi.fn(async () => [trip]),
+    updateTrip: vi.fn(async () => trip)
+  };
+}
+
+describe("trip API workflow helpers", () => {
+  test("creates a saved trip from the current mock itinerary draft", async () => {
+    const trip = createTripRecord();
+    const client = createMockClient(trip);
+
+    const result = await createSavedTrip(
+      client,
+      mockTripRequest,
+      mockItinerary
+    );
+
+    expect(client.createTrip).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cities: mockTripRequest.cities,
+        title: mockItinerary.title
+      })
+    );
+    expect(result.trip).toEqual(trip);
+    expect(result.request).toEqual(mockTripRequest);
+    expect(result.itinerary).toMatchObject({
+      title: mockItinerary.title,
+      days: expect.arrayContaining([
+        expect.not.objectContaining({
+          id: expect.any(String)
+        })
+      ])
+    });
+  });
+
+  test("saves existing trips with PATCH-compatible update behavior", async () => {
+    const client = createMockClient();
+
+    await saveTrip(client, {
+      itinerary: mockItinerary,
+      request: mockTripRequest,
+      tripId: "trip-1"
+    });
+
+    expect(client.updateTrip).toHaveBeenCalledWith(
+      "trip-1",
+      expect.objectContaining({
+        title: mockItinerary.title
+      })
+    );
+    expect(client.createTrip).not.toHaveBeenCalled();
+  });
+
+  test("creates a trip when saving without a selected saved trip id", async () => {
+    const client = createMockClient();
+
+    await saveTrip(client, {
+      itinerary: mockItinerary,
+      request: mockTripRequest,
+      tripId: null
+    });
+
+    expect(client.createTrip).toHaveBeenCalledOnce();
+    expect(client.updateTrip).not.toHaveBeenCalled();
+  });
+
+  test("reopens saved trips through the API client", async () => {
+    const trip = createTripRecord({
+      title: "Reopened spring route"
+    });
+    const client = createMockClient(trip);
+
+    const result = await reopenSavedTrip(client, "trip-1");
+
+    expect(client.getTrip).toHaveBeenCalledWith("trip-1");
+    expect(result.itinerary.title).toBe("Reopened spring route");
+  });
+
+  test("formats API field errors for visible UI feedback", () => {
+    const message = getTripErrorMessage(
+      new TripApiClientError({
+        code: "VALIDATION_ERROR",
+        fieldErrors: [
+          {
+            message: "Title is required.",
+            path: "title"
+          }
+        ],
+        message: "Request validation failed.",
+        status: 400
+      })
+    );
+
+    expect(message).toBe(
+      "Request validation failed. title: Title is required."
+    );
+  });
+});

--- a/apps/web/src/features/trips/useTrips.ts
+++ b/apps/web/src/features/trips/useTrips.ts
@@ -1,0 +1,189 @@
+import { useMemo, useState } from "react";
+
+import type { Itinerary } from "../../../../../packages/shared/src/schemas/itinerary.js";
+import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
+import {
+  createTripApiClient,
+  TripApiClientError,
+  type TripApiClient
+} from "../../lib/api/client.js";
+import {
+  toTripWritePayload,
+  tripRecordToItinerary,
+  tripRecordToTripRequest,
+  type TripRecord
+} from "../../lib/api/types.js";
+
+export type TripDataMode = "api" | "mock";
+
+export type TripOperationStatus =
+  | "creating"
+  | "error"
+  | "idle"
+  | "loading"
+  | "reopening"
+  | "saved"
+  | "saving";
+
+export type TripOperationResult = {
+  itinerary: Itinerary;
+  request: TripRequest;
+  trip: TripRecord;
+};
+
+export type SaveTripOptions = {
+  itinerary: Itinerary;
+  request: TripRequest;
+  tripId: string | null;
+};
+
+export function getDefaultTripDataMode(): TripDataMode {
+  return import.meta.env.VITE_TRIP_DATA_MODE === "mock" ? "mock" : "api";
+}
+
+export function getTripErrorMessage(error: unknown) {
+  if (error instanceof TripApiClientError) {
+    if (error.fieldErrors && error.fieldErrors.length > 0) {
+      return `${error.message} ${error.fieldErrors
+        .map((fieldError) => `${fieldError.path}: ${fieldError.message}`)
+        .join(" ")}`;
+    }
+
+    return error.message;
+  }
+
+  return "Trip storage is unavailable right now.";
+}
+
+export async function createSavedTrip(
+  client: TripApiClient,
+  request: TripRequest,
+  itinerary: Itinerary
+): Promise<TripOperationResult> {
+  const trip = await client.createTrip(toTripWritePayload(request, itinerary));
+
+  return {
+    itinerary: tripRecordToItinerary(trip),
+    request: tripRecordToTripRequest(trip),
+    trip
+  };
+}
+
+export async function saveTrip(
+  client: TripApiClient,
+  options: SaveTripOptions
+): Promise<TripOperationResult> {
+  const payload = toTripWritePayload(options.request, options.itinerary);
+  const trip =
+    options.tripId === null
+      ? await client.createTrip(payload)
+      : await client.updateTrip(options.tripId, payload);
+
+  return {
+    itinerary: tripRecordToItinerary(trip),
+    request: tripRecordToTripRequest(trip),
+    trip
+  };
+}
+
+export async function reopenSavedTrip(
+  client: TripApiClient,
+  tripId: string
+): Promise<TripOperationResult> {
+  const trip = await client.getTrip(tripId);
+
+  return {
+    itinerary: tripRecordToItinerary(trip),
+    request: tripRecordToTripRequest(trip),
+    trip
+  };
+}
+
+function upsertTrip(trips: TripRecord[], trip: TripRecord) {
+  const existingIndex = trips.findIndex(
+    (candidate) => candidate.id === trip.id
+  );
+
+  if (existingIndex === -1) {
+    return [trip, ...trips];
+  }
+
+  return trips.map((candidate) =>
+    candidate.id === trip.id ? trip : candidate
+  );
+}
+
+export function useTrips(options: { client?: TripApiClient } = {}) {
+  const defaultClient = useMemo(() => createTripApiClient(), []);
+  const client = options.client ?? defaultClient;
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [savedTrips, setSavedTrips] = useState<TripRecord[]>([]);
+  const [selectedTripId, setSelectedTripId] = useState<string | null>(null);
+  const [status, setStatus] = useState<TripOperationStatus>("idle");
+
+  function rememberTrip(trip: TripRecord) {
+    setSavedTrips((currentTrips) => upsertTrip(currentTrips, trip));
+    setSelectedTripId(trip.id);
+  }
+
+  async function runOperation(
+    operationStatus: TripOperationStatus,
+    operation: () => Promise<TripOperationResult>
+  ) {
+    setStatus(operationStatus);
+    setErrorMessage(null);
+
+    try {
+      const result = await operation();
+      rememberTrip(result.trip);
+      setStatus("saved");
+      return result;
+    } catch (error) {
+      setErrorMessage(getTripErrorMessage(error));
+      setStatus("error");
+      return null;
+    }
+  }
+
+  return {
+    clearError: () => setErrorMessage(null),
+    createTripFromRequest: (request: TripRequest, itinerary: Itinerary) =>
+      runOperation("creating", () =>
+        createSavedTrip(client, request, itinerary)
+      ),
+    errorMessage,
+    loadSavedTrips: async () => {
+      setStatus("loading");
+      setErrorMessage(null);
+
+      try {
+        const trips = await client.listTrips();
+        setSavedTrips(trips);
+        setStatus("idle");
+        return trips;
+      } catch (error) {
+        setErrorMessage(getTripErrorMessage(error));
+        setStatus("error");
+        return null;
+      }
+    },
+    reopenTrip: (tripId: string) =>
+      runOperation("reopening", () => reopenSavedTrip(client, tripId)),
+    saveTrip: (
+      tripId: string | null,
+      request: TripRequest,
+      itinerary: Itinerary
+    ) =>
+      runOperation("saving", () =>
+        saveTrip(client, {
+          itinerary,
+          request,
+          tripId
+        })
+      ),
+    savedTrips,
+    selectedTripId,
+    selectTrip: setSelectedTripId,
+    status
+  };
+}

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -43,8 +43,11 @@ describe("createTripApiClient", () => {
   test("creates trips with included anonymous session credentials", async () => {
     const trip = createTripRecord();
     const fetchMock = vi.fn(
-      async (_input: RequestInfo | URL, _init?: RequestInit) =>
-        jsonResponse({ trip })
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        void _input;
+        void _init;
+        return jsonResponse({ trip });
+      }
     );
     const client = createTripApiClient({
       baseUrl: "http://localhost:3001",
@@ -85,11 +88,16 @@ describe("createTripApiClient", () => {
       })
     ];
     const fetchMock = vi.fn(
-      async (_input: RequestInfo | URL, _init?: RequestInit) =>
-        responses.shift() ??
-        jsonResponse({
-          trip
-        })
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        void _input;
+        void _init;
+        return (
+          responses.shift() ??
+          jsonResponse({
+            trip
+          })
+        );
+      }
     );
     const client = createTripApiClient({
       baseUrl: "http://localhost:3001",
@@ -119,8 +127,10 @@ describe("createTripApiClient", () => {
 
   test("parses structured API errors for UI display", async () => {
     const fetchMock = vi.fn(
-      async (_input: RequestInfo | URL, _init?: RequestInit) =>
-        jsonResponse(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        void _input;
+        void _init;
+        return jsonResponse(
           {
             error: {
               code: "VALIDATION_ERROR",
@@ -136,7 +146,8 @@ describe("createTripApiClient", () => {
           {
             status: 400
           }
-        )
+        );
+      }
     );
     const client = createTripApiClient({
       baseUrl: "http://localhost:3001",
@@ -160,6 +171,7 @@ describe("createTripApiClient", () => {
 
   test("reports unavailable API errors without leaking fetch internals", async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL) => {
+      void _input;
       throw new TypeError("fetch failed");
     });
     const client = createTripApiClient({

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { mockItinerary, mockTripRequest } from "../../mocks/index.js";
+import { createTripApiClient, TripApiClientError } from "./client.js";
+import type { TripRecord } from "./types.js";
+import { toTripWritePayload } from "./types.js";
+
+function createTripRecord(overrides: Partial<TripRecord> = {}): TripRecord {
+  return {
+    id: "trip-1",
+    title: mockItinerary.title,
+    startDate: mockTripRequest.startDate,
+    endDate: mockTripRequest.endDate,
+    cities: [...mockTripRequest.cities],
+    interests: [...mockTripRequest.interests],
+    pace: mockTripRequest.pace,
+    budget: mockTripRequest.budget,
+    constraints: [...mockTripRequest.constraints],
+    days: mockItinerary.days.map((day, dayIndex) => ({
+      id: `day-${dayIndex + 1}`,
+      ...day,
+      activities: day.activities.map((activity, activityIndex) => ({
+        ...activity,
+        id: activity.id ?? `activity-${activityIndex + 1}`
+      }))
+    })),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json"
+    },
+    ...init
+  });
+}
+
+describe("createTripApiClient", () => {
+  test("creates trips with included anonymous session credentials", async () => {
+    const trip = createTripRecord();
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse({ trip })
+    );
+    const client = createTripApiClient({
+      baseUrl: "http://localhost:3001",
+      fetch: fetchMock
+    });
+    const payload = toTripWritePayload(mockTripRequest, mockItinerary);
+
+    const response = await client.createTrip(payload);
+    const firstCall = fetchMock.mock.calls[0];
+
+    if (!firstCall) {
+      throw new Error("Expected fetch to be called");
+    }
+
+    const [url, init] = firstCall;
+
+    expect(response).toEqual(trip);
+    expect(url).toBe("http://localhost:3001/api/trips");
+    expect(init).toMatchObject({
+      credentials: "include",
+      method: "POST"
+    });
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      title: mockItinerary.title,
+      cities: mockTripRequest.cities
+    });
+  });
+
+  test("lists, reopens, and updates trips through the API", async () => {
+    const trip = createTripRecord();
+    const responses = [
+      jsonResponse({ trips: [trip] }),
+      jsonResponse({ trip }),
+      jsonResponse({
+        trip: createTripRecord({
+          title: "Updated API Trip"
+        })
+      })
+    ];
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        responses.shift() ??
+        jsonResponse({
+          trip
+        })
+    );
+    const client = createTripApiClient({
+      baseUrl: "http://localhost:3001",
+      fetch: fetchMock
+    });
+
+    await expect(client.listTrips()).resolves.toEqual([trip]);
+    await expect(client.getTrip("trip-1")).resolves.toEqual(trip);
+    await expect(
+      client.updateTrip(
+        "trip-1",
+        toTripWritePayload(mockTripRequest, mockItinerary)
+      )
+    ).resolves.toMatchObject({
+      title: "Updated API Trip"
+    });
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "http://localhost:3001/api/trips",
+      "http://localhost:3001/api/trips/trip-1",
+      "http://localhost:3001/api/trips/trip-1"
+    ]);
+    expect(
+      fetchMock.mock.calls.every(([, init]) => init?.credentials === "include")
+    ).toBe(true);
+  });
+
+  test("parses structured API errors for UI display", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse(
+          {
+            error: {
+              code: "VALIDATION_ERROR",
+              fieldErrors: [
+                {
+                  message: "Title is required.",
+                  path: "title"
+                }
+              ],
+              message: "Request validation failed."
+            }
+          },
+          {
+            status: 400
+          }
+        )
+    );
+    const client = createTripApiClient({
+      baseUrl: "http://localhost:3001",
+      fetch: fetchMock
+    });
+
+    await expect(
+      client.createTrip(toTripWritePayload(mockTripRequest, mockItinerary))
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      fieldErrors: [
+        {
+          message: "Title is required.",
+          path: "title"
+        }
+      ],
+      message: "Request validation failed.",
+      status: 400
+    });
+  });
+
+  test("reports unavailable API errors without leaking fetch internals", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => {
+      throw new TypeError("fetch failed");
+    });
+    const client = createTripApiClient({
+      baseUrl: "http://localhost:3001",
+      fetch: fetchMock
+    });
+
+    await expect(client.listTrips()).rejects.toBeInstanceOf(TripApiClientError);
+    await expect(client.listTrips()).rejects.toMatchObject({
+      code: "TRIP_API_UNAVAILABLE",
+      message: "Could not reach the trip API at http://localhost:3001."
+    });
+  });
+});

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1,0 +1,164 @@
+import {
+  apiErrorSchema,
+  type ApiFieldError
+} from "../../../../../packages/shared/src/schemas/apiError.js";
+import type { TripRecord, TripWritePayload } from "./types.js";
+
+export type TripApiClientOptions = {
+  baseUrl?: string;
+  fetch?: typeof fetch;
+};
+
+export type TripApiClientErrorOptions = {
+  code: string;
+  fieldErrors?: ApiFieldError[] | undefined;
+  message: string;
+  status?: number | undefined;
+};
+
+export class TripApiClientError extends Error {
+  readonly code: string;
+  readonly fieldErrors: ApiFieldError[] | undefined;
+  readonly status: number | undefined;
+
+  constructor(options: TripApiClientErrorOptions) {
+    super(options.message);
+    this.name = "TripApiClientError";
+    this.code = options.code;
+    this.fieldErrors = options.fieldErrors;
+    this.status = options.status;
+  }
+}
+
+export type TripApiClient = {
+  createTrip: (payload: TripWritePayload) => Promise<TripRecord>;
+  getTrip: (tripId: string) => Promise<TripRecord>;
+  listTrips: () => Promise<TripRecord[]>;
+  updateTrip: (
+    tripId: string,
+    payload: TripWritePayload
+  ) => Promise<TripRecord>;
+};
+
+function getDefaultApiBaseUrl() {
+  return import.meta.env.VITE_API_BASE_URL?.trim() || "http://localhost:3001";
+}
+
+function joinUrl(baseUrl: string, path: string) {
+  return `${baseUrl.replace(/\/$/, "")}${path}`;
+}
+
+async function parseJsonResponse(response: Response) {
+  const text = await response.text();
+
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function createApiError(response: Response, body: unknown) {
+  const parsedError = apiErrorSchema.safeParse(body);
+
+  if (parsedError.success) {
+    return new TripApiClientError({
+      code: parsedError.data.error.code,
+      message: parsedError.data.error.message,
+      status: response.status,
+      ...(parsedError.data.error.fieldErrors !== undefined
+        ? { fieldErrors: parsedError.data.error.fieldErrors }
+        : {})
+    });
+  }
+
+  return new TripApiClientError({
+    code: "TRIP_API_ERROR",
+    message: `Trip API request failed with status ${response.status}.`,
+    status: response.status
+  });
+}
+
+export function createTripApiClient(
+  options: TripApiClientOptions = {}
+): TripApiClient {
+  const baseUrl = options.baseUrl ?? getDefaultApiBaseUrl();
+  const fetchImpl = options.fetch ?? fetch;
+
+  async function requestJson<T>(
+    path: string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const headers = new Headers(options.headers);
+    headers.set("Accept", "application/json");
+
+    if (options.body !== undefined && !headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+
+    try {
+      const response = await fetchImpl(joinUrl(baseUrl, path), {
+        ...options,
+        credentials: "include",
+        headers
+      });
+      const body = await parseJsonResponse(response);
+
+      if (!response.ok) {
+        throw createApiError(response, body);
+      }
+
+      return body as T;
+    } catch (error) {
+      if (error instanceof TripApiClientError) {
+        throw error;
+      }
+
+      throw new TripApiClientError({
+        code: "TRIP_API_UNAVAILABLE",
+        message: `Could not reach the trip API at ${baseUrl}.`
+      });
+    }
+  }
+
+  return {
+    async createTrip(payload) {
+      const response = await requestJson<{ trip: TripRecord }>("/api/trips", {
+        body: JSON.stringify(payload),
+        method: "POST"
+      });
+
+      return response.trip;
+    },
+
+    async getTrip(tripId) {
+      const response = await requestJson<{ trip: TripRecord }>(
+        `/api/trips/${encodeURIComponent(tripId)}`
+      );
+
+      return response.trip;
+    },
+
+    async listTrips() {
+      const response = await requestJson<{ trips: TripRecord[] }>("/api/trips");
+
+      return response.trips;
+    },
+
+    async updateTrip(tripId, payload) {
+      const response = await requestJson<{ trip: TripRecord }>(
+        `/api/trips/${encodeURIComponent(tripId)}`,
+        {
+          body: JSON.stringify(payload),
+          method: "PATCH"
+        }
+      );
+
+      return response.trip;
+    }
+  };
+}

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -1,0 +1,87 @@
+import type {
+  Activity,
+  Itinerary,
+  TripDay
+} from "../../../../../packages/shared/src/schemas/itinerary.js";
+import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
+
+export type TripActivityRecord = Activity & {
+  id: string;
+};
+
+export type TripDayRecord = Omit<TripDay, "activities"> & {
+  id: string;
+  activities: TripActivityRecord[];
+};
+
+export type TripRecord = Omit<Itinerary, "days"> &
+  TripRequest & {
+    id: string;
+    days: TripDayRecord[];
+    createdAt: string;
+    updatedAt: string;
+  };
+
+export type TripWritePayload = TripRequest & Itinerary;
+
+export function tripRecordToItinerary(trip: TripRecord): Itinerary {
+  return {
+    title: trip.title,
+    startDate: trip.startDate,
+    endDate: trip.endDate,
+    days: trip.days.map((day) => ({
+      date: day.date,
+      city: day.city,
+      ...(day.summary !== undefined ? { summary: day.summary } : {}),
+      ...(day.weatherSummary !== undefined
+        ? { weatherSummary: day.weatherSummary }
+        : {}),
+      activities: day.activities.map((activity) => ({
+        ...activity,
+        location: { ...activity.location },
+        timing: { ...activity.timing }
+      }))
+    }))
+  };
+}
+
+export function tripRecordToTripRequest(trip: TripRecord): TripRequest {
+  return {
+    startDate: trip.startDate,
+    endDate: trip.endDate,
+    cities: [...trip.cities],
+    interests: [...trip.interests],
+    pace: trip.pace,
+    budget: trip.budget,
+    constraints: [...trip.constraints]
+  };
+}
+
+export function toTripWritePayload(
+  request: TripRequest,
+  itinerary: Itinerary
+): TripWritePayload {
+  return {
+    title: itinerary.title,
+    startDate: request.startDate,
+    endDate: request.endDate,
+    cities: [...request.cities],
+    interests: [...request.interests],
+    pace: request.pace,
+    budget: request.budget,
+    constraints: [...request.constraints],
+    days: itinerary.days.map((day) => ({
+      date: day.date,
+      city: day.city,
+      ...(day.summary !== undefined ? { summary: day.summary } : {}),
+      ...(day.weatherSummary !== undefined
+        ? { weatherSummary: day.weatherSummary }
+        : {}),
+      activities: day.activities.map((activity) => ({
+        ...activity,
+        location: { ...activity.location },
+        timing: { ...activity.timing }
+      }))
+    }))
+  };
+}


### PR DESCRIPTION
## Ticket scope

Implements T-018 / Ticket 18: Connect Web App To Trip API. This PR replaces the web app's mock-only persistence path with API-backed create/save/reopen behavior while preserving explicit mock mode for local UI development and E2E tests.

## Changes made

- Added a typed web API client for trip CRUD under `apps/web/src/lib/api`.
- Added trip persistence workflow helpers and hook under `apps/web/src/features/trips/useTrips.ts`.
- Updated the trip intake form so one validated trip request can submit to API mode or mock preview mode.
- Added a compact storage panel in the web app for API/mock mode, save, refresh saved trips, saved trip selection, and reopen.
- Added public web env config examples for `VITE_API_BASE_URL` and `VITE_TRIP_DATA_MODE`.
- Kept Playwright E2E in mock mode so CI/local E2E does not require a live PostgreSQL database.

## API client design

- `createTripApiClient` wraps all raw `fetch` calls.
- The API base URL defaults to `http://localhost:3001` and can be overridden by `VITE_API_BASE_URL`.
- Every request uses `credentials: "include"` so Ticket 17 anonymous session cookies are sent and reused.
- Structured API errors are parsed with the shared `apiErrorSchema` and surfaced as `TripApiClientError`.
- Type helpers convert API trip records into shared `Itinerary` and `TripRequest` shapes for the editor.

## Save/reopen flow

- In API mode, submitting the form creates a trip through `POST /api/trips` using the existing mock itinerary as the draft itinerary until AI generation is implemented later.
- Save uses `PATCH /api/trips/:tripId` when a saved trip is selected, or `POST /api/trips` when saving without an existing trip id.
- Refresh uses `GET /api/trips` for the current anonymous session.
- Reopen uses `GET /api/trips/:tripId` and repopulates the itinerary editor state.
- Successful save/reopen resets the editor to the saved itinerary, clearing dirty state through the existing editor reset behavior.

## Mock mode strategy

- `VITE_TRIP_DATA_MODE=mock` starts the app in mock mode.
- API mode still exposes a `Use mock preview` action so the UI remains usable when API/database is unavailable.
- Playwright is configured with `VITE_TRIP_DATA_MODE=mock pnpm dev` to keep the existing mock E2E stable without requiring DB services.

## API error UI behavior

- API client errors are displayed in the new storage panel with `role="alert"`.
- Structured field errors are flattened into visible UI text.
- If the API is unreachable, the UI reports that the trip API could not be reached.
- If the API is reachable but the local database is unavailable, the structured API error message is shown.

## Anonymous session/cookie behavior

- Web API requests include credentials for all trip CRUD calls.
- Manual browser verification confirmed that an HTTP-only `jtp_session` cookie is set after an API submit attempt against the running API.
- No server-only secrets are exposed to the web bundle; only public `VITE_*` values were added.

## Tests added/updated

- Added API client tests for credentials, create/list/get/update calls, structured API error parsing, and unavailable API errors.
- Added trip workflow helper tests for mocked create, save, reopen, and UI-friendly error formatting.
- Updated App and TripIntakeForm SSR tests for the new API/mock controls.
- Kept the mock itinerary E2E flow passing in mock mode.

## Checks run

- `pnpm install`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit`
- `pnpm --filter @japan-travel-planner/web exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/web exec vite build`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm exec prettier --check` on touched TS/CSS files
- `git diff --check`

## Manual checks run

- Started API with `pnpm dev:api` and confirmed `http://localhost:3001/api/health` returns HTTP 200 with the expected JSON.
- Started web with `pnpm dev:web` at `http://localhost:5173`.
- In API mode with local PostgreSQL unavailable, clicked `Create saved itinerary` and confirmed a visible `Unexpected server error.` UI alert.
- Confirmed the browser received an HTTP-only `jtp_session` cookie from the API submit attempt.
- Clicked `Use mock preview` and confirmed the mock itinerary renders.
- Checked 390px viewport for no horizontal overflow.
- Confirmed no OpenAI, AI, weather, maps, hotel, provider, Prisma schema, migration, or API session strategy changes were added.

## Real API/database save-reopen status

Real DB-backed save/reopen was not tested locally because PostgreSQL was not listening on `localhost:5432`. The API-backed path is implemented and covered with mocked client tests; live DB save/reopen should be verified once a safe local or CI `DATABASE_URL` is available.

## Known risks

- Local `pnpm lint` stalled at `eslint .` after roughly 90 seconds with no diagnostics; targeted ESLint on touched frontend files also stalled with no output. No tooling changes were made in this Ticket 18 PR.
- Because Phase 3 AI generation is not implemented yet, API submit persists the existing mock itinerary draft rather than generating a new AI itinerary.
- CI E2E intentionally remains mock-mode until a reliable test database is configured.

## Ticket 19+ confirmation

Ticket 19 and later tickets were not started. This PR does not add OpenAI code, prompt engineering, AI generation, weather/maps/hotel/provider integrations, Prisma schema changes, migrations, or API auth/session changes.
