### PR TITLE
T-021: Implement generate itinerary endpoint

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,11 +5,17 @@ import { loadApiEnv, type ApiEnvConfig } from "./config/env.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { createSessionMiddleware } from "./middleware/session.js";
 import { healthRouter } from "./routes/health.js";
+import { createItinerariesRouter } from "./routes/itineraries.js";
 import { createTripsRouter } from "./routes/trips.js";
+import {
+  createAiItineraryService,
+  type AiItineraryService
+} from "./services/aiItinerary/generateItinerary.js";
 import { createTripService, type TripService } from "./services/tripService.js";
 
 export type CreateAppOptions = {
   env?: ApiEnvConfig;
+  aiItineraryService?: AiItineraryService;
   sessionMiddleware?: RequestHandler;
   tripService?: TripService;
 };
@@ -21,6 +27,8 @@ export function createApp(options: CreateAppOptions = {}) {
     createSessionMiddleware({
       secret: env.jwtSecret
     });
+  const aiItineraryService =
+    options.aiItineraryService ?? createAiItineraryService(env);
   const tripService = options.tripService ?? createTripService();
   const app = express();
 
@@ -32,6 +40,7 @@ export function createApp(options: CreateAppOptions = {}) {
   );
   app.use(express.json());
   app.use("/api/health", healthRouter);
+  app.use("/api/itineraries", createItinerariesRouter(aiItineraryService));
   app.use("/api/trips", sessionMiddleware, createTripsRouter(tripService));
   app.use(errorHandler);
 

--- a/apps/api/src/routes/itineraries.test.ts
+++ b/apps/api/src/routes/itineraries.test.ts
@@ -1,0 +1,220 @@
+import request from "supertest";
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  apiErrorSchema,
+  itinerarySchema,
+  type TripRequest
+} from "@japan-travel-planner/shared";
+
+import { createApp } from "../app.js";
+import { defaultApiEnv } from "../config/env.js";
+import {
+  AiItineraryService,
+  type AiItineraryProvider
+} from "../services/aiItinerary/generateItinerary.js";
+
+const validTripRequest = {
+  startDate: "2026-04-06",
+  endDate: "2026-04-07",
+  cities: ["Tokyo", "Kyoto"],
+  interests: ["temples", "local food"],
+  pace: "balanced",
+  budget: "moderate",
+  constraints: ["Avoid late-night activities"]
+} satisfies TripRequest;
+
+const validModelOutput = {
+  title: "Tokyo And Kyoto Highlights",
+  startDate: "2026-04-06",
+  endDate: "2026-04-07",
+  days: [
+    {
+      dayNumber: 1,
+      date: "2026-04-06",
+      city: "Tokyo",
+      summary: "Classic Tokyo temple streets and local food.",
+      activities: [
+        {
+          title: "Senso-ji and Nakamise-dori",
+          category: "temple",
+          timing: {
+            startTime: "09:30",
+            endTime: "11:30",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 120,
+          location: {
+            name: "Senso-ji",
+            city: "Tokyo"
+          },
+          costLevel: "free",
+          notes: "Arrive early and keep time flexible."
+        }
+      ]
+    },
+    {
+      dayNumber: 2,
+      date: "2026-04-07",
+      city: "Kyoto",
+      summary: "Transfer to Kyoto and visit one focused district.",
+      activities: [
+        {
+          title: "Tokaido Shinkansen to Kyoto",
+          category: "transport",
+          timing: {
+            startTime: "08:30",
+            endTime: "10:50",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 140,
+          location: {
+            name: "Tokyo Station to Kyoto Station",
+            city: "Tokyo"
+          },
+          costLevel: "expensive",
+          notes: "Keep train timing approximate and leave transfer buffer."
+        }
+      ]
+    }
+  ]
+};
+
+describe("POST /api/itineraries/generate", () => {
+  test("returns a validated itinerary for a valid request with mocked AI success", async () => {
+    const { app, createResponse } = createItineraryTestApp([
+      JSON.stringify(validModelOutput)
+    ]);
+
+    const response = await request(app)
+      .post("/api/itineraries/generate")
+      .send(validTripRequest);
+
+    expect(response.status).toBe(200);
+    expect(itinerarySchema.safeParse(response.body.itinerary).success).toBe(
+      true
+    );
+    expect(response.body.metadata).toEqual({
+      attempts: 1,
+      estimatedCostUsd: null,
+      model: "gpt-test-model",
+      repaired: false,
+      tokenUsage: null
+    });
+    expect(response.body.itinerary.days[0].activities[0]).toMatchObject({
+      category: "culture",
+      costLevel: "free"
+    });
+    expect(createResponse).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns validation errors for an invalid trip request", async () => {
+    const { app, createResponse } = createItineraryTestApp([
+      JSON.stringify(validModelOutput)
+    ]);
+
+    const response = await request(app)
+      .post("/api/itineraries/generate")
+      .send({
+        ...validTripRequest,
+        cities: [],
+        endDate: "2026-04-01"
+      });
+
+    expect(response.status).toBe(400);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "Request validation failed."
+    });
+    expect(response.body.error.fieldErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "cities"
+        }),
+        expect.objectContaining({
+          path: "endDate"
+        })
+      ])
+    );
+    expect(createResponse).not.toHaveBeenCalled();
+  });
+
+  test("returns a structured error when model output remains invalid after repair", async () => {
+    const { app, createResponse } = createItineraryTestApp([
+      "not valid json",
+      JSON.stringify({
+        ...validModelOutput,
+        days: []
+      })
+    ]);
+
+    const response = await request(app)
+      .post("/api/itineraries/generate")
+      .send(validTripRequest);
+
+    expect(response.status).toBe(502);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toEqual({
+      code: "AI_ITINERARY_INVALID_OUTPUT",
+      details: {
+        attempts: 2,
+        reason: "MODEL_OUTPUT_INVALID"
+      },
+      message: "AI itinerary generation returned invalid structured output."
+    });
+    expect(createResponse).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns a structured missing-key error when generation is invoked without OpenAI config", async () => {
+    const response = await request(createApp({ env: defaultApiEnv }))
+      .post("/api/itineraries/generate")
+      .send(validTripRequest);
+
+    expect(response.status).toBe(500);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toEqual({
+      code: "AI_PROVIDER_CONFIGURATION_ERROR",
+      details: {
+        reason: "PROVIDER_CONFIGURATION"
+      },
+      message: "AI itinerary generation is not configured."
+    });
+  });
+});
+
+function createItineraryTestApp(responses: Array<string | Error>) {
+  const pendingResponses = [...responses];
+  const createResponse = vi.fn<AiItineraryProvider["createResponse"]>(
+    async () => {
+      const response = pendingResponses.shift();
+
+      if (response instanceof Error) {
+        throw response;
+      }
+
+      if (response === undefined) {
+        throw new Error("No fake AI response configured.");
+      }
+
+      return {
+        model: "gpt-test-model",
+        text: response
+      };
+    }
+  );
+  const provider = {
+    createResponse
+  } satisfies AiItineraryProvider;
+  const aiItineraryService = new AiItineraryService({
+    providerFactory: () => provider
+  });
+
+  return {
+    app: createApp({
+      aiItineraryService,
+      env: defaultApiEnv
+    }),
+    createResponse
+  };
+}

