### PR TITLE
T-023 Add AI usage logging and guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-5.5
+AI_GENERATION_RATE_LIMIT_WINDOW_MS=60000
+AI_GENERATION_RATE_LIMIT_MAX=5
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/japan_travel_planner_ai?schema=public
 GOOGLE_MAPS_API_KEY=
 WEATHER_API_KEY=

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import express, { type RequestHandler } from "express";
 
 import { loadApiEnv, type ApiEnvConfig } from "./config/env.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { createRateLimitMiddleware } from "./middleware/rateLimit.js";
 import { createSessionMiddleware } from "./middleware/session.js";
 import { healthRouter } from "./routes/health.js";
 import { createItinerariesRouter } from "./routes/itineraries.js";
@@ -11,11 +12,18 @@ import {
   createAiItineraryService,
   type AiItineraryService
 } from "./services/aiItinerary/generateItinerary.js";
+import {
+  createConsoleAiUsageLogger,
+  recordAiUsageSafely,
+  type AiUsageLogger
+} from "./services/aiItinerary/usageLogger.js";
 import { createTripService, type TripService } from "./services/tripService.js";
 
 export type CreateAppOptions = {
   env?: ApiEnvConfig;
+  aiGenerationRateLimitMiddleware?: RequestHandler;
   aiItineraryService?: AiItineraryService;
+  aiUsageLogger?: AiUsageLogger;
   sessionMiddleware?: RequestHandler;
   tripService?: TripService;
 };
