### PR TITLE
T-024 Persist generated itineraries as trips

### DIFF
--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -1,4 +1,250 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const corsHeaders = {
+  "access-control-allow-credentials": "true",
+  "access-control-allow-headers": "content-type",
+  "access-control-allow-methods": "GET, POST, PATCH, OPTIONS",
+  "access-control-allow-origin": "http://127.0.0.1:5173"
+};
+
+const generatedItineraryFixture = {
+  title: "AI Generated Tokyo And Kyoto Route",
+  startDate: "2026-04-06",
+  endDate: "2026-04-07",
+  days: [
+    {
+      date: "2026-04-06",
+      city: "Tokyo",
+      summary: "Generated Tokyo day with temples and local food.",
+      activities: [
+        {
+          id: "generated-sensoji",
+          title: "Generated Senso-ji morning",
+          category: "culture",
+          timing: {
+            startTime: "09:00",
+            endTime: "11:00",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 120,
+          location: {
+            name: "Senso-ji",
+            city: "Tokyo"
+          },
+          costLevel: "free",
+          notes: "Generated note with flexible temple timing."
+        },
+        {
+          id: "generated-lunch",
+          title: "Generated Asakusa lunch",
+          category: "food",
+          timing: {
+            startTime: "12:00",
+            endTime: "13:00",
+            timeOfDay: "afternoon"
+          },
+          durationMinutes: 60,
+          location: {
+            name: "Asakusa",
+            city: "Tokyo"
+          },
+          costLevel: "medium",
+          notes: "Generated lunch stop with vegetarian-friendly options."
+        }
+      ]
+    },
+    {
+      date: "2026-04-07",
+      city: "Kyoto",
+      summary: "Generated Kyoto transfer day.",
+      activities: [
+        {
+          id: "generated-transfer",
+          title: "Generated Shinkansen transfer",
+          category: "transit",
+          timing: {
+            startTime: "08:30",
+            endTime: "10:50",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 140,
+          location: {
+            name: "Tokyo Station to Kyoto Station",
+            city: "Tokyo"
+          },
+          costLevel: "high",
+          notes: "Generated transfer note with station buffer."
+        }
+      ]
+    }
+  ]
+};
+
+type TripWritePayload = typeof generatedItineraryFixture & {
+  budget: string;
+  cities: string[];
+  constraints: string[];
+  interests: string[];
+  pace: string;
+};
+
+function isOptionsRequest(route: Route) {
+  return route.request().method() === "OPTIONS";
+}
+
+async function fulfillOptions(route: Route) {
+  await route.fulfill({
+    headers: corsHeaders,
+    status: 204
+  });
+}
+
+async function routeGeneratedItinerary(page: Page) {
+  await page.route("**/api/itineraries/generate", async (route) => {
+    if (isOptionsRequest(route)) {
+      await fulfillOptions(route);
+      return;
+    }
+
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().postDataJSON()).toMatchObject({
+      cities: ["Tokyo", "Kyoto"],
+      pace: "balanced"
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    await route.fulfill({
+      contentType: "application/json",
+      headers: corsHeaders,
+      json: {
+        itinerary: generatedItineraryFixture,
+        metadata: {
+          attempts: 1,
+          estimatedCostUsd: null,
+          model: "gpt-test-model",
+          repaired: false,
+          tokenUsage: null
+        }
+      },
+      status: 200
+    });
+  });
+}
+
+async function fillGeneratedTripRequest(page: Page) {
+  await page.getByLabel("Start date").fill("2026-04-06");
+  await page.getByLabel("End date").fill("2026-04-07");
+  await page.getByLabel("Cities").fill("Tokyo, Kyoto");
+  await page.getByLabel("Interests").fill("temples, local food");
+  await page.getByLabel("Travel pace").selectOption("balanced");
+  await page.getByLabel("Budget").selectOption("moderate");
+  await page.getByLabel("Constraints").fill("Vegetarian meals only.");
+}
+
+function createTripRecordFromPayload(payload: TripWritePayload) {
+  return {
+    id: "generated-trip-1",
+    title: payload.title,
+    startDate: payload.startDate,
+    endDate: payload.endDate,
+    cities: payload.cities,
+    interests: payload.interests,
+    pace: payload.pace,
+    budget: payload.budget,
+    constraints: payload.constraints,
+    days: payload.days.map((day, dayIndex) => ({
+      id: `saved-day-${dayIndex + 1}`,
+      ...day,
+      activities: day.activities.map((activity, activityIndex) => ({
+        ...activity,
+        id: activity.id ?? `saved-activity-${dayIndex + 1}-${activityIndex + 1}`
+      }))
+    })),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  };
+}
+
+async function routeTripPersistence(
+  page: Page,
+  options: { failFirstSave?: boolean } = {}
+) {
+  let savedTrip: ReturnType<typeof createTripRecordFromPayload> | null = null;
+  let saveAttempts = 0;
+  let lastSavedPayload: TripWritePayload | null = null;
+
+  await page.route("**/api/trips", async (route) => {
+    if (isOptionsRequest(route)) {
+      await fulfillOptions(route);
+      return;
+    }
+
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        contentType: "application/json",
+        headers: corsHeaders,
+        json: {
+          trips: savedTrip ? [savedTrip] : []
+        },
+        status: 200
+      });
+      return;
+    }
+
+    expect(route.request().method()).toBe("POST");
+    saveAttempts += 1;
+
+    if (options.failFirstSave === true && saveAttempts === 1) {
+      await route.fulfill({
+        contentType: "application/json",
+        headers: corsHeaders,
+        json: {
+          error: {
+            code: "TRIP_SAVE_FAILED",
+            message: "Trip storage is temporarily unavailable."
+          }
+        },
+        status: 503
+      });
+      return;
+    }
+
+    lastSavedPayload = route.request().postDataJSON() as TripWritePayload;
+    savedTrip = createTripRecordFromPayload(lastSavedPayload);
+
+    await route.fulfill({
+      contentType: "application/json",
+      headers: corsHeaders,
+      json: {
+        trip: savedTrip
+      },
+      status: 201
+    });
+  });
+
+  await page.route("**/api/trips/generated-trip-1", async (route) => {
+    if (isOptionsRequest(route)) {
+      await fulfillOptions(route);
+      return;
+    }
+
+    expect(route.request().method()).toBe("GET");
+    await route.fulfill({
+      contentType: "application/json",
+      headers: corsHeaders,
+      json: {
+        trip: savedTrip
+      },
+      status: savedTrip ? 200 : 404
+    });
+  });
+
+  return {
+    getLastSavedPayload: () => lastSavedPayload,
+    getSaveAttempts: () => saveAttempts
+  };
+}
 
 test("traveler can plan and edit a mock itinerary", async ({ page }) => {
   await page.goto("/");
@@ -76,129 +322,12 @@ test("traveler can plan and edit a mock itinerary", async ({ page }) => {
 test("traveler can generate and edit an itinerary from a mocked AI API response", async ({
   page
 }) => {
-  await page.route("**/api/itineraries/generate", async (route) => {
-    const corsHeaders = {
-      "access-control-allow-credentials": "true",
-      "access-control-allow-headers": "content-type",
-      "access-control-allow-methods": "POST, OPTIONS",
-      "access-control-allow-origin": "http://127.0.0.1:5173"
-    };
-
-    if (route.request().method() === "OPTIONS") {
-      await route.fulfill({
-        headers: corsHeaders,
-        status: 204
-      });
-      return;
-    }
-
-    expect(route.request().method()).toBe("POST");
-    expect(route.request().postDataJSON()).toMatchObject({
-      cities: ["Tokyo", "Kyoto"],
-      pace: "balanced"
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 150));
-
-    await route.fulfill({
-      contentType: "application/json",
-      headers: corsHeaders,
-      json: {
-        itinerary: {
-          title: "AI Generated Tokyo And Kyoto Route",
-          startDate: "2026-04-06",
-          endDate: "2026-04-07",
-          days: [
-            {
-              date: "2026-04-06",
-              city: "Tokyo",
-              summary: "Generated Tokyo day with temples and local food.",
-              activities: [
-                {
-                  id: "generated-sensoji",
-                  title: "Generated Senso-ji morning",
-                  category: "culture",
-                  timing: {
-                    startTime: "09:00",
-                    endTime: "11:00",
-                    timeOfDay: "morning"
-                  },
-                  durationMinutes: 120,
-                  location: {
-                    name: "Senso-ji",
-                    city: "Tokyo"
-                  },
-                  costLevel: "free",
-                  notes: "Generated note with flexible temple timing."
-                },
-                {
-                  id: "generated-lunch",
-                  title: "Generated Asakusa lunch",
-                  category: "food",
-                  timing: {
-                    startTime: "12:00",
-                    endTime: "13:00",
-                    timeOfDay: "afternoon"
-                  },
-                  durationMinutes: 60,
-                  location: {
-                    name: "Asakusa",
-                    city: "Tokyo"
-                  },
-                  costLevel: "medium",
-                  notes:
-                    "Generated lunch stop with vegetarian-friendly options."
-                }
-              ]
-            },
-            {
-              date: "2026-04-07",
-              city: "Kyoto",
-              summary: "Generated Kyoto transfer day.",
-              activities: [
-                {
-                  id: "generated-transfer",
-                  title: "Generated Shinkansen transfer",
-                  category: "transit",
-                  timing: {
-                    startTime: "08:30",
-                    endTime: "10:50",
-                    timeOfDay: "morning"
-                  },
-                  durationMinutes: 140,
-                  location: {
-                    name: "Tokyo Station to Kyoto Station",
-                    city: "Tokyo"
-                  },
-                  costLevel: "high",
-                  notes: "Generated transfer note with station buffer."
-                }
-              ]
-            }
-          ]
-        },
-        metadata: {
-          attempts: 1,
-          estimatedCostUsd: null,
-          model: "gpt-test-model",
-          repaired: false,
-          tokenUsage: null
-        }
-      },
-      status: 200
-    });
-  });
+  await routeGeneratedItinerary(page);
 
   await page.goto("/");
   await page.getByRole("button", { name: "API" }).click();
 
-  await page.getByLabel("Start date").fill("2026-04-06");
-  await page.getByLabel("End date").fill("2026-04-07");
-  await page.getByLabel("Cities").fill("Tokyo, Kyoto");
-  await page.getByLabel("Interests").fill("temples, local food");
-  await page.getByLabel("Travel pace").selectOption("balanced");
-  await page.getByLabel("Budget").selectOption("moderate");
-  await page.getByLabel("Constraints").fill("Vegetarian meals only.");
+  await fillGeneratedTripRequest(page);
 
   await page.getByRole("button", { name: "Generate AI itinerary" }).click();
 
@@ -235,4 +364,97 @@ test("traveler can generate and edit an itinerary from a mocked AI API response"
     dayOne.getByRole("heading", { name: "Edited generated Senso-ji morning" })
   ).toBeVisible();
   await expect(page.getByText("Unsaved local edits")).toBeVisible();
+});
+
+test("traveler can save, refresh, and reopen an edited generated itinerary", async ({
+  page
+}) => {
+  await routeGeneratedItinerary(page);
+  const persistence = await routeTripPersistence(page, {
+    failFirstSave: true
+  });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "API" }).click();
+  await fillGeneratedTripRequest(page);
+  await page.getByRole("button", { name: "Generate AI itinerary" }).click();
+
+  const dayOne = page.getByRole("region", { name: "Day 1: Tokyo" });
+  await expect(
+    dayOne.getByRole("heading", { name: "Generated Senso-ji morning" })
+  ).toBeVisible();
+
+  await page
+    .getByRole("button", { name: "Edit Generated Senso-ji morning" })
+    .click();
+  const dialog = page.getByRole("dialog", {
+    name: "Edit Generated Senso-ji morning"
+  });
+  await expect(dialog).toBeVisible();
+
+  const savedEditedTitle = "Saved generated Senso-ji morning";
+  await dialog.getByLabel("Title").fill(savedEditedTitle);
+  await dialog.getByRole("button", { name: "Save activity" }).click();
+  await expect(
+    dayOne.getByRole("heading", { name: savedEditedTitle })
+  ).toBeVisible();
+  await expect(page.getByText("Unsaved local edits")).toBeVisible();
+
+  await page.getByRole("button", { name: "Save itinerary" }).click();
+  await expect(
+    page
+      .getByRole("alert")
+      .getByText("Trip storage is temporarily unavailable.")
+  ).toBeVisible();
+  expect(persistence.getSaveAttempts()).toBe(1);
+
+  await page.getByRole("button", { name: "Save itinerary" }).click();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(
+    page
+      .getByRole("region", { name: "Save and reopen" })
+      .getByRole("status")
+      .getByText("Saved")
+  ).toBeVisible();
+  await expect(page.getByText("Unsaved local edits")).toHaveCount(0);
+
+  const savedPayload = persistence.getLastSavedPayload();
+
+  if (!savedPayload) {
+    throw new Error("Expected the generated itinerary to be saved.");
+  }
+
+  expect(savedPayload).toMatchObject({
+    budget: "moderate",
+    cities: ["Tokyo", "Kyoto"],
+    constraints: ["Vegetarian meals only."],
+    interests: ["temples", "local food"],
+    pace: "balanced",
+    title: "AI Generated Tokyo And Kyoto Route"
+  });
+  expect(savedPayload.days[0]?.activities[0]?.title).toBe(savedEditedTitle);
+
+  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: "No itinerary yet" })
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "API" }).click();
+  await page.getByRole("button", { name: "Refresh saved trips" }).click();
+  await page.getByLabel("Saved trips").selectOption("generated-trip-1");
+  await page.getByRole("button", { name: "Reopen trip" }).click();
+
+  await expect(
+    page
+      .getByLabel("Shell status")
+      .getByText("AI Generated Tokyo And Kyoto Route")
+  ).toBeVisible();
+  await expect(
+    page
+      .getByRole("region", { name: "Day 1: Tokyo" })
+      .getByRole("heading", { name: savedEditedTitle })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: `Edit ${savedEditedTitle}` })
+  ).toBeVisible();
 });

