### PR TITLE
T-025 Implement optimistic editing against API

### DIFF
--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -173,6 +173,7 @@ async function routeTripPersistence(
   let savedTrip: ReturnType<typeof createTripRecordFromPayload> | null = null;
   let saveAttempts = 0;
   let lastSavedPayload: TripWritePayload | null = null;
+  let lastUpdatedPayload: TripWritePayload | null = null;
 
   await page.route("**/api/trips", async (route) => {
     if (isOptionsRequest(route)) {
@@ -229,19 +230,36 @@ async function routeTripPersistence(
       return;
     }
 
-    expect(route.request().method()).toBe("GET");
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        contentType: "application/json",
+        headers: corsHeaders,
+        json: {
+          trip: savedTrip
+        },
+        status: savedTrip ? 200 : 404
+      });
+      return;
+    }
+
+    expect(route.request().method()).toBe("PATCH");
+    saveAttempts += 1;
+    lastUpdatedPayload = route.request().postDataJSON() as TripWritePayload;
+    savedTrip = createTripRecordFromPayload(lastUpdatedPayload);
+
     await route.fulfill({
       contentType: "application/json",
       headers: corsHeaders,
       json: {
         trip: savedTrip
       },
-      status: savedTrip ? 200 : 404
+      status: 200
     });
   });
 
   return {
     getLastSavedPayload: () => lastSavedPayload,
+    getLastUpdatedPayload: () => lastUpdatedPayload,
     getSaveAttempts: () => saveAttempts
   };
 }
@@ -317,6 +335,15 @@ test("traveler can plan and edit a mock itinerary", async ({ page }) => {
     "Nishiki Market snack break",
     "Gion and Shirakawa evening walk"
   ]);