@@ -27,8 +35,28 @@ export function createApp(options: CreateAppOptions = {}) {
     createSessionMiddleware({
       secret: env.jwtSecret
     });
+  const aiUsageLogger = options.aiUsageLogger ?? createConsoleAiUsageLogger();
   const aiItineraryService =
-    options.aiItineraryService ?? createAiItineraryService(env);
+    options.aiItineraryService ??
+    createAiItineraryService(env, {
+      usageLogger: aiUsageLogger
+    });
+  const aiGenerationRateLimitMiddleware =
+    options.aiGenerationRateLimitMiddleware ??
+    createRateLimitMiddleware({
+      max: env.aiGenerationRateLimitMax,
+      onRateLimited: ({ identifier }) => {
+        void recordAiUsageSafely(aiUsageLogger, {
+          attempts: 0,
+          estimatedCostUsd: null,
+          model: null,
+          outcome: "rate_limited",
+          requestIdentifier: identifier,
+          tokenUsage: null
+        });
+      },
+      windowMs: env.aiGenerationRateLimitWindowMs
+    });
   const tripService = options.tripService ?? createTripService();
   const app = express();
 
@@ -40,7 +68,13 @@ export function createApp(options: CreateAppOptions = {}) {
   );
   app.use(express.json());
   app.use("/api/health", healthRouter);
-  app.use("/api/itineraries", createItinerariesRouter(aiItineraryService));
+  app.use(
+    "/api/itineraries",
+    createItinerariesRouter(aiItineraryService, {
+      rateLimitMiddleware: aiGenerationRateLimitMiddleware,
+      usageLogger: aiUsageLogger
+    })
+  );
   app.use("/api/trips", sessionMiddleware, createTripsRouter(tripService));
   app.use(errorHandler);
 

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -10,6 +10,8 @@ describe("loadApiEnv", () => {
   test("parses explicit API config", () => {
     expect(
       loadApiEnv({
+        AI_GENERATION_RATE_LIMIT_MAX: "9",
+        AI_GENERATION_RATE_LIMIT_WINDOW_MS: "120000",
         API_PORT: "4001",
         OPENAI_API_KEY: "sk-test-api-key",
         OPENAI_MODEL: "gpt-test-model",
@@ -17,6 +19,8 @@ describe("loadApiEnv", () => {
         JWT_SECRET: "test-session-secret-value"
       })
     ).toEqual({
+      aiGenerationRateLimitMax: 9,
+      aiGenerationRateLimitWindowMs: 120000,
       apiPort: 4001,
       openAiApiKey: "sk-test-api-key",
       openAiModel: "gpt-test-model",
@@ -37,6 +41,19 @@ describe("loadApiEnv", () => {
         WEB_ORIGIN: "http://localhost:5173"
       })
     ).toThrow("Invalid API_PORT");
+  });
+
+  test("fails clearly for invalid AI generation rate limit config", () => {
+    expect(() =>
+      loadApiEnv({
+        AI_GENERATION_RATE_LIMIT_MAX: "0"
+      })
+    ).toThrow("Invalid AI_GENERATION_RATE_LIMIT_MAX");
+    expect(() =>
+      loadApiEnv({
+        AI_GENERATION_RATE_LIMIT_WINDOW_MS: "not-a-window"
+      })
+    ).toThrow("Invalid AI_GENERATION_RATE_LIMIT_WINDOW_MS");
   });
 
   test("fails clearly for invalid WEB_ORIGIN", () => {

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,4 +1,6 @@
 export type ApiEnvConfig = {
+  aiGenerationRateLimitMax: number;
+  aiGenerationRateLimitWindowMs: number;
   apiPort: number;
   openAiApiKey: string | undefined;
   openAiModel: string;
@@ -10,6 +12,8 @@ const localDevelopmentJwtSecret = "local-development-session-secret-change-me";
 const defaultOpenAiModel = "gpt-5.5";
 
 export const defaultApiEnv = {
+  aiGenerationRateLimitMax: 5,
+  aiGenerationRateLimitWindowMs: 60_000,
   apiPort: 3001,
   openAiApiKey: undefined,
   openAiModel: defaultOpenAiModel,
@@ -18,6 +22,8 @@ export const defaultApiEnv = {
 } satisfies ApiEnvConfig;
 
 type ApiEnvSource = {
+  AI_GENERATION_RATE_LIMIT_MAX?: string | undefined;
+  AI_GENERATION_RATE_LIMIT_WINDOW_MS?: string | undefined;
   API_PORT?: string | undefined;
   OPENAI_API_KEY?: string | undefined;
   OPENAI_MODEL?: string | undefined;
@@ -25,6 +31,26 @@ type ApiEnvSource = {
   JWT_SECRET?: string | undefined;
   NODE_ENV?: string | undefined;
 };
+
+function parsePositiveIntegerEnv(options: {
+  defaultValue: number;
+  name: string;
+  value: string | undefined;
+}) {
+  const rawValue = options.value?.trim() || String(options.defaultValue);
+
+  if (!/^\d+$/.test(rawValue)) {
+    throw new Error(`Invalid ${options.name}: expected a positive integer.`);
+  }
+
+  const parsedValue = Number(rawValue);
+
+  if (!Number.isSafeInteger(parsedValue) || parsedValue < 1) {
+    throw new Error(`Invalid ${options.name}: expected a positive integer.`);
+  }
+
+  return parsedValue;
+}
 
 function parseApiPort(value: string | undefined) {
   const rawPort = value?.trim() || String(defaultApiEnv.apiPort);
@@ -101,6 +127,16 @@ function parseJwtSecret(
 
 export function loadApiEnv(env: ApiEnvSource = process.env): ApiEnvConfig {
   return {
+    aiGenerationRateLimitMax: parsePositiveIntegerEnv({
+      defaultValue: defaultApiEnv.aiGenerationRateLimitMax,
+      name: "AI_GENERATION_RATE_LIMIT_MAX",
+      value: env.AI_GENERATION_RATE_LIMIT_MAX
+    }),
+    aiGenerationRateLimitWindowMs: parsePositiveIntegerEnv({
+      defaultValue: defaultApiEnv.aiGenerationRateLimitWindowMs,
+      name: "AI_GENERATION_RATE_LIMIT_WINDOW_MS",
+      value: env.AI_GENERATION_RATE_LIMIT_WINDOW_MS
+    }),
     apiPort: parseApiPort(env.API_PORT),
     openAiApiKey: parseOpenAiApiKey(env.OPENAI_API_KEY),
     openAiModel: parseOpenAiModel(env.OPENAI_MODEL),

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -1,0 +1,112 @@
+import type { Request, RequestHandler } from "express";
+
+import { ApiError } from "../errors/ApiError.js";
+
+export type RateLimitEntry = {
+  count: number;
+  resetAt: number;
+};
+
+export type RateLimitStore = {
+  increment: (key: string, nowMs: number, windowMs: number) => RateLimitEntry;
+};
+
+export type RateLimitOptions = {
+  clock?: () => number;
+  getIdentifier?: (request: Request) => string;
+  max: number;
+  onRateLimited?: (event: {
+    identifier: string;
+    retryAfterSeconds: number;
+  }) => Promise<void> | void;
+  store?: RateLimitStore;
+  windowMs: number;
+};
+
+export class InMemoryRateLimitStore implements RateLimitStore {
+  private readonly buckets = new Map<string, RateLimitEntry>();
+
+  increment(key: string, nowMs: number, windowMs: number): RateLimitEntry {
+    const existingBucket = this.buckets.get(key);
+
+    if (existingBucket === undefined || existingBucket.resetAt <= nowMs) {
+      const nextBucket = {
+        count: 1,
+        resetAt: nowMs + windowMs
+      };
+
+      this.buckets.set(key, nextBucket);
+      return nextBucket;
+    }
+
+    const nextBucket = {
+      count: existingBucket.count + 1,
+      resetAt: existingBucket.resetAt
+    };
+
+    this.buckets.set(key, nextBucket);
+    return nextBucket;
+  }
+}
+
+export function getClientRateLimitIdentifier(request: Request) {
+  const forwardedFor = request.get("x-forwarded-for")?.split(",")[0]?.trim();
+
+  if (forwardedFor !== undefined && forwardedFor.length > 0) {
+    return forwardedFor;
+  }
+
+  return request.ip || request.socket.remoteAddress || "unknown";
+}
+
+export function createRateLimitMiddleware(
+  options: RateLimitOptions
+): RequestHandler {
+  validateRateLimitOptions(options);
+
+  const clock = options.clock ?? Date.now;
+  const getIdentifier = options.getIdentifier ?? getClientRateLimitIdentifier;
+  const store = options.store ?? new InMemoryRateLimitStore();
+
+  return (request, response, next) => {
+    const nowMs = clock();
+    const identifier = getIdentifier(request);
+    const entry = store.increment(identifier, nowMs, options.windowMs);
+
+    if (entry.count <= options.max) {
+      next();
+      return;
+    }
+
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((entry.resetAt - nowMs) / 1000)
+    );
+
+    response.setHeader("Retry-After", String(retryAfterSeconds));
+    void options.onRateLimited?.({
+      identifier,
+      retryAfterSeconds
+    });
+    next(
+      new ApiError({
+        statusCode: 429,
+        code: "RATE_LIMITED",
+        message: "Too many itinerary generation requests. Try again later.",
+        details: {
+          retryAfterSeconds
+        }
+      })
+    );
+  };
+}
+
+function validateRateLimitOptions(options: RateLimitOptions) {
+  if (!Number.isSafeInteger(options.max) || options.max < 1) {
+    throw new Error("Rate limit max must be a positive integer.");
+  }
+
+  if (!Number.isSafeInteger(options.windowMs) || options.windowMs < 1) {
+    throw new Error("Rate limit windowMs must be a positive integer.");
+  }
+}

--- a/apps/api/src/middleware/validateRequest.ts
+++ b/apps/api/src/middleware/validateRequest.ts
@@ -1,16 +1,27 @@
-import type { RequestHandler } from "express";
-import type { ZodType } from "zod";
+import type { Request, RequestHandler } from "express";
+import type { ZodError, ZodType } from "zod";
 
 import {
   createApiErrorResponse,
   zodIssuesToFieldErrors
 } from "../errors/ApiError.js";
 
-export function validateRequest(schema: ZodType): RequestHandler {
+export type ValidateRequestOptions = {
+  onValidationError?: (context: { error: ZodError; request: Request }) => void;
+};
+
+export function validateRequest(
+  schema: ZodType,
+  options: ValidateRequestOptions = {}
+): RequestHandler {
   return (request, response, next) => {
     const result = schema.safeParse(request.body);
 
     if (!result.success) {
+      options.onValidationError?.({
+        error: result.error,
+        request
+      });
       response.status(400).json(
         createApiErrorResponse({
           code: "VALIDATION_ERROR",

--- a/apps/api/src/routes/itineraries.test.ts
+++ b/apps/api/src/routes/itineraries.test.ts
@@ -8,11 +8,17 @@ import {
 } from "@japan-travel-planner/shared";
 
 import { createApp } from "../app.js";
-import { defaultApiEnv } from "../config/env.js";
+import { defaultApiEnv, type ApiEnvConfig } from "../config/env.js";
 import {
   AiItineraryService,
   type AiItineraryProvider
 } from "../services/aiItinerary/generateItinerary.js";
+import {
+  createConsoleAiUsageLogger,
+  type AiUsageLogEntry
+} from "../services/aiItinerary/usageLogger.js";
+import type { TripRepository } from "../repositories/tripRepository.js";
+import { TripService } from "../services/tripService.js";
 
 const validTripRequest = {
   startDate: "2026-04-06",
@@ -82,7 +88,7 @@ const validModelOutput = {
 
 describe("POST /api/itineraries/generate", () => {
   test("returns a validated itinerary for a valid request with mocked AI success", async () => {
-    const { app, createResponse } = createItineraryTestApp([
+    const { app, createResponse, usageEntries } = createItineraryTestApp([
       JSON.stringify(validModelOutput)
     ]);
 
@@ -106,10 +112,22 @@ describe("POST /api/itineraries/generate", () => {
       costLevel: "free"
     });
     expect(createResponse).toHaveBeenCalledTimes(1);
+    expect(usageEntries).toEqual([
+      expect.objectContaining({
+        attempts: 1,
+        estimatedCostUsd: null,
+        model: "gpt-test-model",
+        outcome: "success",
+        tokenUsage: null
+      })
+    ]);
+    expect(JSON.stringify(usageEntries[0])).not.toContain(
+      "Avoid late-night activities"
+    );
   });
 
   test("returns validation errors for an invalid trip request", async () => {
-    const { app, createResponse } = createItineraryTestApp([
+    const { app, createResponse, usageEntries } = createItineraryTestApp([
       JSON.stringify(validModelOutput)
     ]);
 
@@ -138,6 +156,14 @@ describe("POST /api/itineraries/generate", () => {
       ])
     );
     expect(createResponse).not.toHaveBeenCalled();
+    expect(usageEntries).toEqual([
+      expect.objectContaining({
+        attempts: 0,
+        model: null,
+        outcome: "validation_error",
+        tokenUsage: null
+      })
+    ]);
   });
 
   test("returns a structured error when model output remains invalid after repair", async () => {
@@ -167,7 +193,16 @@ describe("POST /api/itineraries/generate", () => {
   });
 
   test("returns a structured missing-key error when generation is invoked without OpenAI config", async () => {
-    const response = await request(createApp({ env: defaultApiEnv }))
+    const usageEntries: AiUsageLogEntry[] = [];
+    const usageLogger = createConsoleAiUsageLogger({
+      sink: (entry) => usageEntries.push(entry)
+    });
+    const response = await request(
+      createApp({
+        aiUsageLogger: usageLogger,
+        env: defaultApiEnv
+      })
+    )
       .post("/api/itineraries/generate")
       .send(validTripRequest);
 
@@ -180,11 +215,102 @@ describe("POST /api/itineraries/generate", () => {
       },
       message: "AI itinerary generation is not configured."
     });
+    expect(usageEntries).toEqual([
+      expect.objectContaining({
+        attempts: 0,
+        model: null,
+        outcome: "provider_configuration_error"
+      })
+    ]);
+  });
+
+  test("rate limits generation with a structured API error", async () => {
+    const { app, createResponse, usageEntries } = createItineraryTestApp(
+      [JSON.stringify(validModelOutput)],
+      {
+        env: {
+          ...defaultApiEnv,
+          aiGenerationRateLimitMax: 1,
+          aiGenerationRateLimitWindowMs: 60_000
+        }
+      }
+    );
+
+    const firstResponse = await request(app)
+      .post("/api/itineraries/generate")
+      .send(validTripRequest);
+    const secondResponse = await request(app)
+      .post("/api/itineraries/generate")
+      .send(validTripRequest);
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(429);
+    expect(secondResponse.headers["retry-after"]).toBe("60");
+    expect(apiErrorSchema.safeParse(secondResponse.body).success).toBe(true);
+    expect(secondResponse.body).toEqual({
+      error: {
+        code: "RATE_LIMITED",
+        details: {
+          retryAfterSeconds: 60
+        },
+        message: "Too many itinerary generation requests. Try again later."
+      }
+    });
+    expect(createResponse).toHaveBeenCalledTimes(1);
+    expect(usageEntries).toEqual([
+      expect.objectContaining({
+        outcome: "success"
+      }),
+      expect.objectContaining({
+        attempts: 0,
+        model: null,
+        outcome: "rate_limited",
+        tokenUsage: null
+      })
+    ]);
+  });
+
+  test("generation rate limit does not affect health or Trip CRUD routes", async () => {
+    const { app } = createItineraryTestApp([JSON.stringify(validModelOutput)], {
+      env: {
+        ...defaultApiEnv,
+        aiGenerationRateLimitMax: 1,
+        aiGenerationRateLimitWindowMs: 60_000
+      },
+      tripService: createEmptyTripService()
+    });
+
+    await request(app).post("/api/itineraries/generate").send(validTripRequest);
+    await request(app).post("/api/itineraries/generate").send(validTripRequest);
+
+    const healthResponse = await request(app).get("/api/health");
+    const tripListResponse = await request(app).get("/api/trips");
+
+    expect(healthResponse.status).toBe(200);
+    expect(healthResponse.body).toEqual({
+      service: "japan-travel-planner-api",
+      status: "ok"
+    });
+    expect(tripListResponse.status).toBe(200);
+    expect(tripListResponse.body).toEqual({
+      trips: []
+    });
   });
 });
 
-function createItineraryTestApp(responses: Array<string | Error>) {
+function createItineraryTestApp(
+  responses: Array<string | Error>,
+  options: {
+    env?: ApiEnvConfig | undefined;
+    tripService?: TripService | undefined;
+  } = {}
+) {
   const pendingResponses = [...responses];
+  const usageEntries: AiUsageLogEntry[] = [];
+  const usageLogger = createConsoleAiUsageLogger({
+    clock: () => new Date("2026-01-01T00:00:00.000Z"),
+    sink: (entry) => usageEntries.push(entry)
+  });
   const createResponse = vi.fn<AiItineraryProvider["createResponse"]>(
     async () => {
       const response = pendingResponses.shift();
@@ -207,14 +333,37 @@ function createItineraryTestApp(responses: Array<string | Error>) {
     createResponse
   } satisfies AiItineraryProvider;
   const aiItineraryService = new AiItineraryService({
-    providerFactory: () => provider
+    providerFactory: () => provider,
+    usageLogger
   });
 
   return {
     app: createApp({
       aiItineraryService,
-      env: defaultApiEnv
+      aiUsageLogger: usageLogger,
+      env: options.env ?? defaultApiEnv,
+      ...(options.tripService !== undefined
+        ? { tripService: options.tripService }
+        : {})
     }),
-    createResponse
+    createResponse,
+    usageEntries
   };
+}
+
+function createEmptyTripService() {
+  const repository = {
+    createTrip: async () => {
+      throw new Error("createTrip should not be called in this test.");
+    },
+    deleteTrip: async () => false,
+    findOrCreateOwner: async () => ({
+      id: "owner-1"
+    }),
+    findTrip: async () => null,
+    listTrips: async () => [],
+    updateTrip: async () => null
+  } satisfies TripRepository;
+
+  return new TripService(repository);
 }

--- a/apps/api/src/routes/itineraries.ts
+++ b/apps/api/src/routes/itineraries.ts
@@ -4,8 +4,14 @@ import {
   type TripRequest
 } from "@japan-travel-planner/shared";
 
+import { getClientRateLimitIdentifier } from "../middleware/rateLimit.js";
 import { validateRequest } from "../middleware/validateRequest.js";
 import type { AiItineraryService } from "../services/aiItinerary/generateItinerary.js";
+import {
+  noopAiUsageLogger,
+  recordAiUsageSafely,
+  type AiUsageLogger
+} from "../services/aiItinerary/usageLogger.js";
 
 function asyncHandler(handler: RequestHandler): RequestHandler {
   return (request, response, next) => {
@@ -13,17 +19,41 @@ function asyncHandler(handler: RequestHandler): RequestHandler {
   };
 }
 
+type CreateItinerariesRouterOptions = {
+  rateLimitMiddleware?: RequestHandler | undefined;
+  usageLogger?: AiUsageLogger | undefined;
+};
+
 export function createItinerariesRouter(
-  aiItineraryService: AiItineraryService
+  aiItineraryService: AiItineraryService,
+  options: CreateItinerariesRouterOptions = {}
 ) {
   const router = Router();
+  const usageLogger = options.usageLogger ?? noopAiUsageLogger;
 
   router.post(
     "/generate",
-    validateRequest(tripRequestSchema),
+    ...(options.rateLimitMiddleware !== undefined
+      ? [options.rateLimitMiddleware]
+      : []),
+    validateRequest(tripRequestSchema, {
+      onValidationError: ({ request }) => {
+        void recordAiUsageSafely(usageLogger, {
+          attempts: 0,
+          estimatedCostUsd: null,
+          model: null,
+          outcome: "validation_error",
+          requestIdentifier: getClientRateLimitIdentifier(request),
+          tokenUsage: null
+        });
+      }
+    }),
     asyncHandler(async (request, response) => {
       const result = await aiItineraryService.generateItinerary(
-        request.body as TripRequest
+        request.body as TripRequest,
+        {
+          requestIdentifier: getClientRateLimitIdentifier(request)
+        }
       );
 
       response.status(200).json(result);

--- a/apps/api/src/services/aiItinerary/generateItinerary.test.ts
+++ b/apps/api/src/services/aiItinerary/generateItinerary.test.ts
@@ -12,6 +12,10 @@ import {
   createAiItineraryService,
   type AiItineraryProvider
 } from "./generateItinerary.js";
+import {
+  createConsoleAiUsageLogger,
+  type AiUsageLogEntry
+} from "./usageLogger.js";
 
 const representativeTripRequest = {
   startDate: "2026-04-06",
@@ -81,11 +85,13 @@ const validModelOutput = {
 
 describe("AiItineraryService", () => {
   test("returns a validated itinerary for valid model output", async () => {
-    const { createResponse, service } = createTestService([
+    const { createResponse, service, usageEntries } = createTestService([
       JSON.stringify(validModelOutput)
     ]);
 
-    const result = await service.generateItinerary(representativeTripRequest);
+    const result = await service.generateItinerary(representativeTripRequest, {
+      requestIdentifier: "198.51.100.10"
+    });
 
     expect(itinerarySchema.safeParse(result.itinerary).success).toBe(true);
     expect(result).toMatchObject({
@@ -105,10 +111,21 @@ describe("AiItineraryService", () => {
     expect(createResponse.mock.calls[0]?.[0].input).toContain(
       "Dates: 2026-04-06 to 2026-04-07"
     );
+    expect(usageEntries).toEqual([
+      expect.objectContaining({
+        attempts: 1,
+        estimatedCostUsd: null,
+        model: "gpt-test-model",
+        outcome: "success",
+        tokenUsage: null
+      })
+    ]);
+    expect(usageEntries[0]?.requestIdentifierHash).toHaveLength(64);
+    expect(JSON.stringify(usageEntries[0])).not.toContain("198.51.100.10");
   });
 
   test("repairs invalid first output once and returns the repaired itinerary", async () => {
-    const { createResponse, service } = createTestService([
+    const { createResponse, service, usageEntries } = createTestService([
       "not valid json",
       JSON.stringify(validModelOutput)
     ]);
@@ -129,10 +146,17 @@ describe("AiItineraryService", () => {
     expect(createResponse.mock.calls[1]?.[0].instructions).toContain(
       "Return corrected structured JSON only"
     );
+    expect(usageEntries).toEqual([
+      expect.objectContaining({
+        attempts: 2,
+        model: "gpt-test-model",
+        outcome: "repaired_success"
+      })
+    ]);
   });
 
   test("returns a structured generation failure after invalid output and invalid repair", async () => {
-    const { createResponse, service } = createTestService([
+    const { createResponse, service, usageEntries } = createTestService([
       "not valid json",
       JSON.stringify({
         ...validModelOutput,
@@ -152,10 +176,17 @@ describe("AiItineraryService", () => {
       statusCode: 502
     } satisfies Partial<ApiError>);
     expect(createResponse).toHaveBeenCalledTimes(2);
+    expect(usageEntries).toEqual([
+      expect.objectContaining({
+        attempts: 2,
+        model: "gpt-test-model",
+        outcome: "invalid_model_output"
+      })
+    ]);
   });
 
   test("maps provider failures to a safe structured error", async () => {
-    const { service } = createTestService([
+    const { service, usageEntries } = createTestService([
       new Error("secret provider detail")
     ]);
 
@@ -169,10 +200,25 @@ describe("AiItineraryService", () => {
       message: "AI itinerary provider request failed.",
       statusCode: 502
     } satisfies Partial<ApiError>);
+    expect(usageEntries).toEqual([
+      expect.objectContaining({
+        attempts: 1,
+        model: null,
+        outcome: "provider_request_failed"
+      })
+    ]);
+    expect(JSON.stringify(usageEntries[0])).not.toContain(
+      "secret provider detail"
+    );
   });
 
   test("fails clearly when generation is invoked without OPENAI_API_KEY", async () => {
-    const service = createAiItineraryService(defaultApiEnv);
+    const usageEntries: AiUsageLogEntry[] = [];
+    const service = createAiItineraryService(defaultApiEnv, {
+      usageLogger: createConsoleAiUsageLogger({
+        sink: (entry) => usageEntries.push(entry)
+      })
+    });
 
     await expect(
       service.generateItinerary(representativeTripRequest)
@@ -184,6 +230,13 @@ describe("AiItineraryService", () => {
       message: "AI itinerary generation is not configured.",
       statusCode: 500
     } satisfies Partial<ApiError>);
+    expect(usageEntries).toEqual([
+      expect.objectContaining({
+        attempts: 0,
+        model: null,
+        outcome: "provider_configuration_error"
+      })
+    ]);
   });
 });
 
@@ -192,8 +245,10 @@ function createTestService(responses: Array<string | Error>): {
     typeof vi.fn<AiItineraryProvider["createResponse"]>
   >;
   service: AiItineraryService;
+  usageEntries: AiUsageLogEntry[];
 } {
   const pendingResponses = [...responses];
+  const usageEntries: AiUsageLogEntry[] = [];
   const createResponse = vi.fn<AiItineraryProvider["createResponse"]>(
     async () => {
       const response = pendingResponses.shift();
@@ -219,7 +274,12 @@ function createTestService(responses: Array<string | Error>): {
   return {
     createResponse,
     service: new AiItineraryService({
-      providerFactory: () => provider
-    })
+      providerFactory: () => provider,
+      usageLogger: createConsoleAiUsageLogger({
+        clock: () => new Date("2026-01-01T00:00:00.000Z"),
+        sink: (entry) => usageEntries.push(entry)
+      })
+    }),
+    usageEntries
   };
 }

--- a/apps/api/src/services/aiItinerary/generateItinerary.ts
+++ b/apps/api/src/services/aiItinerary/generateItinerary.ts
@@ -14,6 +14,12 @@ import {
   AiItineraryOutputParseError,
   parseAiItineraryOutput
 } from "./schema.js";
+import {
+  type AiUsageLogger,
+  type AiUsageOutcome,
+  createConsoleAiUsageLogger,
+  recordAiUsageSafely
+} from "./usageLogger.js";
 
 export type AiItineraryProvider = {
   createResponse: (request: OpenAiTextRequest) => Promise<OpenAiTextResult>;
@@ -32,72 +38,113 @@ export type GenerateItineraryResult = {
   metadata: AiItineraryGenerationMetadata;
 };
 
+export type AiItineraryGenerationContext = {
+  requestIdentifier?: string | undefined;
+};
+
 type AiItineraryServiceOptions = {
   providerFactory: () => AiItineraryProvider;
+  usageLogger?: AiUsageLogger | undefined;
 };
 
 export class AiItineraryService {
-  constructor(private readonly options: AiItineraryServiceOptions) {}
+  private readonly usageLogger: AiUsageLogger;
+
+  constructor(private readonly options: AiItineraryServiceOptions) {
+    this.usageLogger = options.usageLogger ?? createConsoleAiUsageLogger();
+  }
 
   async generateItinerary(
-    request: TripRequest
+    request: TripRequest,
+    context: AiItineraryGenerationContext = {}
   ): Promise<GenerateItineraryResult> {
-    const provider = this.createProvider();
-    const prompt = buildItineraryPrompt(request);
-    const firstResponse = await this.createProviderResponse(provider, {
-      instructions: prompt.instructions,
-      input: prompt.input
-    });
+    let attempts = 0;
+    let model: string | null = null;
 
     try {
-      return {
-        itinerary: parseAiItineraryOutput(firstResponse.text),
-        metadata: createGenerationMetadata({
-          attempts: 1,
-          model: firstResponse.model,
-          repaired: false
-        })
-      };
-    } catch (error) {
-      if (!(error instanceof AiItineraryOutputParseError)) {
-        throw error;
-      }
-
-      const repairPrompt = buildItineraryRepairPrompt({
-        originalPrompt: prompt,
-        invalidOutput: firstResponse.text,
-        parseError: error
+      const provider = this.createProvider();
+      const prompt = buildItineraryPrompt(request);
+      attempts = 1;
+      const firstResponse = await this.createProviderResponse(provider, {
+        instructions: prompt.instructions,
+        input: prompt.input
       });
-      const repairResponse = await this.createProviderResponse(provider, {
-        instructions: repairPrompt.instructions,
-        input: repairPrompt.input
-      });
+      model = firstResponse.model;
 
       try {
-        return {
-          itinerary: parseAiItineraryOutput(repairResponse.text),
+        const result = {
+          itinerary: parseAiItineraryOutput(firstResponse.text),
           metadata: createGenerationMetadata({
-            attempts: 2,
-            model: repairResponse.model,
-            repaired: true
+            attempts: 1,
+            model: firstResponse.model,
+            repaired: false
           })
         };
-      } catch (repairError) {
-        if (repairError instanceof AiItineraryOutputParseError) {
-          throw new ApiError({
-            statusCode: 502,
-            code: "AI_ITINERARY_INVALID_OUTPUT",
-            message:
-              "AI itinerary generation returned invalid structured output.",
-            details: {
-              attempts: 2,
-              reason: "MODEL_OUTPUT_INVALID"
-            }
-          });
+
+        await this.recordUsage({
+          context,
+          metadata: result.metadata,
+          outcome: "success"
+        });
+        return result;
+      } catch (error) {
+        if (!(error instanceof AiItineraryOutputParseError)) {
+          throw error;
         }
 
-        throw repairError;
+        const repairPrompt = buildItineraryRepairPrompt({
+          originalPrompt: prompt,
+          invalidOutput: firstResponse.text,
+          parseError: error
+        });
+        attempts = 2;
+        const repairResponse = await this.createProviderResponse(provider, {
+          instructions: repairPrompt.instructions,
+          input: repairPrompt.input
+        });
+        model = repairResponse.model;
+
+        try {
+          const result = {
+            itinerary: parseAiItineraryOutput(repairResponse.text),
+            metadata: createGenerationMetadata({
+              attempts: 2,
+              model: repairResponse.model,
+              repaired: true
+            })
+          };
+
+          await this.recordUsage({
+            context,
+            metadata: result.metadata,
+            outcome: "repaired_success"
+          });
+          return result;
+        } catch (repairError) {
+          if (repairError instanceof AiItineraryOutputParseError) {
+            throw new ApiError({
+              statusCode: 502,
+              code: "AI_ITINERARY_INVALID_OUTPUT",
+              message:
+                "AI itinerary generation returned invalid structured output.",
+              details: {
+                attempts: 2,
+                reason: "MODEL_OUTPUT_INVALID"
+              }
+            });
+          }
+
+          throw repairError;
+        }
       }
+    } catch (error) {
+      await this.recordFailureUsage({
+        attempts,
+        context,
+        error,
+        model
+      });
+      throw error;
     }
   }
 
@@ -119,13 +166,52 @@ export class AiItineraryService {
       throw mapGenerationError(error);
     }
   }
+
+  private async recordUsage(options: {
+    context: AiItineraryGenerationContext;
+    metadata: AiItineraryGenerationMetadata;
+    outcome: AiUsageOutcome;
+  }) {
+    await recordAiUsageSafely(this.usageLogger, {
+      attempts: options.metadata.attempts,
+      estimatedCostUsd: options.metadata.estimatedCostUsd,
+      model: options.metadata.model,
+      outcome: options.outcome,
+      requestIdentifier: options.context.requestIdentifier,
+      tokenUsage: options.metadata.tokenUsage
+    });
+  }
+
+  private async recordFailureUsage(options: {
+    attempts: number;
+    context: AiItineraryGenerationContext;
+    error: unknown;
+    model: string | null;
+  }) {
+    const outcome = generationErrorToUsageOutcome(options.error);
+
+    if (outcome === null) {
+      return;
+    }
+
+    await recordAiUsageSafely(this.usageLogger, {
+      attempts: options.attempts,
+      estimatedCostUsd: null,
+      model: options.model,
+      outcome,
+      requestIdentifier: options.context.requestIdentifier,
+      tokenUsage: null
+    });
+  }
 }
 
 export function createAiItineraryService(
-  env: ApiEnvConfig = loadApiEnv()
+  env: ApiEnvConfig = loadApiEnv(),
+  options: { usageLogger?: AiUsageLogger } = {}
 ): AiItineraryService {
   return new AiItineraryService({
-    providerFactory: () => createOpenAiProviderFromEnv(env)
+    providerFactory: () => createOpenAiProviderFromEnv(env),
+    usageLogger: options.usageLogger
   });
 }
 
@@ -167,4 +253,24 @@ function mapGenerationError(error: unknown): ApiError {
       reason: "PROVIDER_FAILURE"
     }
   });
+}
+
+function generationErrorToUsageOutcome(error: unknown): AiUsageOutcome | null {
+  if (!(error instanceof ApiError)) {
+    return null;
+  }
+
+  if (error.code === "AI_PROVIDER_CONFIGURATION_ERROR") {
+    return "provider_configuration_error";
+  }
+
+  if (error.code === "AI_PROVIDER_REQUEST_FAILED") {
+    return "provider_request_failed";
+  }
+
+  if (error.code === "AI_ITINERARY_INVALID_OUTPUT") {
+    return "invalid_model_output";
+  }
+
+  return null;
 }

--- a/apps/api/src/services/aiItinerary/usageLogger.test.ts
+++ b/apps/api/src/services/aiItinerary/usageLogger.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  createAiUsageLogEntry,
+  createConsoleAiUsageLogger,
+  recordAiUsageSafely
+} from "./usageLogger.js";
+
+describe("AI usage logger", () => {
+  test("records only safe structured metadata", () => {
+    const entry = createAiUsageLogEntry(
+      {
+        attempts: 2,
+        estimatedCostUsd: null,
+        model: "gpt-test-model",
+        outcome: "repaired_success",
+        requestIdentifier: "203.0.113.10",
+        tokenUsage: null,
+        apiKey: "sk-secret-key",
+        constraints: ["My private medical constraint"],
+        rawModelResponse: '{"secret":"raw model output"}',
+        rawPrompt: "Full prompt with sensitive user data"
+      } as Parameters<typeof createAiUsageLogEntry>[0],
+      new Date("2026-01-01T00:00:00.000Z")
+    );
+    const serializedEntry = JSON.stringify(entry);
+
+    expect(entry).toMatchObject({
+      attempts: 2,
+      estimatedCostUsd: null,
+      event: "ai_itinerary_usage",
+      model: "gpt-test-model",
+      outcome: "repaired_success",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      tokenUsage: null
+    });
+    expect(entry.requestIdentifierHash).toHaveLength(64);
+    expect(serializedEntry).not.toContain("203.0.113.10");
+    expect(serializedEntry).not.toContain("sk-secret-key");
+    expect(serializedEntry).not.toContain("Full prompt");
+    expect(serializedEntry).not.toContain("raw model output");
+    expect(serializedEntry).not.toContain("medical constraint");
+  });
+
+  test("sanitizes invalid numeric metadata", () => {
+    const entry = createAiUsageLogEntry({
+      attempts: -1,
+      estimatedCostUsd: Number.NaN,
+      model: "  ",
+      outcome: "provider_request_failed",
+      tokenUsage: {
+        inputTokens: 100,
+        outputTokens: -5,
+        totalTokens: 200
+      }
+    });
+
+    expect(entry.attempts).toBeNull();
+    expect(entry.estimatedCostUsd).toBeNull();
+    expect(entry.model).toBeNull();
+    expect(entry.tokenUsage).toEqual({
+      inputTokens: 100,
+      totalTokens: 200
+    });
+  });
+
+  test("writes sanitized entries through an injectable sink", () => {
+    const sink = vi.fn();
+    const logger = createConsoleAiUsageLogger({
+      clock: () => new Date("2026-01-02T00:00:00.000Z"),
+      sink
+    });
+
+    logger.recordUsage({
+      attempts: 1,
+      estimatedCostUsd: null,
+      model: "gpt-test-model",
+      outcome: "success",
+      requestIdentifier: "test-client",
+      tokenUsage: null
+    });
+
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempts: 1,
+        model: "gpt-test-model",
+        outcome: "success",
+        timestamp: "2026-01-02T00:00:00.000Z"
+      })
+    );
+  });
+
+  test("swallows logger failures", async () => {
+    await expect(
+      recordAiUsageSafely(
+        {
+          recordUsage: () => {
+            throw new Error("log sink unavailable");
+          }
+        },
+        {
+          outcome: "provider_request_failed"
+        }
+      )
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/services/aiItinerary/usageLogger.ts
+++ b/apps/api/src/services/aiItinerary/usageLogger.ts
@@ -1,0 +1,149 @@
+import { createHash } from "node:crypto";
+
+export type AiUsageOutcome =
+  | "invalid_model_output"
+  | "provider_configuration_error"
+  | "provider_request_failed"
+  | "rate_limited"
+  | "repaired_success"
+  | "success"
+  | "validation_error";
+
+export type AiTokenUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+};
+
+export type AiUsageEvent = {
+  attempts?: number | null | undefined;
+  estimatedCostUsd?: number | null | undefined;
+  model?: string | null | undefined;
+  outcome: AiUsageOutcome;
+  requestIdentifier?: string | undefined;
+  tokenUsage?: AiTokenUsage | null | undefined;
+};
+
+export type AiUsageLogEntry = {
+  attempts: number | null;
+  estimatedCostUsd: number | null;
+  event: "ai_itinerary_usage";
+  model: string | null;
+  outcome: AiUsageOutcome;
+  requestIdentifierHash?: string;
+  timestamp: string;
+  tokenUsage: AiTokenUsage | null;
+};
+
+export type AiUsageLogger = {
+  recordUsage: (event: AiUsageEvent) => Promise<void> | void;
+};
+
+export type ConsoleAiUsageLoggerOptions = {
+  clock?: () => Date;
+  sink?: (entry: AiUsageLogEntry) => void;
+};
+
+export const noopAiUsageLogger: AiUsageLogger = {
+  recordUsage: () => {}
+};
+
+export function createAiUsageLogEntry(
+  event: AiUsageEvent,
+  timestamp: Date = new Date()
+): AiUsageLogEntry {
+  return {
+    attempts: sanitizePositiveInteger(event.attempts),
+    estimatedCostUsd: sanitizeEstimatedCost(event.estimatedCostUsd),
+    event: "ai_itinerary_usage",
+    model: sanitizeModel(event.model),
+    outcome: event.outcome,
+    ...(event.requestIdentifier !== undefined &&
+    event.requestIdentifier.trim().length > 0
+      ? { requestIdentifierHash: hashIdentifier(event.requestIdentifier) }
+      : {}),
+    timestamp: timestamp.toISOString(),
+    tokenUsage: sanitizeTokenUsage(event.tokenUsage)
+  };
+}
+
+export function createConsoleAiUsageLogger(
+  options: ConsoleAiUsageLoggerOptions = {}
+): AiUsageLogger {
+  const clock = options.clock ?? (() => new Date());
+  const sink =
+    options.sink ??
+    ((entry: AiUsageLogEntry) => {
+      console.info(JSON.stringify(entry));
+    });
+
+  return {
+    recordUsage: (event) => {
+      sink(createAiUsageLogEntry(event, clock()));
+    }
+  };
+}
+
+export async function recordAiUsageSafely(
+  logger: AiUsageLogger,
+  event: AiUsageEvent
+): Promise<void> {
+  try {
+    await logger.recordUsage(event);
+  } catch {
+    // Usage logging must never break itinerary generation.
+  }
+}
+
+function hashIdentifier(identifier: string) {
+  return createHash("sha256").update(identifier).digest("hex");
+}
+
+function sanitizePositiveInteger(value: number | null | undefined) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    return null;
+  }
+
+  return value;
+}
+
+function sanitizeEstimatedCost(value: number | null | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+
+  return value;
+}
+
+function sanitizeModel(value: string | null | undefined) {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue && trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function sanitizeTokenUsage(
+  tokenUsage: AiTokenUsage | null | undefined
+): AiTokenUsage | null {
+  if (tokenUsage === null || tokenUsage === undefined) {
+    return null;
+  }
+
+  const sanitizedUsage: AiTokenUsage = {};
+  const inputTokens = sanitizePositiveInteger(tokenUsage.inputTokens);
+  const outputTokens = sanitizePositiveInteger(tokenUsage.outputTokens);
+  const totalTokens = sanitizePositiveInteger(tokenUsage.totalTokens);
+
+  if (inputTokens !== null) {
+    sanitizedUsage.inputTokens = inputTokens;
+  }
+
+  if (outputTokens !== null) {
+    sanitizedUsage.outputTokens = outputTokens;
+  }
+
+  if (totalTokens !== null) {
+    sanitizedUsage.totalTokens = totalTokens;
+  }
+
+  return Object.keys(sanitizedUsage).length > 0 ? sanitizedUsage : null;
+}


### PR DESCRIPTION
## Ticket scope

Implements T-023 / Ticket 23: Add AI Usage Logging And Guardrails.

This PR adds safe usage metadata logging and route-scoped abuse protection for `POST /api/itineraries/generate` only. It does not start Ticket 24 generated-itinerary persistence or any later work.

## Changes made

- Added a safe AI usage logger abstraction under `apps/api/src/services/aiItinerary/usageLogger.ts`.
- Added a dependency-free in-memory rate-limit middleware under `apps/api/src/middleware/rateLimit.ts`.
- Added backend-only rate-limit env config:
  - `AI_GENERATION_RATE_LIMIT_WINDOW_MS`
  - `AI_GENERATION_RATE_LIMIT_MAX`
- Wired usage logging into AI generation success, repaired success, provider configuration failure, provider request failure, invalid model output, validation failure, and rate-limited attempts.
- Scoped rate limiting to `POST /api/itineraries/generate` through the itineraries router.
- Added an optional validation-failure hook to `validateRequest` so generation validation errors can be logged without changing response behavior.
- Updated tests for env parsing, safe logger output, service usage outcomes, route validation logging, rate limiting, health scoping, and Trip CRUD scoping.

## Usage logging design

- Uses a small `AiUsageLogger` interface with `recordUsage(event)` so tests can inject a sink.
- The default API app logger writes structured JSON through `console.info`.
- Usage logging is best-effort via `recordAiUsageSafely`; logger failures do not break itinerary generation.
- Logged metadata includes:
  - timestamp
  - outcome
  - attempts count when available
  - model when available
  - token usage, currently null unless explicitly provided as numeric metadata
  - estimated cost, currently null unless explicitly provided
  - hashed request identifier when available

## Rate limiting design

- Uses an in-memory store with a fixed window per request identifier.
- Defaults are local-MVP conservative:
  - `AI_GENERATION_RATE_LIMIT_WINDOW_MS=60000`
  - `AI_GENERATION_RATE_LIMIT_MAX=5`
- The limiter uses the client IP / forwarded-for value for its in-memory key, but logs only a SHA-256 hash of that identifier.
- No new dependencies were added.

## Error response behavior

- Rate-limit failures return HTTP 429 with the existing shared API error shape:

```json
{
  "error": {
    "code": "RATE_LIMITED",
    "message": "Too many itinerary generation requests. Try again later.",
    "details": {
      "retryAfterSeconds": 60
    }
  }
}
```

- The response also sets `Retry-After`.
- Existing AI generation errors remain compatible with the previous shared API error format.

## Redaction / sensitive data handling

- Logs do not store raw prompts, raw model responses, raw OpenAI API keys, stack traces, or full user constraints.
- Request identifiers are hashed before logging.
- The logger builds entries from an allowlist of fields and ignores extra unsafe input.
- No `VITE_OPENAI_*` variables were added.
- No server-only OpenAI config was exposed to the web bundle.

## Tests added/updated

- Added unit tests for safe AI usage logger output and logger failure isolation.
- Added env tests for backend-only rate-limit config parsing.
- Added AI service tests for:
  - success usage logging
  - repaired success usage logging
  - provider configuration failure logging
  - provider request failure logging
  - invalid model output logging
- Added API route tests for:
  - generation success logs safe metadata
  - validation errors log `validation_error`
  - rate limit returns a structured shared-schema-compatible error
  - rate limit does not affect `/api/health`
  - rate limit does not affect Trip CRUD routes

## Checks run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `git diff --check`
- `git diff --cached --check`

## Manual checks run

- Started API with no OpenAI key and a tiny local generation limit:
  - `env -u OPENAI_API_KEY AI_GENERATION_RATE_LIMIT_MAX=2 AI_GENERATION_RATE_LIMIT_WINDOW_MS=60000 pnpm dev:api`
- Confirmed `GET http://localhost:3001/api/health` returns HTTP 200.
- Called `POST /api/itineraries/generate` three times with a valid request.
- Confirmed first two generation requests return structured `AI_PROVIDER_CONFIGURATION_ERROR` responses because no server key is configured.
- Confirmed third generation request returns structured HTTP 429 `RATE_LIMITED` response with `Retry-After`.
- Confirmed `GET /api/health` still returns HTTP 200 after rate limiting.
- Inspected console usage logs and confirmed they include only safe structured metadata: outcome, attempts, null model/cost/token usage, timestamp, and hashed request identifier.
- Confirmed logs do not include API keys, raw prompts, raw model responses, or the submitted constraints.
- Confirmed no web OpenAI key exposure was added.

## Real OpenAI call made

No. Automated tests use mocked providers, and the manual check intentionally ran the API without `OPENAI_API_KEY`.

## Known risks

- The rate limiter is in-memory and per API process. It is appropriate for this MVP ticket but will not coordinate across multiple deployed instances.
- The identifier is IP/forwarded-for based until a generation route session/user identifier is introduced.
- Console logging is suitable for MVP visibility but is not queryable durable observability; later observability tickets can route the same logger interface to a production sink.
- No local runner stalls were observed.

## Ticket boundary confirmation

Ticket 24 and later were not started. This PR does not add generated itinerary persistence, Prisma schema changes, migrations, Trip CRUD behavior changes, web save/reopen behavior changes, maps, weather, hotels, transit, sharing, PDF export, mobile work, deployment work, or client-exposed OpenAI config.