--- a/apps/web/src/features/trips/useTrips.test.ts
+++ b/apps/web/src/features/trips/useTrips.test.ts
@@ -10,7 +10,8 @@ import {
   createSavedTrip,
   getTripErrorMessage,
   reopenSavedTrip,
-  saveTrip
+  saveTrip,
+  type TripOperationResult
 } from "./useTrips.js";
 
 function createTripRecord(overrides: Partial<TripRecord> = {}): TripRecord {
@@ -54,6 +55,51 @@ function createMockClient(trip = createTripRecord()): TripApiClient {
     getTrip: vi.fn(async () => trip),
     listTrips: vi.fn(async () => [trip]),
     updateTrip: vi.fn(async () => trip)
+  };
+}
+
+function createGeneratedTripResult(
+  overrides: {
+    itineraryTitle?: string;
+    firstActivityTitle?: string;
+    tripId?: string;
+  } = {}
+) {
+  const itineraryTitle =
+    overrides.itineraryTitle ?? "AI Generated Tokyo And Kyoto Route";
+  const firstActivityTitle =
+    overrides.firstActivityTitle ?? "Generated Senso-ji morning";
+  const itinerary = {
+    ...mockItinerary,
+    title: itineraryTitle,
+    days: mockItinerary.days.map((day, dayIndex) => ({
+      ...day,
+      activities: day.activities.map((activity, activityIndex) => ({
+        ...activity,
+        id: `generated-${dayIndex + 1}-${activityIndex + 1}`,
+        title:
+          dayIndex === 0 && activityIndex === 0
+            ? firstActivityTitle
+            : activity.title
+      }))
+    }))
+  };
+  const trip = createTripRecord({
+    id: overrides.tripId ?? "generated-trip-1",
+    title: itinerary.title,
+    days: itinerary.days.map((day, dayIndex) => ({
+      id: `generated-day-${dayIndex + 1}`,
+      ...day,
+      activities: day.activities.map((activity) => ({
+        ...activity,
+        id: activity.id ?? `generated-activity-${dayIndex + 1}`
+      }))
+    }))
+  });
+
+  return {
+    itinerary,
+    trip
   };
 }
 