--- a/apps/api/src/routes/itineraries.ts
+++ b/apps/api/src/routes/itineraries.ts
@@ -1,0 +1,34 @@
+import { Router, type RequestHandler } from "express";
+import {
+  tripRequestSchema,
+  type TripRequest
+} from "@japan-travel-planner/shared";
+
+import { validateRequest } from "../middleware/validateRequest.js";
+import type { AiItineraryService } from "../services/aiItinerary/generateItinerary.js";
+
+function asyncHandler(handler: RequestHandler): RequestHandler {
+  return (request, response, next) => {
+    Promise.resolve(handler(request, response, next)).catch(next);
+  };
+}
+
+export function createItinerariesRouter(
+  aiItineraryService: AiItineraryService
+) {
+  const router = Router();
+
+  router.post(
+    "/generate",
+    validateRequest(tripRequestSchema),
+    asyncHandler(async (request, response) => {
+      const result = await aiItineraryService.generateItinerary(
+        request.body as TripRequest
+      );
+
+      response.status(200).json(result);
+    })
+  );
+
+  return router;
+}

--- a/apps/api/src/services/aiItinerary/generateItinerary.test.ts
+++ b/apps/api/src/services/aiItinerary/generateItinerary.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  itinerarySchema,
+  type TripRequest
+} from "@japan-travel-planner/shared";
+
+import { defaultApiEnv } from "../../config/env.js";
+import { ApiError } from "../../errors/ApiError.js";
+import {
+  AiItineraryService,
+  createAiItineraryService,
+  type AiItineraryProvider
+} from "./generateItinerary.js";
+
+const representativeTripRequest = {
+  startDate: "2026-04-06",
+  endDate: "2026-04-07",
+  cities: ["Tokyo", "Kyoto"],
+  interests: ["temples", "local food"],
+  pace: "balanced",
+  budget: "moderate",
+  constraints: ["Vegetarian meals only"]
+} satisfies TripRequest;
+
+const validModelOutput = {
+  title: "Tokyo And Kyoto Highlights",
+  startDate: "2026-04-06",
+  endDate: "2026-04-07",
+  days: [
+    {
+      dayNumber: 1,
+      date: "2026-04-06",
+      city: "Tokyo",
+      summary: "Start with classic temple streets and local food.",
+      activities: [
+        {
+          title: "Senso-ji and Nakamise-dori",
+          category: "temple",
+          timing: {
+            startTime: "09:30",
+            endTime: "11:30",
+            timeOfDay: "morning"
+          },
+          durationMinutes: "120 minutes",
+          location: {
+            name: "Senso-ji",
+            city: "Tokyo"
+          },
+          costLevel: "free",
+          notes: "Arrive early and keep time flexible around the market street."
+        }
+      ]
+    },
+    {
+      dayNumber: 2,
+      date: "2026-04-07",
+      city: "Kyoto",
+      summary: "Transfer to Kyoto and keep the afternoon focused.",
+      activities: [
+        {
+          title: "Tokaido Shinkansen to Kyoto",
+          category: "transport",
+          timing: {
+            startTime: "08:30",
+            endTime: "10:50",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 140,
+          location: {
+            name: "Tokyo Station to Kyoto Station",
+            city: "Tokyo"
+          },
+          costLevel: "expensive",
+          notes: "Treat train timing as approximate and leave transfer buffer."
+        }
+      ]
+    }
+  ]
+};
+
+describe("AiItineraryService", () => {
+  test("returns a validated itinerary for valid model output", async () => {
+    const { createResponse, service } = createTestService([
+      JSON.stringify(validModelOutput)
+    ]);
+
+    const result = await service.generateItinerary(representativeTripRequest);
+
+    expect(itinerarySchema.safeParse(result.itinerary).success).toBe(true);
+    expect(result).toMatchObject({
+      metadata: {
+        attempts: 1,
+        estimatedCostUsd: null,
+        model: "gpt-test-model",
+        repaired: false,
+        tokenUsage: null
+      }
+    });
+    expect(result.itinerary.days[0]?.activities[0]).toMatchObject({
+      category: "culture",
+      durationMinutes: 120
+    });
+    expect(createResponse).toHaveBeenCalledTimes(1);
+    expect(createResponse.mock.calls[0]?.[0].input).toContain(
+      "Dates: 2026-04-06 to 2026-04-07"
+    );
+  });
+
+  test("repairs invalid first output once and returns the repaired itinerary", async () => {
+    const { createResponse, service } = createTestService([
+      "not valid json",
+      JSON.stringify(validModelOutput)
+    ]);
+
+    const result = await service.generateItinerary(representativeTripRequest);
+
+    expect(itinerarySchema.safeParse(result.itinerary).success).toBe(true);
+    expect(result.metadata).toMatchObject({
+      attempts: 2,
+      model: "gpt-test-model",
+      repaired: true
+    });
+    expect(createResponse).toHaveBeenCalledTimes(2);
+    expect(createResponse.mock.calls[1]?.[0].input).toContain(
+      "Validation errors:"
+    );
+    expect(createResponse.mock.calls[1]?.[0].input).toContain("modelOutput");
+    expect(createResponse.mock.calls[1]?.[0].instructions).toContain(
+      "Return corrected structured JSON only"
+    );
+  });
+
+  test("returns a structured generation failure after invalid output and invalid repair", async () => {
+    const { createResponse, service } = createTestService([
+      "not valid json",
+      JSON.stringify({
+        ...validModelOutput,
+        days: []
+      })
+    ]);
+
+    await expect(
+      service.generateItinerary(representativeTripRequest)
+    ).rejects.toMatchObject({
+      code: "AI_ITINERARY_INVALID_OUTPUT",
+      details: {
+        attempts: 2,
+        reason: "MODEL_OUTPUT_INVALID"
+      },
+      message: "AI itinerary generation returned invalid structured output.",
+      statusCode: 502
+    } satisfies Partial<ApiError>);
+    expect(createResponse).toHaveBeenCalledTimes(2);
+  });
+
+  test("maps provider failures to a safe structured error", async () => {
+    const { service } = createTestService([
+      new Error("secret provider detail")
+    ]);
+
+    await expect(
+      service.generateItinerary(representativeTripRequest)
+    ).rejects.toMatchObject({
+      code: "AI_PROVIDER_REQUEST_FAILED",
+      details: {
+        reason: "PROVIDER_FAILURE"
+      },
+      message: "AI itinerary provider request failed.",
+      statusCode: 502
+    } satisfies Partial<ApiError>);
+  });
+
+  test("fails clearly when generation is invoked without OPENAI_API_KEY", async () => {
+    const service = createAiItineraryService(defaultApiEnv);
+
+    await expect(
+      service.generateItinerary(representativeTripRequest)
+    ).rejects.toMatchObject({
+      code: "AI_PROVIDER_CONFIGURATION_ERROR",
+      details: {
+        reason: "PROVIDER_CONFIGURATION"
+      },
+      message: "AI itinerary generation is not configured.",
+      statusCode: 500
+    } satisfies Partial<ApiError>);
+  });
+});
+
+function createTestService(responses: Array<string | Error>): {
+  createResponse: ReturnType<
+    typeof vi.fn<AiItineraryProvider["createResponse"]>
+  >;
+  service: AiItineraryService;
+} {
+  const pendingResponses = [...responses];
+  const createResponse = vi.fn<AiItineraryProvider["createResponse"]>(
+    async () => {
+      const response = pendingResponses.shift();
+
+      if (response instanceof Error) {
+        throw response;
+      }
+
+      if (response === undefined) {
+        throw new Error("No fake AI response configured.");
+      }
+
+      return {
+        model: "gpt-test-model",
+        text: response
+      };
+    }
+  );
+  const provider = {
+    createResponse
+  } satisfies AiItineraryProvider;
+
+  return {
+    createResponse,
+    service: new AiItineraryService({
+      providerFactory: () => provider
+    })
+  };
+}

--- a/apps/api/src/services/aiItinerary/generateItinerary.ts
+++ b/apps/api/src/services/aiItinerary/generateItinerary.ts
@@ -1,0 +1,170 @@
+import type { Itinerary, TripRequest } from "@japan-travel-planner/shared";
+
+import { type ApiEnvConfig, loadApiEnv } from "../../config/env.js";
+import { ApiError } from "../../errors/ApiError.js";
+import {
+  createOpenAiProviderFromEnv,
+  type OpenAiTextRequest,
+  type OpenAiTextResult
+} from "../../providers/openai/openaiClient.js";
+import { OpenAiConfigurationError } from "../../providers/openai/openaiConfig.js";
+import { buildItineraryPrompt } from "./prompt.js";
+import { buildItineraryRepairPrompt } from "./repairItinerary.js";
+import {
+  AiItineraryOutputParseError,
+  parseAiItineraryOutput
+} from "./schema.js";
+
+export type AiItineraryProvider = {
+  createResponse: (request: OpenAiTextRequest) => Promise<OpenAiTextResult>;
+};
+
+export type AiItineraryGenerationMetadata = {
+  attempts: number;
+  repaired: boolean;
+  model: string;
+  tokenUsage: null;
+  estimatedCostUsd: null;
+};
+
+export type GenerateItineraryResult = {
+  itinerary: Itinerary;
+  metadata: AiItineraryGenerationMetadata;
+};
+
+type AiItineraryServiceOptions = {
+  providerFactory: () => AiItineraryProvider;
+};
+
+export class AiItineraryService {
+  constructor(private readonly options: AiItineraryServiceOptions) {}
+
+  async generateItinerary(
+    request: TripRequest
+  ): Promise<GenerateItineraryResult> {
+    const provider = this.createProvider();
+    const prompt = buildItineraryPrompt(request);
+    const firstResponse = await this.createProviderResponse(provider, {
+      instructions: prompt.instructions,
+      input: prompt.input
+    });
+
+    try {
+      return {
+        itinerary: parseAiItineraryOutput(firstResponse.text),
+        metadata: createGenerationMetadata({
+          attempts: 1,
+          model: firstResponse.model,
+          repaired: false
+        })
+      };
+    } catch (error) {
+      if (!(error instanceof AiItineraryOutputParseError)) {
+        throw error;
+      }
+
+      const repairPrompt = buildItineraryRepairPrompt({
+        originalPrompt: prompt,
+        invalidOutput: firstResponse.text,
+        parseError: error
+      });
+      const repairResponse = await this.createProviderResponse(provider, {
+        instructions: repairPrompt.instructions,
+        input: repairPrompt.input
+      });
+
+      try {
+        return {
+          itinerary: parseAiItineraryOutput(repairResponse.text),
+          metadata: createGenerationMetadata({
+            attempts: 2,
+            model: repairResponse.model,
+            repaired: true
+          })
+        };
+      } catch (repairError) {
+        if (repairError instanceof AiItineraryOutputParseError) {
+          throw new ApiError({
+            statusCode: 502,
+            code: "AI_ITINERARY_INVALID_OUTPUT",
+            message:
+              "AI itinerary generation returned invalid structured output.",
+            details: {
+              attempts: 2,
+              reason: "MODEL_OUTPUT_INVALID"
+            }
+          });
+        }
+
+        throw repairError;
+      }
+    }
+  }
+
+  private createProvider() {
+    try {
+      return this.options.providerFactory();
+    } catch (error) {
+      throw mapGenerationError(error);
+    }
+  }
+
+  private async createProviderResponse(
+    provider: AiItineraryProvider,
+    request: OpenAiTextRequest
+  ) {
+    try {
+      return await provider.createResponse(request);
+    } catch (error) {
+      throw mapGenerationError(error);
+    }
+  }
+}
+
+export function createAiItineraryService(
+  env: ApiEnvConfig = loadApiEnv()
+): AiItineraryService {
+  return new AiItineraryService({
+    providerFactory: () => createOpenAiProviderFromEnv(env)
+  });
+}
+
+function createGenerationMetadata(options: {
+  attempts: number;
+  repaired: boolean;
+  model: string;
+}): AiItineraryGenerationMetadata {
+  return {
+    attempts: options.attempts,
+    repaired: options.repaired,
+    model: options.model,
+    tokenUsage: null,
+    estimatedCostUsd: null
+  };
+}
+
+function mapGenerationError(error: unknown): ApiError {
+  if (error instanceof ApiError) {
+    return error;
+  }
+
+  if (error instanceof OpenAiConfigurationError) {
+    return new ApiError({
+      statusCode: 500,
+      code: "AI_PROVIDER_CONFIGURATION_ERROR",
+      message: "AI itinerary generation is not configured.",
+      details: {
+        reason: "PROVIDER_CONFIGURATION"
+      }
+    });
+  }
+
+  return new ApiError({
+    statusCode: 502,
+    code: "AI_PROVIDER_REQUEST_FAILED",
+    message: "AI itinerary provider request failed.",
+    details: {
+      reason: "PROVIDER_FAILURE"
+    }
+  });
+}

--- a/apps/api/src/services/aiItinerary/repairItinerary.ts
+++ b/apps/api/src/services/aiItinerary/repairItinerary.ts
@@ -1,0 +1,55 @@
+import type { ItineraryPrompt } from "./prompt.js";
+import type { AiItineraryOutputParseError } from "./schema.js";
+
+export type ItineraryRepairPrompt = {
+  instructions: string;
+  input: string;
+};
+
+const maxInvalidOutputLength = 6000;
+
+export function buildItineraryRepairPrompt(options: {
+  originalPrompt: ItineraryPrompt;
+  invalidOutput: string;
+  parseError: AiItineraryOutputParseError;
+}): ItineraryRepairPrompt {
+  return {
+    instructions: [
+      "You are repairing a Japan Travel Planner AI itinerary JSON response.",
+      "Return corrected structured JSON only. Do not include Markdown, commentary, citations, or prose outside the JSON object.",
+      "Preserve the traveler request and planning rules from the original prompt.",
+      "Fix only the structural/schema issues described in the validation errors."
+    ].join("\n"),
+    input: [
+      "The previous model output could not be parsed into the required itinerary schema.",
+      "",
+      "Validation errors:",
+      formatParseErrors(options.parseError),
+      "",
+      "Original prompt instructions:",
+      options.originalPrompt.instructions,
+      "",
+      "Original trip request and output contract:",
+      options.originalPrompt.input,
+      "",
+      "Invalid model output to repair:",
+      truncateInvalidOutput(options.invalidOutput),
+      "",
+      "Return exactly one corrected JSON object that satisfies the original output contract."
+    ].join("\n")
+  };
+}
+
+function formatParseErrors(error: AiItineraryOutputParseError) {
+  return error.fieldErrors
+    .map((fieldError) => `- ${fieldError.path}: ${fieldError.message}`)
+    .join("\n");
+}
+
+function truncateInvalidOutput(output: string) {
+  if (output.length <= maxInvalidOutputLength) {
+    return output;
+  }
+
+  return `${output.slice(0, maxInvalidOutputLength)}\n[truncated]`;
+}


### PR DESCRIPTION
## Ticket scope

Implements T-021 / Ticket 21: backend-only `POST /api/itineraries/generate` for AI itinerary generation.

This PR does not connect the web app to AI generation, does not modify web files, does not change Trip CRUD behavior, does not change Prisma schema or migrations, does not add maps/weather/hotel/transit integrations, and does not add database-backed AI usage logging or rate limiting.

## Changes made

- Added `apps/api/src/routes/itineraries.ts` with `POST /api/itineraries/generate`.
- Mounted the itinerary router in `apps/api/src/app.ts` with test injection support for `AiItineraryService`.
- Added `apps/api/src/services/aiItinerary/generateItinerary.ts` for prompt construction, provider invocation, parsing, repair retry, safe error mapping, and response metadata.
- Added `apps/api/src/services/aiItinerary/repairItinerary.ts` for deterministic repair prompts.
- Added route and service tests with mocked AI provider responses.

## Endpoint behavior

- Accepts a shared `TripRequest` body.
- Uses existing `validateRequest` middleware and `tripRequestSchema` for request validation.
- Builds the deterministic Ticket 20 itinerary prompt.
- Calls the backend-only Ticket 19 OpenAI provider wrapper through `AiItineraryService`.
- Parses model text through the Ticket 20 structured output parser.
- Returns `{ itinerary, metadata }` when parsing succeeds.

## AI generation service structure

- `AiItineraryService` depends on an injected provider factory for testability.
- Production construction uses `createOpenAiProviderFromEnv(env)` lazily when generation is invoked.
- Tests inject fake providers, so automated tests do not make real OpenAI calls.

## Retry/repair behavior

- The service attempts the initial model response once.
- If parsing fails, it builds one deterministic repair prompt containing a validation-error summary and the invalid model output, then calls the provider one more time.
- If repaired output parses, the endpoint returns the validated itinerary with `metadata.repaired: true` and `metadata.attempts: 2`.
- If repair fails, the endpoint returns a safe structured `AI_ITINERARY_INVALID_OUTPUT` error.

## Error handling behavior

- Invalid request body: `400 VALIDATION_ERROR` through existing middleware.
- Missing OpenAI config when generation is invoked: `500 AI_PROVIDER_CONFIGURATION_ERROR`.
- Provider/network/model request failure: `502 AI_PROVIDER_REQUEST_FAILED`.
- Invalid model output after repair: `502 AI_ITINERARY_INVALID_OUTPUT`.
- Production API errors do not expose API keys, raw prompts, raw model responses, stack traces, or provider exception details.
- Error responses remain compatible with the shared API error schema.

## Metadata handling

- Response metadata currently includes `attempts`, `repaired`, `model`, `tokenUsage: null`, and `estimatedCostUsd: null`.
- Token/cost values are placeholders because the current OpenAI wrapper does not expose usage metadata yet.
- No prompts or raw model responses are stored in a database.

## Mocking/testing strategy

- Service tests inject mocked `AiItineraryProvider` implementations.
- Route tests create an app with injected `AiItineraryService` for success and invalid-output paths.
- Missing-key route behavior uses `defaultApiEnv` with no `OPENAI_API_KEY`, proving the endpoint fails clearly without attempting a real generation call.

## Tests added/updated

- `apps/api/src/services/aiItinerary/generateItinerary.test.ts`
- `apps/api/src/routes/itineraries.test.ts`

Coverage includes valid mocked generation, invalid request validation, invalid first output then repair success, invalid output plus invalid repair, provider failure, missing OpenAI config, shared itinerary validation, and existing health/Trip CRUD regression through the full API suite.

## Checks run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec vitest run src/services/aiItinerary/generateItinerary.test.ts src/routes/itineraries.test.ts --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `git diff --check`

## Manual checks run

- Started the API with `env -u OPENAI_API_KEY pnpm dev:api`.
- Confirmed `GET http://localhost:3001/api/health` returns HTTP 200 and `{ "status": "ok", "service": "japan-travel-planner-api" }`.
- Confirmed `POST http://localhost:3001/api/itineraries/generate` with a valid trip request and no OpenAI key returns HTTP 500 structured `AI_PROVIDER_CONFIGURATION_ERROR`.
- Confirmed no web files were modified.
- Confirmed no Ticket 22 web AI integration was started.
- Confirmed no database usage logging or rate limiting was added.

## Real OpenAI calls

No real OpenAI API call was made.

## Known risks

- Model-output ambiguity remains: the parser fails closed after one repair attempt if the model still does not satisfy the structured contract.
- Token/cost metadata is currently a safe placeholder until the provider wrapper exposes usage data.
- Local Prisma-generating commands can collide if run concurrently, so validation commands were run sequentially.
- No local runner stalls were observed.

## Ticket 22+ confirmation

Ticket 22 and later tickets were not started.
