### PR TITLE
T-020: Implement itinerary prompt and structured output contract

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,16 +5,17 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm build && node dist/server.js",
-    "build": "pnpm db:generate && rm -rf dist && tsc -p tsconfig.build.json",
+    "build": "pnpm --filter @japan-travel-planner/shared build && pnpm db:generate && rm -rf dist && tsc -p tsconfig.build.json",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
     "db:validate": "prisma validate",
     "start": "node dist/server.js",
-    "typecheck": "pnpm db:generate && tsc -p tsconfig.json --noEmit",
-    "test": "pnpm db:generate && vitest run"
+    "typecheck": "pnpm --filter @japan-travel-planner/shared build && pnpm db:generate && tsc -p tsconfig.json --noEmit",
+    "test": "pnpm --filter @japan-travel-planner/shared build && pnpm db:generate && vitest run"
   },
   "dependencies": {
+    "@japan-travel-planner/shared": "workspace:*",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "cors": "^2.8.6",

--- a/apps/api/src/services/aiItinerary/prompt.test.ts
+++ b/apps/api/src/services/aiItinerary/prompt.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+
+import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
+
+import { buildItineraryPrompt, itineraryPromptInstructions } from "./prompt.js";
+
+const representativeTripRequest = {
+  startDate: "2026-04-06",
+  endDate: "2026-04-08",
+  cities: ["Tokyo", "Kyoto"],
+  interests: [
+    "spring flowers",
+    "temples",
+    "local food",
+    "walkable neighborhoods"
+  ],
+  pace: "balanced",
+  budget: "moderate",
+  constraints: [
+    "Vegetarian meals only",
+    "Traveler uses a wheelchair and needs step-free station routes",
+    "Avoid late-night activities"
+  ]
+} satisfies TripRequest;
+
+describe("buildItineraryPrompt", () => {
+  test("constructs a deterministic prompt for a representative Tokyo/Kyoto trip", () => {
+    const prompt = buildItineraryPrompt(representativeTripRequest);
+    const repeatedPrompt = buildItineraryPrompt({
+      ...representativeTripRequest,
+      constraints: [...representativeTripRequest.constraints]
+    });
+
+    expect(prompt).toEqual(repeatedPrompt);
+    expect(prompt.instructions).toBe(itineraryPromptInstructions);
+    expect(prompt.input).toContain("Dates: 2026-04-06 to 2026-04-08");
+    expect(prompt.input).toContain(
+      "Destination cities, in requested order: Tokyo, Kyoto"
+    );
+    expect(prompt.input).toContain("Travel pace: balanced");
+    expect(prompt.input).toContain("Budget level: moderate");
+    expect(prompt.input).toContain("- spring flowers");
+    expect(prompt.input).toContain("- temples");
+  });
+
+  test("includes pacing, city grouping, travel-time, constraints, and activity count limits", () => {
+    const prompt = buildItineraryPrompt(representativeTripRequest);
+    const combinedPrompt = `${prompt.instructions}\n${prompt.input}`;
+
+    expect(combinedPrompt).toContain("realistic Japan travel days");
+    expect(combinedPrompt).toContain("Group activities by city");
+    expect(combinedPrompt).toContain("approximate travel time");
+    expect(combinedPrompt).toContain("Dietary constraints identified");
+    expect(combinedPrompt).toContain("- Vegetarian meals only");
+    expect(combinedPrompt).toContain("Accessibility constraints identified");
+    expect(combinedPrompt).toContain(
+      "- Traveler uses a wheelchair and needs step-free station routes"
+    );
+    expect(combinedPrompt).toContain("3 to 4 activities per day");
+  });
+
+  test("asks for structured output only and avoids unsupported provider claims", () => {
+    const prompt = buildItineraryPrompt(representativeTripRequest);
+    const combinedPrompt = `${prompt.instructions}\n${prompt.input}`;
+
+    expect(combinedPrompt).toContain("Return structured JSON only");
+    expect(combinedPrompt).toContain("Return exactly one JSON object");
+    expect(combinedPrompt).toContain("Do not claim live booking availability");
+    expect(combinedPrompt).toContain("exact transit guarantees");
+    expect(combinedPrompt).toContain(
+      "Map, weather, hotel, booking, and provider enrichment are not available yet"
+    );
+    expect(combinedPrompt).toContain('"activities"');
+    expect(combinedPrompt).toContain('"title"');
+    expect(combinedPrompt).toContain('"category"');
+    expect(combinedPrompt).toContain('"timing"');
+    expect(combinedPrompt).toContain('"durationMinutes"');
+    expect(combinedPrompt).toContain('"location"');
+    expect(combinedPrompt).toContain('"costLevel"');
+    expect(combinedPrompt).toContain('"notes"');
+  });
+});

--- a/apps/api/src/services/aiItinerary/prompt.ts
+++ b/apps/api/src/services/aiItinerary/prompt.ts
@@ -1,0 +1,154 @@
+import {
+  activityCategorySchema,
+  activityCostLevelSchema,
+  tripRequestSchema,
+  type TravelPace,
+  type TripRequest
+} from "@japan-travel-planner/shared";
+
+export type ItineraryPrompt = {
+  instructions: string;
+  input: string;
+};
+
+const activityCountLimitsByPace = {
+  relaxed: "2 to 3 substantial activities per day",
+  balanced: "3 to 4 activities per day",
+  packed: "4 to 5 activities per day, only when travel time still works"
+} satisfies Record<TravelPace, string>;
+
+const dietaryConstraintKeywords = [
+  "allerg",
+  "dairy",
+  "diet",
+  "gluten",
+  "halal",
+  "kosher",
+  "nut",
+  "pescatarian",
+  "seafood",
+  "shellfish",
+  "vegan",
+  "vegetarian"
+];
+
+const accessibilityConstraintKeywords = [
+  "accessible",
+  "accessibility",
+  "cane",
+  "elevator",
+  "lift",
+  "mobility",
+  "step-free",
+  "stairs",
+  "stroller",
+  "walking limit",
+  "wheelchair"
+];
+
+const allowedCategories = activityCategorySchema.options.join(", ");
+const allowedCostLevels = activityCostLevelSchema.options.join(", ");
+
+export const itineraryPromptInstructions = [
+  "You are Japan Travel Planner AI's backend itinerary planner.",
+  "Return structured JSON only. Do not include Markdown, commentary, citations, or prose outside the JSON object.",
+  "Create realistic Japan travel days that respect the requested dates, destination cities, pace, budget, interests, and constraints.",
+  "Group activities by city and avoid bouncing between distant neighborhoods or cities within the same day.",
+  "Account for approximate travel time between activities, including transfer time when a day changes cities.",
+  "Do not claim live booking availability, exact transit guarantees, real-time opening hours, hidden provider data, weather certainty, or map route precision.",
+  "Map, weather, hotel, booking, and provider enrichment are not available yet; write notes that are useful without pretending those integrations were queried.",
+  "Use conservative wording for uncertain details and keep every activity editable by the application."
+].join("\n");
+
+export function buildItineraryPrompt(input: TripRequest): ItineraryPrompt {
+  const request = tripRequestSchema.parse(input);
+  const dietaryConstraints = pickMatchingConstraints(
+    request.constraints,
+    dietaryConstraintKeywords
+  );
+  const accessibilityConstraints = pickMatchingConstraints(
+    request.constraints,
+    accessibilityConstraintKeywords
+  );
+  const activityCountLimit = activityCountLimitsByPace[request.pace];
+
+  return {
+    instructions: itineraryPromptInstructions,
+    input: [
+      "Trip request",
+      `Dates: ${request.startDate} to ${request.endDate}`,
+      `Destination cities, in requested order: ${request.cities.join(", ")}`,
+      `Travel pace: ${request.pace}`,
+      `Budget level: ${request.budget}`,
+      "",
+      "Interests:",
+      formatBulletList(request.interests),
+      "",
+      "User constraints:",
+      formatBulletList(request.constraints),
+      "",
+      "Dietary constraints identified from user constraints:",
+      formatBulletList(dietaryConstraints),
+      "",
+      "Accessibility constraints identified from user constraints:",
+      formatBulletList(accessibilityConstraints),
+      "",
+      "Planning rules:",
+      "- Keep each day centered on one primary city unless the day is a realistic transfer day.",
+      "- Preserve the requested city order and group consecutive days in the same city where practical.",
+      "- Include an explicit transit activity when moving between Tokyo, Kyoto, Osaka, or other distant cities.",
+      "- Leave enough buffer for meals, station transfers, luggage handling, and neighborhood changes.",
+      `- Activity count limit: ${activityCountLimit}.`,
+      "- Prefer realistic pacing over covering every possible attraction.",
+      "- Avoid unsupported claims about bookings, exact train schedules, weather, hotel availability, or provider-only facts.",
+      "",
+      "Structured output contract:",
+      "Return exactly one JSON object with this shape:",
+      "{",
+      '  "title": "string",',
+      '  "startDate": "YYYY-MM-DD",',
+      '  "endDate": "YYYY-MM-DD",',
+      '  "days": [',
+      "    {",
+      '      "dayNumber": 1,',
+      '      "date": "YYYY-MM-DD",',
+      '      "city": "string",',
+      '      "summary": "string",',
+      '      "activities": [',
+      "        {",
+      '          "title": "string",',
+      `          "category": "one of: ${allowedCategories}",`,
+      '          "timing": { "startTime": "HH:MM", "endTime": "HH:MM", "timeOfDay": "morning | afternoon | evening | night" },',
+      '          "durationMinutes": 90,',
+      '          "location": { "name": "string", "address": "string", "city": "string" },',
+      `          "costLevel": "one of: ${allowedCostLevels}",`,
+      '          "notes": "string"',
+      "        }",
+      "      ]",
+      "    }",
+      "  ]",
+      "}"
+    ].join("\n")
+  };
+}
+
+function pickMatchingConstraints(
+  constraints: string[],
+  keywords: string[]
+): string[] {
+  return constraints.filter((constraint) => {
+    const normalizedConstraint = constraint.toLowerCase();
+
+    return keywords.some((keyword) =>
+      normalizedConstraint.includes(keyword.toLowerCase())
+    );
+  });
+}
+
+function formatBulletList(items: string[]): string {
+  if (items.length === 0) {
+    return "- None provided";
+  }
+
+  return items.map((item) => `- ${item}`).join("\n");
+}

--- a/apps/api/src/services/aiItinerary/schema.test.ts
+++ b/apps/api/src/services/aiItinerary/schema.test.ts
@@ -1,0 +1,223 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+import { itinerarySchema } from "../../../../../packages/shared/src/schemas/itinerary.js";
+
+import {
+  AiItineraryOutputParseError,
+  parseAiItineraryOutput
+} from "./schema.js";
+
+const validModelOutput = {
+  title: "Tokyo And Kyoto Spring Highlights",
+  startDate: "2026-04-06",
+  endDate: "2026-04-07",
+  days: [
+    {
+      dayNumber: 1,
+      date: "2026-04-06",
+      city: "Tokyo",
+      summary: "Ease into Tokyo with blossoms, food, and classic temples.",
+      activities: [
+        {
+          title: "Senso-ji and Nakamise-dori",
+          category: "temple",
+          timing: {
+            startTime: "09:30",
+            endTime: "11:30",
+            timeOfDay: "early morning"
+          },
+          durationMinutes: "120 minutes",
+          location: {
+            name: "Senso-ji",
+            address: "2 Chome-3-1 Asakusa, Taito City, Tokyo",
+            city: "Tokyo"
+          },
+          costLevel: "free",
+          notes: "Arrive early and keep side-street time flexible."
+        },
+        {
+          title: "Ameyoko lunch crawl",
+          category: "restaurant",
+          timing: {
+            startTime: "12:00",
+            endTime: "13:15",
+            timeOfDay: "midday"
+          },
+          durationMinutes: 75,
+          location: {
+            name: "Ameya-Yokocho Market",
+            city: "Tokyo"
+          },
+          costLevel: "moderate",
+          notes:
+            "Pick a few vegetarian-friendly stalls instead of one heavy lunch."
+        }
+      ]
+    },
+    {
+      dayNumber: 2,
+      date: "2026-04-07",
+      city: "Kyoto",
+      summary: "Transfer to Kyoto, then focus on eastern temples.",
+      activities: [
+        {
+          title: "Tokaido Shinkansen to Kyoto",
+          category: "transport",
+          timing: {
+            startTime: "08:30",
+            endTime: "10:50",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 140,
+          location: {
+            name: "Tokyo Station to Kyoto Station",
+            city: "Tokyo"
+          },
+          costLevel: "expensive",
+          notes:
+            "Treat train timing as approximate and leave station transfer buffer."
+        }
+      ]
+    }
+  ]
+};
+
+describe("parseAiItineraryOutput", () => {
+  test("parses representative model output into a shared-schema-valid itinerary", () => {
+    const itinerary = parseAiItineraryOutput(validModelOutput);
+    const firstActivity = itinerary.days[0]?.activities[0];
+    const secondActivity = itinerary.days[0]?.activities[1];
+    const transferActivity = itinerary.days[1]?.activities[0];
+
+    expect(itinerarySchema.safeParse(itinerary).success).toBe(true);
+    expect(itinerary.title).toBe("Tokyo And Kyoto Spring Highlights");
+    expect(firstActivity).toMatchObject({
+      category: "culture",
+      costLevel: "free",
+      durationMinutes: 120,
+      timing: {
+        timeOfDay: "morning"
+      }
+    });
+    expect(secondActivity).toMatchObject({
+      category: "food",
+      costLevel: "medium",
+      timing: {
+        timeOfDay: "afternoon"
+      }
+    });
+    expect(transferActivity).toMatchObject({
+      category: "transit",
+      costLevel: "high"
+    });
+  });
+
+  test("accepts a JSON string model output", () => {
+    expect(parseAiItineraryOutput(JSON.stringify(validModelOutput))).toEqual(
+      parseAiItineraryOutput(validModelOutput)
+    );
+  });
+
+  test("rejects missing required activity fields with a structured error", () => {
+    const invalidOutput = {
+      ...validModelOutput,
+      days: [
+        {
+          ...validModelOutput.days[0],
+          activities: [
+            {
+              title: "Senso-ji and Nakamise-dori",
+              category: "culture",
+              timing: {
+                startTime: "09:30",
+                endTime: "11:30",
+                timeOfDay: "morning"
+              },
+              durationMinutes: 120,
+              costLevel: "free",
+              notes: "Location is intentionally missing."
+            }
+          ]
+        }
+      ]
+    };
+
+    expectAiItineraryParseError(invalidOutput, "days.0.activities.0.location");
+  });
+
+  test("rejects malformed day structures", () => {
+    const invalidOutput = {
+      ...validModelOutput,
+      days: [
+        {
+          ...validModelOutput.days[0],
+          dayNumber: 2,
+          date: "2026-04-09"
+        }
+      ]
+    };
+
+    expectAiItineraryParseError(invalidOutput, "days.0.dayNumber");
+    expectAiItineraryParseError(invalidOutput, "days.0.date");
+  });
+
+  test("rejects unsupported category and cost values", () => {
+    const invalidOutput = {
+      ...validModelOutput,
+      days: [
+        {
+          ...validModelOutput.days[0],
+          activities: [
+            {
+              ...validModelOutput.days[0]?.activities[0],
+              category: "nightlife",
+              costLevel: "splurge"
+            }
+          ]
+        }
+      ]
+    };
+
+    expectAiItineraryParseError(invalidOutput, "days.0.activities.0.category");
+    expectAiItineraryParseError(invalidOutput, "days.0.activities.0.costLevel");
+  });
+
+  test("rejects non-JSON string output", () => {
+    expectAiItineraryParseError("not json", "modelOutput");
+  });
+
+  test("does not import or call the OpenAI provider", () => {
+    const serviceDirectory = fileURLToPath(new URL(".", import.meta.url));
+    const promptSource = readFileSync(`${serviceDirectory}/prompt.ts`, "utf8");
+    const schemaSource = readFileSync(`${serviceDirectory}/schema.ts`, "utf8");
+
+    expect(`${promptSource}\n${schemaSource}`).not.toMatch(
+      /providers\/openai|openaiClient|responses\.create|createOpenAiProvider/
+    );
+  });
+});
+
+function expectAiItineraryParseError(
+  output: unknown,
+  expectedPath: string
+): void {
+  try {
+    parseAiItineraryOutput(output);
+  } catch (error) {
+    expect(error).toBeInstanceOf(AiItineraryOutputParseError);
+
+    if (error instanceof AiItineraryOutputParseError) {
+      expect(error.code).toBe("AI_ITINERARY_OUTPUT_INVALID");
+      expect(error.fieldErrors.map((fieldError) => fieldError.path)).toContain(
+        expectedPath
+      );
+    }
+
+    return;
+  }
+
+  throw new Error("Expected parseAiItineraryOutput to throw.");
+}

--- a/apps/api/src/services/aiItinerary/schema.ts
+++ b/apps/api/src/services/aiItinerary/schema.ts
@@ -1,0 +1,297 @@
+import { z, type ZodIssue } from "zod";
+
+import {
+  activityCategorySchema,
+  activityCostLevelSchema,
+  activityLocationSchema,
+  itinerarySchema,
+  isoDateSchema,
+  type ActivityCategory,
+  type ActivityCostLevel,
+  type Itinerary
+} from "@japan-travel-planner/shared";
+
+export type AiItineraryOutputFieldError = {
+  path: string;
+  message: string;
+};
+
+export class AiItineraryOutputParseError extends Error {
+  readonly code = "AI_ITINERARY_OUTPUT_INVALID";
+  readonly fieldErrors: AiItineraryOutputFieldError[];
+
+  constructor(message: string, fieldErrors: AiItineraryOutputFieldError[]) {
+    super(message);
+    this.name = "AiItineraryOutputParseError";
+    this.fieldErrors = fieldErrors;
+  }
+}
+
+const timeOfDaySchema = z.enum(["morning", "afternoon", "evening", "night"]);
+
+const categoryAliases = {
+  attraction: "sightseeing",
+  dining: "food",
+  dinner: "food",
+  lunch: "food",
+  market: "shopping",
+  meal: "food",
+  museum: "culture",
+  park: "nature",
+  restaurant: "food",
+  scenery: "nature",
+  scenic: "sightseeing",
+  shrine: "culture",
+  temple: "culture",
+  train: "transit",
+  transfer: "transit",
+  transport: "transit",
+  transportation: "transit",
+  walk: "sightseeing"
+} satisfies Record<string, ActivityCategory>;
+
+const costLevelAliases = {
+  cheap: "low",
+  expensive: "high",
+  luxury: "high",
+  mid: "medium",
+  moderate: "medium",
+  premium: "high"
+} satisfies Record<string, ActivityCostLevel>;
+
+const timeOfDayAliases = {
+  brunch: "morning",
+  daytime: "afternoon",
+  dinner: "evening",
+  early: "morning",
+  "early morning": "morning",
+  late: "night",
+  midday: "afternoon",
+  noon: "afternoon",
+  overnight: "night",
+  sunset: "evening"
+} satisfies Record<string, z.infer<typeof timeOfDaySchema>>;
+
+const modelActivityCategorySchema = z.preprocess(
+  (value) => normalizeAliasedValue(value, categoryAliases),
+  activityCategorySchema
+);
+
+const modelActivityCostLevelSchema = z.preprocess(
+  (value) => normalizeAliasedValue(value, costLevelAliases),
+  activityCostLevelSchema
+);
+
+const modelTimeOfDaySchema = z.preprocess((value) => {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  return normalizeAliasedValue(value, timeOfDayAliases);
+}, timeOfDaySchema.optional());
+
+const modelDurationMinutesSchema = z.preprocess((value) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const match = value
+    .trim()
+    .match(/^(\d+)(?:\s*(?:m|min|mins|minute|minutes))?$/i);
+
+  return match?.[1] === undefined ? value : Number(match[1]);
+}, z.number().int().positive());
+
+const modelActivityTimingSchema = z
+  .object({
+    startTime: z
+      .string()
+      .regex(/^([01]\d|2[0-3]):[0-5]\d$/)
+      .optional(),
+    endTime: z
+      .string()
+      .regex(/^([01]\d|2[0-3]):[0-5]\d$/)
+      .optional(),
+    timeOfDay: modelTimeOfDaySchema
+  })
+  .strict()
+  .refine(
+    (timing) => Boolean(timing.startTime ?? timing.timeOfDay),
+    "Provide either startTime or timeOfDay."
+  );
+
+const modelActivitySchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    title: z.string().min(1),
+    category: modelActivityCategorySchema,
+    timing: modelActivityTimingSchema,
+    durationMinutes: modelDurationMinutesSchema,
+    location: activityLocationSchema,
+    costLevel: modelActivityCostLevelSchema,
+    notes: z.string().min(1)
+  })
+  .strict();
+
+const modelTripDaySchema = z
+  .object({
+    dayNumber: z.number().int().positive().optional(),
+    date: isoDateSchema,
+    city: z.string().min(1),
+    summary: z.string().min(1).optional(),
+    activities: z.array(modelActivitySchema).min(1)
+  })
+  .strict();
+
+export const aiItineraryModelOutputSchema = z
+  .object({
+    title: z.string().min(1),
+    startDate: isoDateSchema,
+    endDate: isoDateSchema,
+    days: z.array(modelTripDaySchema).min(1)
+  })
+  .strict()
+  .superRefine((output, context) => {
+    if (output.startDate > output.endDate) {
+      context.addIssue({
+        code: "custom",
+        path: ["endDate"],
+        message: "endDate must be on or after startDate."
+      });
+    }
+
+    const seenDates = new Set<string>();
+    let previousDate: string | undefined;
+
+    output.days.forEach((day, index) => {
+      if (day.dayNumber !== undefined && day.dayNumber !== index + 1) {
+        context.addIssue({
+          code: "custom",
+          path: ["days", index, "dayNumber"],
+          message: "dayNumber must match the day position."
+        });
+      }
+
+      if (day.date < output.startDate || day.date > output.endDate) {
+        context.addIssue({
+          code: "custom",
+          path: ["days", index, "date"],
+          message: "day date must be within the itinerary date range."
+        });
+      }
+
+      if (previousDate !== undefined && day.date < previousDate) {
+        context.addIssue({
+          code: "custom",
+          path: ["days", index, "date"],
+          message: "day dates must be in chronological order."
+        });
+      }
+
+      if (seenDates.has(day.date)) {
+        context.addIssue({
+          code: "custom",
+          path: ["days", index, "date"],
+          message: "day dates must be unique."
+        });
+      }
+
+      seenDates.add(day.date);
+      previousDate = day.date;
+    });
+  });
+
+export type AiItineraryModelOutput = z.infer<
+  typeof aiItineraryModelOutputSchema
+>;
+
+export function parseAiItineraryOutput(modelOutput: unknown): Itinerary {
+  const jsonOutput = parseUnknownJson(modelOutput);
+  const modelResult = aiItineraryModelOutputSchema.safeParse(jsonOutput);
+
+  if (!modelResult.success) {
+    throw new AiItineraryOutputParseError(
+      "AI itinerary output did not match the expected structured contract.",
+      zodIssuesToOutputFieldErrors(modelResult.error.issues)
+    );
+  }
+
+  const itineraryResult = itinerarySchema.safeParse(
+    mapModelOutputToItinerary(modelResult.data)
+  );
+
+  if (!itineraryResult.success) {
+    throw new AiItineraryOutputParseError(
+      "AI itinerary output could not be mapped to the shared itinerary schema.",
+      zodIssuesToOutputFieldErrors(itineraryResult.error.issues)
+    );
+  }
+
+  return itineraryResult.data;
+}
+
+function mapModelOutputToItinerary(output: AiItineraryModelOutput): Itinerary {
+  return {
+    title: output.title,
+    startDate: output.startDate,
+    endDate: output.endDate,
+    days: output.days.map((day) => ({
+      date: day.date,
+      city: day.city,
+      ...(day.summary !== undefined ? { summary: day.summary } : {}),
+      activities: day.activities.map((activity) => ({
+        ...(activity.id !== undefined ? { id: activity.id } : {}),
+        title: activity.title,
+        category: activity.category,
+        timing: activity.timing,
+        durationMinutes: activity.durationMinutes,
+        location: activity.location,
+        costLevel: activity.costLevel,
+        notes: activity.notes
+      }))
+    }))
+  };
+}
+
+function parseUnknownJson(modelOutput: unknown): unknown {
+  if (typeof modelOutput !== "string") {
+    return modelOutput;
+  }
+
+  try {
+    return JSON.parse(modelOutput) as unknown;
+  } catch {
+    throw new AiItineraryOutputParseError(
+      "AI itinerary output must be valid JSON.",
+      [
+        {
+          path: "modelOutput",
+          message: "Expected a valid JSON object or object-compatible value."
+        }
+      ]
+    );
+  }
+}
+
+function normalizeAliasedValue<T extends string>(
+  value: unknown,
+  aliases: Record<string, T>
+): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const normalized = value.trim().toLowerCase().replace(/[_-]+/g, " ");
+
+  return aliases[normalized] ?? normalized.replace(/\s+/g, "");
+}
+
+function zodIssuesToOutputFieldErrors(
+  issues: readonly ZodIssue[]
+): AiItineraryOutputFieldError[] {
+  return issues.map((issue) => ({
+    path:
+      issue.path.length > 0 ? issue.path.map(String).join(".") : "modelOutput",
+    message: issue.message
+  }));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@japan-travel-planner/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0


### PR DESCRIPTION
## Ticket scope

Implements T-020 / Ticket 20: backend-only itinerary prompt construction and structured model output parsing/mapping for future AI itinerary generation.

This PR does not add `POST /api/itineraries/generate`, does not call OpenAI, does not connect the web app to AI generation, and does not change Trip CRUD, Prisma schema/migrations, persistence behavior, or web UI behavior.

## Changes made

- Added deterministic prompt construction under `apps/api/src/services/aiItinerary/prompt.ts`.
- Added structured model output schema, parser, mapper, and structured parse error under `apps/api/src/services/aiItinerary/schema.ts`.
- Added API unit tests for prompt guardrails and schema parsing.
- Added an API workspace dependency on `@japan-travel-planner/shared` so production API code can reuse shared schemas through the package export instead of importing source internals.
- Updated API typecheck/test/build scripts to build the shared package first, so targeted API commands work from a clean checkout where `packages/shared/dist` does not already exist.

## Prompt construction approach

- Builds prompt content from the shared `tripRequestSchema`.
- Includes trip dates, destination cities, pace, budget, interests, and user constraints.
- Detects dietary and accessibility constraints from the generic constraints list and renders explicit sections when present.
- Includes city grouping rules, travel-time awareness, transfer guidance, and pace-based activity count limits.
- Requires structured JSON only and discourages unsupported claims about bookings, exact transit guarantees, weather, maps, hotels, hidden provider data, or unavailable enrichment.

## Structured output schema approach

- Defines a strict Zod model-output contract for itinerary days and activities.
- Requires activity title, category, timing, duration, location, cost level, and notes.
- Rejects missing required activity fields, invalid dates, out-of-range day dates, duplicate day dates, non-chronological days, and mismatched `dayNumber` values.
- Normalizes practical model-friendly values such as `temple -> culture`, `restaurant -> food`, `transport -> transit`, `moderate -> medium`, `expensive -> high`, and string durations like `120 minutes`.

## Mapping to shared itinerary schema

- `parseAiItineraryOutput` accepts unknown object-compatible output or a JSON string.
- It parses and validates the model contract first.
- It maps model output into the shared `Itinerary` shape.
- It runs the mapped result through the shared `itinerarySchema` as the final validation gate.
- Invalid output throws `AiItineraryOutputParseError` with `AI_ITINERARY_OUTPUT_INVALID` and field-level paths.

## Tests added/updated

- `apps/api/src/services/aiItinerary/prompt.test.ts`
- `apps/api/src/services/aiItinerary/schema.test.ts`

Coverage includes representative Tokyo/Kyoto prompt construction, pacing/city grouping/travel-time/dietary/accessibility/activity-limit prompt content, structured-output-only guardrails, valid model output parsing, shared-schema validation, alias normalization, missing field rejection, malformed day rejection, unsupported enum rejection, non-JSON rejection, and a source guard that the prompt/schema modules do not import or call the OpenAI provider.

## Checks run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `git diff --check`

The final root typecheck/test/build reruns were performed sequentially after clearing `packages/shared/dist` and `apps/api/dist` to catch fresh-checkout behavior.

## Manual checks run

- Confirmed no OpenAI provider import/call in the new prompt/schema production files.
- Confirmed no generation route was added.
- Confirmed no web files import AI itinerary service code.
- Confirmed no `VITE_OPENAI` public env variable was added.
- Confirmed representative prompt construction is deterministic.
- Confirmed representative model output parses into a shared-schema-valid itinerary using built ESM output.

## Real OpenAI calls

No real OpenAI API call was made.

## Known risks

- Model output ambiguity remains until Ticket 21 adds the generation endpoint, retry/repair handling, and real model integration. This parser fails closed for unsupported shapes.
- Local Prisma-generating commands can collide if run concurrently. Sequential required commands passed, and the API scripts now build shared first for clean-checkout reliability.
- A manual `tsx --eval` smoke command against TS source hit an ESM workspace export-map quirk; the same smoke check against built ESM output passed.
- No final local runner stalls were observed; root lint, typecheck, test, and build passed.

## Ticket 21+ confirmation

Ticket 21 and later tickets were not started.