@@ -115,6 +161,76 @@ describe("trip API workflow helpers", () => {
 
     expect(client.createTrip).toHaveBeenCalledOnce();
     expect(client.updateTrip).not.toHaveBeenCalled();
+  });
+
+  test("saves generated itineraries with original request metadata", async () => {
+    const { itinerary, trip } = createGeneratedTripResult();
+    const client = createMockClient(trip);
+
+    const result = await saveTrip(client, {
+      itinerary,
+      request: mockTripRequest,
+      tripId: null
+    });
+
+    expect(client.createTrip).toHaveBeenCalledWith(
+      expect.objectContaining({
+        budget: mockTripRequest.budget,
+        cities: mockTripRequest.cities,
+        constraints: mockTripRequest.constraints,
+        interests: mockTripRequest.interests,
+        pace: mockTripRequest.pace,
+        title: "AI Generated Tokyo And Kyoto Route"
+      })
+    );
+    expect(result.request).toEqual(mockTripRequest);
+    expect(result.itinerary.title).toBe("AI Generated Tokyo And Kyoto Route");
+  });
+
+  test("saves the currently edited generated itinerary data", async () => {
+    const { itinerary, trip } = createGeneratedTripResult({
+      firstActivityTitle: "Edited generated Senso-ji morning"
+    });
+    const client = createMockClient(trip);
+
+    await saveTrip(client, {
+      itinerary,
+      request: mockTripRequest,
+      tripId: null
+    });
+
+    expect(client.createTrip).toHaveBeenCalledWith(
+      expect.objectContaining({
+        days: expect.arrayContaining([
+          expect.objectContaining({
+            activities: expect.arrayContaining([
+              expect.objectContaining({
+                title: "Edited generated Senso-ji morning"
+              })
+            ])
+          })
+        ])
+      })
+    );
+  });
+
+  test("reopens saved generated trips into editable itinerary state", async () => {
+    const { trip } = createGeneratedTripResult({
+      firstActivityTitle: "Saved generated Senso-ji morning"
+    });
+    const client = createMockClient(trip);
+
+    const result: TripOperationResult = await reopenSavedTrip(
+      client,
+      "generated-trip-1"
+    );
+
+    expect(result.request).toEqual(mockTripRequest);
+    expect(result.itinerary.title).toBe("AI Generated Tokyo And Kyoto Route");
+    expect(result.itinerary.days[0]?.activities[0]).toMatchObject({
+      id: "generated-1-1",
+      title: "Saved generated Senso-ji morning"
+    });
   });
 
   test("reopens saved trips through the API client", async () => {


### PR DESCRIPTION
## Ticket scope

Implement T-024 / Ticket 24: Persist Generated Itineraries As Trips.

The existing API generation and Trip CRUD implementation already supports the Ticket 24 production path: generated itinerary state is saved through the existing trip save flow, preserves the original trip request metadata, and can be reopened into the editable itinerary board. This PR locks that behavior with focused tests and does not change production app/API/schema code.

## Changes made

- Added web hook tests covering generated itinerary save/reopen behavior through the existing trip persistence adapter.
- Expanded the Playwright mock flow to save an edited generated itinerary, retry after a save failure, refresh the app, and reopen the saved generated trip.
- Refactored E2E route helpers so the generated itinerary route and trip persistence route are explicit and reusable in the spec.

## Generated itinerary save flow

- The E2E flow submits a trip request through API generation mode.
- The generated itinerary is edited locally.
- The current edited itinerary is sent to the existing Trip CRUD save endpoint.
- The save flow remains retryable after a structured API failure.

## Original request metadata handling

- Added assertions that the saved trip payload preserves the original generated request metadata, including budget, cities, constraints, interests, and pace.

## Editable itinerary persistence behavior

- Added assertions that edited generated activity data is what gets saved.
- Added hook-level coverage that reopened generated trips are normalized back into editable itinerary state.

## Save/reopen behavior

- Added an E2E save, refresh, refresh-saved-trips, select, and reopen flow for a generated itinerary.
- Verified the reopened trip shows the saved generated title and the edited activity title, with edit controls still available.

## Error handling behavior

- Added E2E coverage for a first save failure using the existing structured API error path.
- The same flow retries successfully without changing app behavior.

## Mock mode strategy

- No real OpenAI call is made in tests.
- The E2E test mocks the AI generation endpoint and Trip CRUD endpoints while preserving the production browser flow.
- Existing mock preview behavior remains separate from the API generation path.

## Tests added/updated

- `apps/web/src/features/trips/useTrips.test.ts`
- `apps/web/e2e/trip-planning.spec.ts`

## Checks run

- `pnpm install` passed
- `pnpm lint` passed
- `pnpm typecheck` passed
- `pnpm test` passed
- `pnpm build` passed
- `pnpm --filter @japan-travel-planner/web test` passed
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit` passed
- `pnpm --filter @japan-travel-planner/web exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism` passed
- `pnpm --filter @japan-travel-planner/web exec vite build` passed
- `pnpm --filter @japan-travel-planner/web test:e2e` passed
- `pnpm --filter @japan-travel-planner/api test` passed on rerun. The first run hit a transient cleanup error removing `packages/shared/dist`; no code changes were made for that because the same targeted command passed immediately after.
- `pnpm --filter @japan-travel-planner/api typecheck` passed
- `pnpm --filter @japan-travel-planner/api build` passed
- `pnpm --filter @japan-travel-planner/api exec prisma validate` passed
- `pnpm --filter @japan-travel-planner/api exec prisma generate` passed
- `git diff --check` passed

## GitHub Actions

- CI `Install, lint, typecheck, test, and build` passed on PR #23.

## Manual checks run

- Started API without `OPENAI_API_KEY`; `GET http://localhost:3001/api/health` returned HTTP 200 with JSON status `ok`.
- Started web at `http://localhost:5173`.
- Completed a browser mock-mode form submit and local itinerary edit.
- Confirmed the edited activity appears and the dirty state is shown.

## Real DB / OpenAI checks

- No real OpenAI call was made.
- Real DB-backed save/reopen was not manually exercised because the local environment did not have a `DATABASE_URL` and local PostgreSQL availability could not be confirmed. The generated save/reopen path is covered by mocked E2E and hook-level tests.

## Known risks

- The production behavior relies on the existing Trip CRUD and generated itinerary state integration; this PR intentionally adds tests only because no production gap was found.
- Manual real-database verification remains dependent on a local or CI database environment.
- One targeted API test command had a transient `dist` cleanup failure and passed on rerun.

## Out of scope confirmation

Ticket 25 and later were not started. This PR does not add optimistic edit persistence, maps, weather, hotels, transit, sharing, PDF export, mobile app work, deployment, observability, API routes, Prisma changes, shared schema changes, AI generation changes, or web production behavior changes.