+
+  await page.getByRole("button", { name: "Revert local edits" }).click();
+  await expect(page.getByText("Unsaved local edits")).toHaveCount(0);
+  await expect(
+    dayOne.getByRole("heading", { name: "Morning walk through Ueno Park" })
+  ).toBeVisible();
+  await expect(
+    dayOne.getByRole("heading", { name: editedTitle })
+  ).toHaveCount(0);
 });
 
 test("traveler can generate and edit an itinerary from a mocked AI API response", async ({
@@ -406,9 +433,16 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
       .getByRole("alert")
       .getByText("Trip storage is temporarily unavailable.")
   ).toBeVisible();
+  await expect(
+    dayOne.getByRole("heading", { name: savedEditedTitle })
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Retry save" })).toBeEnabled();
+  await expect(
+    page.getByRole("button", { name: "Revert local edits" })
+  ).toBeEnabled();
   expect(persistence.getSaveAttempts()).toBe(1);
 
-  await page.getByRole("button", { name: "Save itinerary" }).click();
+  await page.getByRole("button", { name: "Retry save" }).click();
   await expect(page.getByRole("alert")).toHaveCount(0);
   await expect(
     page
@@ -457,4 +491,48 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
   await expect(
     page.getByRole("button", { name: `Edit ${savedEditedTitle}` })
   ).toBeVisible();
+
+  await page.getByRole("button", { name: `Edit ${savedEditedTitle}` }).click();
+  const reopenedDialog = page.getByRole("dialog", {
+    name: `Edit ${savedEditedTitle}`
+  });
+  await expect(reopenedDialog).toBeVisible();
+
+  const patchedEditedTitle = "Patched generated Senso-ji afternoon";
+  await reopenedDialog.getByLabel("Title").fill(patchedEditedTitle);
+  await reopenedDialog.getByRole("button", { name: "Save activity" }).click();
+  await expect(
+    page
+      .getByRole("region", { name: "Day 1: Tokyo" })
+      .getByRole("heading", { name: patchedEditedTitle })
+  ).toBeVisible();
+  await page
+    .getByRole("region", { name: "Day 1: Tokyo" })
+    .getByRole("button", { name: `Move ${patchedEditedTitle} down` })
+    .click();
+  await expect(page.getByText("Unsaved local edits")).toBeVisible();
+
+  await page.getByRole("button", { name: "Save itinerary" }).click();
+  await expect(page.getByText("Unsaved local edits")).toHaveCount(0);
+
+  const patchedPayload = persistence.getLastUpdatedPayload();
+
+  if (!patchedPayload) {
+    throw new Error("Expected reopened itinerary edits to be patched.");
+  }
+
+  expect(patchedPayload.days[0]?.activities.map((activity) => activity.title))
+    .toEqual(["Generated Asakusa lunch", patchedEditedTitle]);
+
+  await page.reload();
+  await page.getByRole("button", { name: "API" }).click();
+  await page.getByRole("button", { name: "Refresh saved trips" }).click();
+  await page.getByLabel("Saved trips").selectOption("generated-trip-1");
+  await page.getByRole("button", { name: "Reopen trip" }).click();
+
+  const reopenedDayOne = page.getByRole("region", { name: "Day 1: Tokyo" });
+  await expect(reopenedDayOne.getByRole("heading", { level: 4 })).toHaveText([
+    "Generated Asakusa lunch",
+    patchedEditedTitle
+  ]);
 });

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -339,7 +339,7 @@ select {
 .trip-reopen-button:disabled,
 .storage-actions button:disabled,
 .mode-toggle button:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.72;
 }
 

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -13,6 +13,7 @@ describe("App", () => {
     expect(html).toContain("Generate AI itinerary");
     expect(html).toContain("Use mock preview");
     expect(html).toContain("Save and reopen");
+    expect(html).toContain("Revert local edits");
     expect(html).toContain("Refresh saved trips");
     expect(html).toContain("No itinerary yet");
     expect(html).toContain("API");

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -48,6 +48,10 @@ export function App() {
     isGenerating ||
     trips.status === "creating" ||
     trips.status === "saving";
+  const saveButtonLabel =
+    trips.status === "error" && itineraryEditor.isDirty
+      ? "Retry save"
+      : "Save itinerary";
   const storageMessage =
     localError ?? generatedItinerary.errorMessage ?? trips.errorMessage;
 
@@ -75,6 +79,8 @@ export function App() {
       status:
         dataMode === "mock"
           ? "Mock mode"
+          : trips.status === "error" && itineraryEditor.isDirty
+            ? "Retry needed"
           : trips.status === "saved"
             ? "Saved"
             : "API ready",
@@ -148,6 +154,13 @@ export function App() {
       setActiveRequest(result.request);
       resetToItinerary(result.itinerary);
     }
+  }
+
+  function handleRevertItinerary() {
+    itineraryEditor.revertItinerary();
+    setLocalError(null);
+    trips.clearError();
+    generatedItinerary.clearError();
   }
 
   async function handleReopenTrip() {
@@ -294,6 +307,8 @@ export function App() {
                     ? "Generation needs retry"
                     : apiBusy
                       ? "Working"
+                      : trips.status === "error" && itineraryEditor.isDirty
+                        ? "Retry or revert local edits"
                       : trips.status === "saved"
                         ? "Saved"
                         : itineraryEditor.isDirty
@@ -315,7 +330,14 @@ export function App() {
                   onClick={handleSaveItinerary}
                   type="button"
                 >
-                  Save itinerary
+                  {saveButtonLabel}
+                </button>
+                <button
+                  disabled={apiBusy || !itinerary || !itineraryEditor.isDirty}
+                  onClick={handleRevertItinerary}
+                  type="button"
+                >
+                  Revert local edits
                 </button>
                 <button
                   disabled={dataMode === "mock" || apiBusy}

--- a/apps/web/src/features/itinerary/editing/useItineraryEditor.test.ts
+++ b/apps/web/src/features/itinerary/editing/useItineraryEditor.test.ts
@@ -176,4 +176,81 @@ describe("itineraryEditorReducer", () => {
     expect(dirtyState.isDirty).toBe(true);
     expect(resetState.isDirty).toBe(false);
   });
+
+  test("marks a successful save result as the clean editor baseline", () => {
+    const state = createItineraryEditorState(mockItinerary);
+    const activity = getDay(state, "2026-04-06").activities[0];
+
+    if (!activity?.id) {
+      throw new Error("Expected editable activity id");
+    }
+
+    const dirtyState = itineraryEditorReducer(state, {
+      type: "updateActivity",
+      dayDate: "2026-04-06",
+      activityId: activity.id,
+      activity: {
+        ...activity,
+        title: "Optimistic local title"
+      }
+    });
+    const savedItinerary = {
+      ...mockItinerary,
+      days: mockItinerary.days.map((day) =>
+        day.date === "2026-04-06"
+          ? {
+              ...day,
+              activities: day.activities.map((candidateActivity, index) =>
+                index === 0
+                  ? {
+                      ...candidateActivity,
+                      title: "Server-confirmed title"
+                    }
+                  : candidateActivity
+              )
+            }
+          : day
+      )
+    };
+    const savedState = itineraryEditorReducer(dirtyState, {
+      type: "reset",
+      itinerary: savedItinerary
+    });
+
+    expect(savedState.isDirty).toBe(false);
+    expect(getDay(savedState, "2026-04-06").activities[0]?.title).toBe(
+      "Server-confirmed title"
+    );
+  });
+
+  test("reverts dirty edits to the last clean itinerary", () => {
+    const state = createItineraryEditorState(mockItinerary);
+    const activity = getDay(state, "2026-04-06").activities[0];
+
+    if (!activity?.id) {
+      throw new Error("Expected editable activity id");
+    }
+
+    const dirtyState = itineraryEditorReducer(state, {
+      type: "updateActivity",
+      dayDate: "2026-04-06",
+      activityId: activity.id,
+      activity: {
+        ...activity,
+        title: "Failed save should not become baseline"
+      }
+    });
+    const revertedState = itineraryEditorReducer(dirtyState, {
+      type: "revert"
+    });
+
+    expect(dirtyState.isDirty).toBe(true);
+    expect(getDay(dirtyState, "2026-04-06").activities[0]?.title).toBe(
+      "Failed save should not become baseline"
+    );
+    expect(revertedState.isDirty).toBe(false);
+    expect(getDay(revertedState, "2026-04-06").activities[0]?.title).toBe(
+      activity.title
+    );
+  });
 });

--- a/apps/web/src/features/itinerary/editing/useItineraryEditor.ts
+++ b/apps/web/src/features/itinerary/editing/useItineraryEditor.ts
@@ -10,6 +10,7 @@ export type ReorderDirection = "up" | "down";
 export type ItineraryEditorState = {
   itinerary: Itinerary | null;
   isDirty: boolean;
+  lastSavedItinerary: Itinerary | null;
   nextActivityNumber: number;
 };
 
@@ -39,6 +40,9 @@ export type ItineraryEditorAction =
       dayDate: string;
       activityId: string;
       direction: ReorderDirection;
+    }
+  | {
+      type: "revert";
     };
 
 function cloneActivity(activity: Activity): Activity {
@@ -87,6 +91,9 @@ export function createItineraryEditorState(
   return {
     itinerary: editableItinerary,
     isDirty: false,
+    lastSavedItinerary: editableItinerary
+      ? cloneItinerary(editableItinerary)
+      : null,
     nextActivityNumber: activityCount + 1
   };
 }
@@ -122,6 +129,10 @@ export function itineraryEditorReducer(
 ): ItineraryEditorState {
   if (action.type === "reset") {
     return createItineraryEditorState(action.itinerary);
+  }
+
+  if (action.type === "revert") {
+    return createItineraryEditorState(state.lastSavedItinerary);
   }
 
   if (!state.itinerary) {
@@ -221,6 +232,7 @@ export function useItineraryEditor(initialItinerary: Itinerary | null = null) {
   return {
     itinerary: state.itinerary,
     isDirty: state.isDirty,
+    revertItinerary: () => dispatch({ type: "revert" }),
     resetItinerary: (itinerary: Itinerary | null) =>
       dispatch({ type: "reset", itinerary }),
     addActivity: (dayDate: string, activity: Activity) =>


### PR DESCRIPTION
## Ticket scope

Implement T-025 / Ticket 25: Implement Optimistic Editing Against API.

This PR keeps the conservative MVP from the ticket: local optimistic editor updates plus explicit save through the existing Trip CRUD API. It does not add autosave because the existing manual save flow already persists editor state through `POST /api/trips` and `PATCH /api/trips/:tripId`.

## Changes made

- Added a clean itinerary baseline to the itinerary editor reducer.
- Added `revertItinerary` so dirty local edits can be discarded back to the last loaded/saved itinerary.
- Added a `Revert local edits` control in the existing storage panel.
- Changed the save button label to `Retry save` after a failed save while local edits remain dirty.
- Extended E2E route mocking to support `PATCH /api/trips/:tripId` for persisted edits after reopen.
- Added tests for saved-baseline reset, revert behavior, mock-mode revert, retry after save failure, and persisted patched edits after refresh/reopen.

## Optimistic editing design

- Add/edit/delete/reorder remain immediate local reducer updates.
- No API call is made while editing fields or pressing local activity controls.
- Explicit save sends the current edited itinerary through the existing trip save path.
- Existing `PATCH /api/trips/:tripId` support is used for already-saved trips.
- No autosave was added.

## Save/retry/revert behavior

- Successful save resets the editor from the server-confirmed itinerary and clears dirty state.
- Failed save leaves local edits in place and shows the existing API error message.
- After failed save, the save action is labeled `Retry save`.
- `Revert local edits` restores the last clean loaded/saved itinerary and clears dirty state.

## Day grouping preservation

- Reorder remains scoped to the selected day in `useItineraryEditor`.
- Existing reducer coverage confirms activities cannot move across days.
- E2E coverage confirms Day 2 is unchanged while Day 1 is edited/reordered.

## Persisted edit behavior after refresh/reopen

- The E2E flow creates a generated itinerary, saves it, refreshes, reopens it, edits/reorders the reopened saved trip, saves via mocked `PATCH`, refreshes again, and confirms the edited/reordered Day 1 content persists after reopen.

## Mock mode strategy

- Mock mode remains local-only and does not require API persistence.
- The mock E2E flow now confirms local edit/delete/reorder still update immediately and `Revert local edits` restores the loaded mock itinerary.

## Tests added/updated

- `apps/web/src/features/itinerary/editing/useItineraryEditor.test.ts`
- `apps/web/src/App.test.tsx`
- `apps/web/e2e/trip-planning.spec.ts`

## Checks run

- `pnpm install` passed
- `pnpm lint` passed
- `pnpm typecheck` passed
- `pnpm test` passed
- `pnpm build` passed
- `pnpm --filter @japan-travel-planner/web test` passed
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit` passed
- `pnpm --filter @japan-travel-planner/web exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism` passed
- `pnpm --filter @japan-travel-planner/web exec vite build` passed
- `pnpm --filter @japan-travel-planner/web test:e2e` passed
- `pnpm --filter @japan-travel-planner/api test` passed
- `pnpm --filter @japan-travel-planner/api typecheck` passed
- `pnpm --filter @japan-travel-planner/api build` passed
- `pnpm --filter @japan-travel-planner/api exec prisma validate` passed
- `pnpm --filter @japan-travel-planner/api exec prisma generate` passed
- `git diff --check` passed

## GitHub Actions

- CI `Install, lint, typecheck, test, and build` passed on PR #24.

## Manual checks run

- Started API with `env -u OPENAI_API_KEY pnpm dev:api`.
- Confirmed `GET http://localhost:3001/api/health` returned HTTP 200 with JSON status `ok`.
- Started web with `pnpm dev:web` at `http://localhost:5173`.
- Browser smoke checked mock mode: generated a mock itinerary, edited one activity, deleted one activity, reordered within Day 1, confirmed Day 2 was unchanged, reverted local edits, and confirmed dirty state cleared.
- Checked 390px mobile width for no horizontal overflow.

## Real DB-backed persistence

Real DB-backed edit persistence was not manually tested because this local shell has no `DATABASE_URL` and no local PostgreSQL readiness signal. Persistence behavior is covered by mocked Playwright API routes plus unit tests. A real DB-backed manual pass requires a working `DATABASE_URL`.

## Real OpenAI calls

No real OpenAI API call was made.

## Known risks

- The PR intentionally relies on the existing Trip CRUD API and Prisma persistence behavior; production API code was not changed.
- Manual save/reopen against a real database still depends on local database availability.
- The clean baseline is the last loaded or server-confirmed itinerary. For a newly generated unsaved itinerary, revert restores the generated itinerary rather than deleting the board.

## Out of scope confirmation

Ticket 26 and later were not started. This PR does not add maps, weather, hotels, transit, sharing, PDF export, mobile work, deployment, observability, OpenAI behavior changes, rate limiting changes, usage logging changes, server-only config exposure, Prisma schema changes, migrations, or production API route changes.