### PR TITLE
T-022 Connect web intake to AI generation

### DIFF
--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -72,3 +72,167 @@ test("traveler can plan and edit a mock itinerary", async ({ page }) => {
     "Gion and Shirakawa evening walk"
   ]);
 });
+
+test("traveler can generate and edit an itinerary from a mocked AI API response", async ({
+  page
+}) => {
+  await page.route("**/api/itineraries/generate", async (route) => {
+    const corsHeaders = {
+      "access-control-allow-credentials": "true",
+      "access-control-allow-headers": "content-type",
+      "access-control-allow-methods": "POST, OPTIONS",
+      "access-control-allow-origin": "http://127.0.0.1:5173"
+    };
+
+    if (route.request().method() === "OPTIONS") {
+      await route.fulfill({
+        headers: corsHeaders,
+        status: 204
+      });
+      return;
+    }
+
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().postDataJSON()).toMatchObject({
+      cities: ["Tokyo", "Kyoto"],
+      pace: "balanced"
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    await route.fulfill({
+      contentType: "application/json",
+      headers: corsHeaders,
+      json: {
+        itinerary: {
+          title: "AI Generated Tokyo And Kyoto Route",
+          startDate: "2026-04-06",
+          endDate: "2026-04-07",
+          days: [
+            {
+              date: "2026-04-06",
+              city: "Tokyo",
+              summary: "Generated Tokyo day with temples and local food.",
+              activities: [
+                {
+                  id: "generated-sensoji",
+                  title: "Generated Senso-ji morning",
+                  category: "culture",
+                  timing: {
+                    startTime: "09:00",
+                    endTime: "11:00",
+                    timeOfDay: "morning"
+                  },
+                  durationMinutes: 120,
+                  location: {
+                    name: "Senso-ji",
+                    city: "Tokyo"
+                  },
+                  costLevel: "free",
+                  notes: "Generated note with flexible temple timing."
+                },
+                {
+                  id: "generated-lunch",
+                  title: "Generated Asakusa lunch",
+                  category: "food",
+                  timing: {
+                    startTime: "12:00",
+                    endTime: "13:00",
+                    timeOfDay: "afternoon"
+                  },
+                  durationMinutes: 60,
+                  location: {
+                    name: "Asakusa",
+                    city: "Tokyo"
+                  },
+                  costLevel: "medium",
+                  notes:
+                    "Generated lunch stop with vegetarian-friendly options."
+                }
+              ]
+            },
+            {
+              date: "2026-04-07",
+              city: "Kyoto",
+              summary: "Generated Kyoto transfer day.",
+              activities: [
+                {
+                  id: "generated-transfer",
+                  title: "Generated Shinkansen transfer",
+                  category: "transit",
+                  timing: {
+                    startTime: "08:30",
+                    endTime: "10:50",
+                    timeOfDay: "morning"
+                  },
+                  durationMinutes: 140,
+                  location: {
+                    name: "Tokyo Station to Kyoto Station",
+                    city: "Tokyo"
+                  },
+                  costLevel: "high",
+                  notes: "Generated transfer note with station buffer."
+                }
+              ]
+            }
+          ]
+        },
+        metadata: {
+          attempts: 1,
+          estimatedCostUsd: null,
+          model: "gpt-test-model",
+          repaired: false,
+          tokenUsage: null
+        }
+      },
+      status: 200
+    });
+  });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "API" }).click();
+
+  await page.getByLabel("Start date").fill("2026-04-06");
+  await page.getByLabel("End date").fill("2026-04-07");
+  await page.getByLabel("Cities").fill("Tokyo, Kyoto");
+  await page.getByLabel("Interests").fill("temples, local food");
+  await page.getByLabel("Travel pace").selectOption("balanced");
+  await page.getByLabel("Budget").selectOption("moderate");
+  await page.getByLabel("Constraints").fill("Vegetarian meals only.");
+
+  await page.getByRole("button", { name: "Generate AI itinerary" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Preparing itinerary" })
+  ).toBeVisible();
+  await expect(
+    page
+      .getByLabel("Shell status")
+      .getByText("AI Generated Tokyo And Kyoto Route")
+  ).toBeVisible();
+
+  const dayOne = page.getByRole("region", { name: "Day 1: Tokyo" });
+  await expect(
+    dayOne.getByRole("heading", { name: "Generated Senso-ji morning" })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Save itinerary" })
+  ).toBeEnabled();
+
+  await page
+    .getByRole("button", { name: "Edit Generated Senso-ji morning" })
+    .click();
+
+  const dialog = page.getByRole("dialog", {
+    name: "Edit Generated Senso-ji morning"
+  });
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByLabel("Title").fill("Edited generated Senso-ji morning");
+  await dialog.getByRole("button", { name: "Save activity" }).click();
+
+  await expect(
+    dayOne.getByRole("heading", { name: "Edited generated Senso-ji morning" })
+  ).toBeVisible();
+  await expect(page.getByText("Unsaved local edits")).toBeVisible();
+});

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -10,7 +10,7 @@ describe("App", () => {
     expect(html).toContain("Japan Travel Planner");
     expect(html).toContain("Japan trip planner");
     expect(html).toContain("Plan your Japan route");
-    expect(html).toContain("Create saved itinerary");
+    expect(html).toContain("Generate AI itinerary");
     expect(html).toContain("Use mock preview");
     expect(html).toContain("Save and reopen");
     expect(html).toContain("Refresh saved trips");

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,7 @@ import {
   cloneItinerary,
   useItineraryEditor
 } from "./features/itinerary/editing/useItineraryEditor.js";
+import { useGeneratedItinerary } from "./features/itinerary/useGeneratedItinerary.js";
 import { TripIntakeForm } from "./features/trip-intake/index.js";
 import {
   getDefaultTripDataMode,
@@ -36,20 +37,28 @@ export function App() {
   );
   const [localError, setLocalError] = useState<string | null>(null);
   const [isMockSubmitting, setIsMockSubmitting] = useState(false);
+  const generatedItinerary = useGeneratedItinerary();
   const itineraryEditor = useItineraryEditor(null);
   const itinerary = itineraryEditor.itinerary;
   const trips = useTrips();
   const apiBusy = isApiBusy(trips.status);
+  const isGenerating = generatedItinerary.status === "generating";
   const isSubmitting =
     isMockSubmitting ||
+    isGenerating ||
     trips.status === "creating" ||
     trips.status === "saving";
-  const storageMessage = localError ?? trips.errorMessage;
+  const storageMessage =
+    localError ?? generatedItinerary.errorMessage ?? trips.errorMessage;
 
   const workspacePanels = [
     {
       title: "Trip setup",
-      status: isSubmitting ? "Submitting" : "Ready",
+      status: isGenerating
+        ? "Generating"
+        : isSubmitting
+          ? "Submitting"
+          : "Ready",
       detail: "Dates, cities, pace, budget, and interests"
     },
     {
@@ -83,8 +92,10 @@ export function App() {
     setActiveRequest(request);
     setLocalError(null);
     trips.clearError();
+    generatedItinerary.clearError();
     setIsMockSubmitting(true);
     itineraryEditor.resetItinerary(null);
+    trips.selectTrip(null);
 
     setTimeout(() => {
       resetToItinerary(mockItinerary);
@@ -100,15 +111,15 @@ export function App() {
 
     setActiveRequest(request);
     setLocalError(null);
+    trips.clearError();
+    generatedItinerary.clearError();
     resetToItinerary(null);
+    trips.selectTrip(null);
 
-    const result = await trips.createTripFromRequest(
-      request,
-      cloneItinerary(mockItinerary)
-    );
+    const result = await generatedItinerary.generateItinerary(request);
 
     if (result) {
-      setActiveRequest(result.request);
+      setActiveRequest(request);
       resetToItinerary(result.itinerary);
     }
   }
@@ -125,6 +136,7 @@ export function App() {
     }
 
     setLocalError(null);
+    generatedItinerary.clearError();
 
     const result = await trips.saveTrip(
       trips.selectedTripId,
@@ -145,6 +157,7 @@ export function App() {
     }
 
     setLocalError(null);
+    generatedItinerary.clearError();
 
     const result = await trips.reopenTrip(trips.selectedTripId);
 
@@ -156,6 +169,7 @@ export function App() {
 
   async function handleLoadSavedTrips() {
     setLocalError(null);
+    generatedItinerary.clearError();
     await trips.loadSavedTrips();
   }
 
@@ -163,6 +177,7 @@ export function App() {
     setDataMode(nextMode);
     setLocalError(null);
     trips.clearError();
+    generatedItinerary.clearError();
   }
 
   return (
@@ -235,7 +250,7 @@ export function App() {
               onSubmitTrip={handleTripSubmit}
               submitLabel={
                 dataMode === "api"
-                  ? "Create saved itinerary"
+                  ? "Generate AI itinerary"
                   : "Generate mock itinerary"
               }
               {...(dataMode === "api"
@@ -273,15 +288,19 @@ export function App() {
               </div>
 
               <p className="storage-status" role="status">
-                {apiBusy
-                  ? "Working"
-                  : trips.status === "saved"
-                    ? "Saved"
-                    : itineraryEditor.isDirty
-                      ? "Local edits pending"
-                      : dataMode === "mock"
-                        ? "Mock mode"
-                        : "Ready"}
+                {isGenerating
+                  ? "Generating itinerary"
+                  : generatedItinerary.status === "error"
+                    ? "Generation needs retry"
+                    : apiBusy
+                      ? "Working"
+                      : trips.status === "saved"
+                        ? "Saved"
+                        : itineraryEditor.isDirty
+                          ? "Local edits pending"
+                          : dataMode === "mock"
+                            ? "Mock mode"
+                            : "Ready"}
               </p>
 
               {storageMessage ? (

--- a/apps/web/src/features/itinerary/useGeneratedItinerary.test.ts
+++ b/apps/web/src/features/itinerary/useGeneratedItinerary.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { TripApiClientError } from "../../lib/api/client.js";
+import { mockItinerary, mockTripRequest } from "../../mocks/index.js";
+import {
+  createItineraryEditorState,
+  itineraryEditorReducer
+} from "./editing/useItineraryEditor.js";
+import {
+  generateTripItinerary,
+  getGenerateItineraryErrorMessage
+} from "./useGeneratedItinerary.js";
+
+function createGeneratedResponse() {
+  return {
+    itinerary: mockItinerary,
+    metadata: {
+      attempts: 1,
+      estimatedCostUsd: null,
+      model: "gpt-test-model",
+      repaired: false,
+      tokenUsage: null
+    }
+  };
+}
+
+describe("generateTripItinerary", () => {
+  test("returns a generated itinerary from the API client", async () => {
+    const response = createGeneratedResponse();
+    const client = {
+      generateItinerary: vi.fn(async () => response)
+    };
+
+    await expect(
+      generateTripItinerary(client, mockTripRequest)
+    ).resolves.toEqual(response);
+    expect(client.generateItinerary).toHaveBeenCalledWith(mockTripRequest);
+  });
+
+  test("can retry generation after a failure", async () => {
+    const response = createGeneratedResponse();
+    const client = {
+      generateItinerary: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new TripApiClientError({
+            code: "AI_PROVIDER_REQUEST_FAILED",
+            message: "AI itinerary provider request failed.",
+            status: 502
+          })
+        )
+        .mockResolvedValueOnce(response)
+    };
+
+    await expect(
+      generateTripItinerary(client, mockTripRequest)
+    ).rejects.toThrow("AI itinerary provider request failed.");
+    await expect(
+      generateTripItinerary(client, mockTripRequest)
+    ).resolves.toEqual(response);
+    expect(client.generateItinerary).toHaveBeenCalledTimes(2);
+  });
+
+  test("generated itineraries remain editable after loading into editor state", async () => {
+    const response = createGeneratedResponse();
+    const client = {
+      generateItinerary: vi.fn(async () => response)
+    };
+    const generated = await generateTripItinerary(client, mockTripRequest);
+    const cleanState = createItineraryEditorState(generated.itinerary);
+    const firstActivity = cleanState.itinerary?.days[0]?.activities[0];
+
+    if (!firstActivity?.id) {
+      throw new Error("Expected generated itinerary to receive activity ids.");
+    }
+
+    const dirtyState = itineraryEditorReducer(cleanState, {
+      type: "updateActivity",
+      dayDate: "2026-04-06",
+      activityId: firstActivity.id,
+      activity: {
+        ...firstActivity,
+        title: "Generated activity edited in the browser"
+      }
+    });
+
+    expect(cleanState.isDirty).toBe(false);
+    expect(dirtyState.isDirty).toBe(true);
+    expect(dirtyState.itinerary?.days[0]?.activities[0]?.title).toBe(
+      "Generated activity edited in the browser"
+    );
+  });
+});
+
+describe("getGenerateItineraryErrorMessage", () => {
+  test("maps provider configuration errors to recoverable UI copy", () => {
+    expect(
+      getGenerateItineraryErrorMessage(
+        new TripApiClientError({
+          code: "AI_PROVIDER_CONFIGURATION_ERROR",
+          message: "AI itinerary generation is not configured.",
+          status: 500
+        })
+      )
+    ).toBe(
+      "AI itinerary generation is not configured on the API server. Add the server OpenAI key or use mock preview."
+    );
+  });
+
+  test("maps provider failure and invalid output errors", () => {
+    expect(
+      getGenerateItineraryErrorMessage(
+        new TripApiClientError({
+          code: "AI_PROVIDER_REQUEST_FAILED",
+          message: "AI itinerary provider request failed.",
+          status: 502
+        })
+      )
+    ).toBe(
+      "AI itinerary generation is unavailable right now. Try again or use mock preview."
+    );
+    expect(
+      getGenerateItineraryErrorMessage(
+        new TripApiClientError({
+          code: "AI_ITINERARY_INVALID_OUTPUT",
+          message:
+            "AI itinerary generation returned invalid structured output.",
+          status: 502
+        })
+      )
+    ).toBe(
+      "AI returned an itinerary the app could not use. Try again or use mock preview."
+    );
+  });
+
+  test("maps unreachable API and validation errors", () => {
+    expect(
+      getGenerateItineraryErrorMessage(
+        new TripApiClientError({
+          code: "TRIP_API_UNAVAILABLE",
+          message: "Could not reach the trip API at http://localhost:3001."
+        })
+      )
+    ).toBe(
+      "Could not reach the itinerary generation API. Make sure the API server is running, then try again."
+    );
+    expect(
+      getGenerateItineraryErrorMessage(
+        new TripApiClientError({
+          code: "VALIDATION_ERROR",
+          fieldErrors: [
+            {
+              message: "Add at least one city.",
+              path: "cities"
+            }
+          ],
+          message: "Request validation failed.",
+          status: 400
+        })
+      )
+    ).toBe("Request validation failed. cities: Add at least one city.");
+  });
+});

--- a/apps/web/src/features/itinerary/useGeneratedItinerary.ts
+++ b/apps/web/src/features/itinerary/useGeneratedItinerary.ts
@@ -1,0 +1,91 @@
+import { useMemo, useState } from "react";
+
+import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
+import {
+  createTripApiClient,
+  TripApiClientError,
+  type TripApiClient
+} from "../../lib/api/client.js";
+import type { GenerateItineraryResponse } from "../../lib/api/types.js";
+
+export type GenerateItineraryStatus =
+  | "error"
+  | "generated"
+  | "generating"
+  | "idle";
+
+export function getGenerateItineraryErrorMessage(error: unknown) {
+  if (error instanceof TripApiClientError) {
+    if (error.code === "TRIP_API_UNAVAILABLE") {
+      return "Could not reach the itinerary generation API. Make sure the API server is running, then try again.";
+    }
+
+    if (error.code === "AI_PROVIDER_CONFIGURATION_ERROR") {
+      return "AI itinerary generation is not configured on the API server. Add the server OpenAI key or use mock preview.";
+    }
+
+    if (error.code === "AI_PROVIDER_REQUEST_FAILED") {
+      return "AI itinerary generation is unavailable right now. Try again or use mock preview.";
+    }
+
+    if (error.code === "AI_ITINERARY_INVALID_OUTPUT") {
+      return "AI returned an itinerary the app could not use. Try again or use mock preview.";
+    }
+
+    if (error.code === "VALIDATION_ERROR") {
+      const fieldErrorSummary =
+        error.fieldErrors && error.fieldErrors.length > 0
+          ? ` ${error.fieldErrors
+              .map((fieldError) => `${fieldError.path}: ${fieldError.message}`)
+              .join(" ")}`
+          : "";
+
+      return `${error.message}${fieldErrorSummary}`;
+    }
+
+    return error.message;
+  }
+
+  return "AI itinerary generation is unavailable right now. Try again or use mock preview.";
+}
+
+export async function generateTripItinerary(
+  client: Pick<TripApiClient, "generateItinerary">,
+  request: TripRequest
+): Promise<GenerateItineraryResponse> {
+  return client.generateItinerary(request);
+}
+
+export function useGeneratedItinerary(
+  options: { client?: Pick<TripApiClient, "generateItinerary"> } = {}
+) {
+  const defaultClient = useMemo(() => createTripApiClient(), []);
+  const client = options.client ?? defaultClient;
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [status, setStatus] = useState<GenerateItineraryStatus>("idle");
+
+  return {
+    clearError: () => {
+      setErrorMessage(null);
+      setStatus((currentStatus) =>
+        currentStatus === "error" ? "idle" : currentStatus
+      );
+    },
+    errorMessage,
+    generateItinerary: async (request: TripRequest) => {
+      setStatus("generating");
+      setErrorMessage(null);
+
+      try {
+        const result = await generateTripItinerary(client, request);
+        setStatus("generated");
+        return result;
+      } catch (error) {
+        setErrorMessage(getGenerateItineraryErrorMessage(error));
+        setStatus("error");
+        return null;
+      }
+    },
+    status
+  };
+}

--- a/apps/web/src/features/trips/useTrips.test.ts
+++ b/apps/web/src/features/trips/useTrips.test.ts
@@ -41,6 +41,16 @@ function createTripRecord(overrides: Partial<TripRecord> = {}): TripRecord {
 function createMockClient(trip = createTripRecord()): TripApiClient {
   return {
     createTrip: vi.fn(async () => trip),
+    generateItinerary: vi.fn(async () => ({
+      itinerary: mockItinerary,
+      metadata: {
+        attempts: 1,
+        estimatedCostUsd: null,
+        model: "gpt-test-model",
+        repaired: false,
+        tokenUsage: null
+      }
+    })),
     getTrip: vi.fn(async () => trip),
     listTrips: vi.fn(async () => [trip]),
     updateTrip: vi.fn(async () => trip)

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -125,6 +125,58 @@ describe("createTripApiClient", () => {
     ).toBe(true);
   });
 
+  test("generates itineraries with included anonymous session credentials", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        void _input;
+        void _init;
+        return jsonResponse({
+          itinerary: mockItinerary,
+          metadata: {
+            attempts: 1,
+            estimatedCostUsd: null,
+            model: "gpt-test-model",
+            repaired: false,
+            tokenUsage: null
+          }
+        });
+      }
+    );
+    const client = createTripApiClient({
+      baseUrl: "http://localhost:3001",
+      fetch: fetchMock
+    });
+
+    const response = await client.generateItinerary(mockTripRequest);
+    const firstCall = fetchMock.mock.calls[0];
+
+    if (!firstCall) {
+      throw new Error("Expected fetch to be called");
+    }
+
+    const [url, init] = firstCall;
+
+    expect(response).toEqual({
+      itinerary: mockItinerary,
+      metadata: {
+        attempts: 1,
+        estimatedCostUsd: null,
+        model: "gpt-test-model",
+        repaired: false,
+        tokenUsage: null
+      }
+    });
+    expect(url).toBe("http://localhost:3001/api/itineraries/generate");
+    expect(init).toMatchObject({
+      credentials: "include",
+      method: "POST"
+    });
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      cities: mockTripRequest.cities,
+      interests: mockTripRequest.interests
+    });
+  });
+
   test("parses structured API errors for UI display", async () => {
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL, _init?: RequestInit) => {
@@ -166,6 +218,44 @@ describe("createTripApiClient", () => {
       ],
       message: "Request validation failed.",
       status: 400
+    });
+  });
+
+  test("parses structured generation API errors for UI display", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        void _input;
+        void _init;
+        return jsonResponse(
+          {
+            error: {
+              code: "AI_PROVIDER_CONFIGURATION_ERROR",
+              details: {
+                reason: "PROVIDER_CONFIGURATION"
+              },
+              message: "AI itinerary generation is not configured."
+            }
+          },
+          {
+            status: 500
+          }
+        );
+      }
+    );
+    const client = createTripApiClient({
+      baseUrl: "http://localhost:3001",
+      fetch: fetchMock
+    });
+
+    await expect(
+      client.generateItinerary(mockTripRequest)
+    ).rejects.toMatchObject({
+      code: "AI_PROVIDER_CONFIGURATION_ERROR",
+      details: {
+        reason: "PROVIDER_CONFIGURATION"
+      },
+      message: "AI itinerary generation is not configured.",
+      status: 500
     });
   });
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -2,7 +2,12 @@ import {
   apiErrorSchema,
   type ApiFieldError
 } from "../../../../../packages/shared/src/schemas/apiError.js";
-import type { TripRecord, TripWritePayload } from "./types.js";
+import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
+import type {
+  GenerateItineraryResponse,
+  TripRecord,
+  TripWritePayload
+} from "./types.js";
 
 export type TripApiClientOptions = {
   baseUrl?: string;
@@ -11,6 +16,7 @@ export type TripApiClientOptions = {
 
 export type TripApiClientErrorOptions = {
   code: string;
+  details?: unknown;
   fieldErrors?: ApiFieldError[] | undefined;
   message: string;
   status?: number | undefined;
@@ -18,6 +24,7 @@ export type TripApiClientErrorOptions = {
 
 export class TripApiClientError extends Error {
   readonly code: string;
+  readonly details: unknown;
   readonly fieldErrors: ApiFieldError[] | undefined;
   readonly status: number | undefined;
 
@@ -25,6 +32,7 @@ export class TripApiClientError extends Error {
     super(options.message);
     this.name = "TripApiClientError";
     this.code = options.code;
+    this.details = options.details;
     this.fieldErrors = options.fieldErrors;
     this.status = options.status;
   }
@@ -32,6 +40,9 @@ export class TripApiClientError extends Error {
 
 export type TripApiClient = {
   createTrip: (payload: TripWritePayload) => Promise<TripRecord>;
+  generateItinerary: (
+    payload: TripRequest
+  ) => Promise<GenerateItineraryResponse>;
   getTrip: (tripId: string) => Promise<TripRecord>;
   listTrips: () => Promise<TripRecord[]>;
   updateTrip: (
@@ -68,6 +79,7 @@ function createApiError(response: Response, body: unknown) {
   if (parsedError.success) {
     return new TripApiClientError({
       code: parsedError.data.error.code,
+      details: parsedError.data.error.details,
       message: parsedError.data.error.message,
       status: response.status,
       ...(parsedError.data.error.fieldErrors !== undefined
@@ -133,6 +145,16 @@ export function createTripApiClient(
       });
 
       return response.trip;
+    },
+
+    async generateItinerary(payload) {
+      return requestJson<GenerateItineraryResponse>(
+        "/api/itineraries/generate",
+        {
+          body: JSON.stringify(payload),
+          method: "POST"
+        }
+      );
     },
 
     async getTrip(tripId) {

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -5,6 +5,19 @@ import type {
 } from "../../../../../packages/shared/src/schemas/itinerary.js";
 import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
 
+export type GenerateItineraryMetadata = {
+  attempts: number;
+  repaired: boolean;
+  model: string;
+  tokenUsage: null;
+  estimatedCostUsd: null;
+};
+
+export type GenerateItineraryResponse = {
+  itinerary: Itinerary;
+  metadata: GenerateItineraryMetadata;
+};
+
 export type TripActivityRecord = Activity & {
   id: string;
 };


### PR DESCRIPTION
## Ticket scope

Implement T-022 / Ticket 22: Connect Web Intake To AI Generation.

This PR connects the existing web intake form's API mode to the backend `POST /api/itineraries/generate` endpoint, loads the generated itinerary into the existing editable itinerary board, and keeps the existing mock preview, local editing, and save/reopen surfaces intact.

## Changes made

- Added a web generation hook for API generation status, success, retryable error messaging, and API-client delegation.
- Updated API mode submit behavior from saved mock creation to AI itinerary generation.
- Preserved mock-mode submission and the API-mode `Use mock preview` fallback.
- Reset selected saved trip state when starting a new generated/mock preview so later saves create the correct trip record.
- Kept generated/mock itineraries flowing through the existing itinerary editor so local edits and dirty state still work.
- Updated the app shell copy from `Create saved itinerary` to `Generate AI itinerary` in API mode.

## Web generation flow

- API mode form submit calls `generateItinerary(request)`.
- While the request is pending, the app displays generation/submitting state through the existing itinerary loading UI.
- On success, the generated itinerary is loaded into `useItineraryEditor` and becomes editable.
- On failure, the UI shows a recoverable message and leaves `Use mock preview` available.
- Clearing generation errors also clears the retry status before mock fallback or other storage actions.

## API client changes

- Added `TripApiClient.generateItinerary(payload)` for `POST /api/itineraries/generate`.
- Added typed `GenerateItineraryResponse` / metadata shape matching the current API response.
- Preserved `credentials: "include"` behavior for anonymous session compatibility.
- Preserved structured API error parsing, including generation `details`.

## Loading/error/retry behavior

- Loading: `Generating itinerary` status and existing itinerary loading view while generation is pending.
- Error: provider config, provider failure, invalid output, validation, and API-unavailable errors map to user-facing retry/fallback copy.
- Retry: submitting again calls the same generation flow; mock preview remains available after errors.

## Mock mode strategy

- Existing mock mode remains fully local and unchanged.
- In API mode, `Use mock preview` remains available as a fallback and loads the existing mock itinerary into editable local state.
- The E2E suite still covers the original mock planning/editing path.

## Editing compatibility

- Generated itineraries are loaded into the existing itinerary editor state.
- Added tests proving generated itinerary data remains editable and marks the board dirty.
- Added E2E coverage for generated itinerary display and activity editing from a mocked AI API response.

## Save/reopen compatibility

- Existing trip storage UI remains present in API mode.
- Save and refresh controls are enabled after a mock fallback itinerary is loaded in API mode.
- Existing root/web/API tests continue to cover trip save/reopen helpers and API storage behavior.

## Tests added/updated

- Added generation hook tests for success, retry after failure, editable generated itinerary state, and error-message mapping.
- Added API client tests for itinerary generation and structured generation errors.
- Updated app smoke test for API submit label copy.
- Updated trip test client mocks to include `generateItinerary`.
- Added Playwright E2E coverage for mocked AI generation and editing.

## Checks run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit`
- `pnpm --filter @japan-travel-planner/web exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/web exec vite build`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `git diff --check`
- `git diff --cached --check`

## Manual checks run

- Started API without `OPENAI_API_KEY` using `env -u OPENAI_API_KEY pnpm dev:api`.
- Started web in API mode using `VITE_TRIP_DATA_MODE=api pnpm dev:web`.
- Opened `http://localhost:5173`.
- Confirmed initial empty itinerary state.
- Submitted a valid trip request in API mode.
- Confirmed no-key server configuration error appears and retry status is shown.
- Confirmed `Use mock preview` fallback loads the mock itinerary.
- Confirmed activity editing works after fallback and dirty state appears.
- Confirmed save and refresh saved trip controls are enabled after fallback in API mode.
- Confirmed no horizontal overflow at 390px width.

## Real OpenAI call made

No. Local manual validation intentionally ran the API without `OPENAI_API_KEY`, so no real OpenAI request was made.

## Known risks

- Real model output variability is not exercised locally in this PR; backend validation/repair and API tests remain the guard for model output shape.
- Local manual check used the documented `http://localhost:5173` origin because the API CORS config allows that origin by default.
- No local runner stalls were observed in this pass.

## Ticket boundary confirmation

Ticket 23 and later were not started. This PR does not add itinerary export/share behavior, new API routes, persistence changes, database changes, AI provider changes, shared schema changes, or server-side key exposure to the web app.
