### PR TITLE
T-026 Add map link enrichment

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,11 @@ import { loadApiEnv, type ApiEnvConfig } from "./config/env.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { createRateLimitMiddleware } from "./middleware/rateLimit.js";
 import { createSessionMiddleware } from "./middleware/session.js";
+import {
+  createGoogleMapsProvider,
+  type MapsProvider
+} from "./providers/maps/mapsProvider.js";
+import { createEnrichmentRouter } from "./routes/enrichment.js";
 import { healthRouter } from "./routes/health.js";
 import { createItinerariesRouter } from "./routes/itineraries.js";
 import { createTripsRouter } from "./routes/trips.js";
@@ -24,6 +29,7 @@ export type CreateAppOptions = {
   aiGenerationRateLimitMiddleware?: RequestHandler;
   aiItineraryService?: AiItineraryService;
   aiUsageLogger?: AiUsageLogger;
+  mapsProvider?: MapsProvider;
   sessionMiddleware?: RequestHandler;
   tripService?: TripService;
 };
@@ -58,6 +64,7 @@ export function createApp(options: CreateAppOptions = {}) {
       windowMs: env.aiGenerationRateLimitWindowMs
     });
   const tripService = options.tripService ?? createTripService();
+  const mapsProvider = options.mapsProvider ?? createGoogleMapsProvider();
   const app = express();
 
   app.use(
@@ -68,6 +75,7 @@ export function createApp(options: CreateAppOptions = {}) {
   );
   app.use(express.json());
   app.use("/api/health", healthRouter);
+  app.use("/api/enrichment", createEnrichmentRouter({ mapsProvider }));
   app.use(
     "/api/itineraries",
     createItinerariesRouter(aiItineraryService, {

--- a/apps/api/src/providers/maps/mapsProvider.test.ts
+++ b/apps/api/src/providers/maps/mapsProvider.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildGoogleMapsSearchQuery,
+  createGoogleMapsSearchLink,
+  createGoogleMapsSearchUrl
+} from "./mapsProvider.js";
+
+describe("Google Maps search link provider", () => {
+  test("generates a search URL from activity title and location", () => {
+    expect(
+      createGoogleMapsSearchLink({
+        title: "Senso-ji morning visit",
+        location: {
+          name: "Senso-ji",
+          city: "Tokyo"
+        }
+      })
+    ).toBe(
+      "https://www.google.com/maps/search/?api=1&query=Senso-ji%20morning%20visit%20Senso-ji%20Tokyo"
+    );
+  });
+
+  test("generates a search URL from location only", () => {
+    expect(
+      createGoogleMapsSearchLink({
+        location: {
+          address: "2 Chome-3-1 Asakusa",
+          city: "Tokyo"
+        }
+      })
+    ).toBe(
+      "https://www.google.com/maps/search/?api=1&query=2%20Chome-3-1%20Asakusa%20Tokyo"
+    );
+  });
+
+  test("encodes special characters and Japanese text safely", () => {
+    const query = "金閣寺 & 龍安寺 Kyoto";
+
+    expect(createGoogleMapsSearchUrl(query)).toBe(
+      `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+        query
+      )}`
+    );
+  });
+
+  test("uses coordinates when exact latitude and longitude are available", () => {
+    expect(
+      buildGoogleMapsSearchQuery({
+        title: "Senso-ji morning visit",
+        location: {
+          latitude: 35.7148,
+          longitude: 139.7967,
+          name: "Senso-ji"
+        }
+      })
+    ).toBe("35.7148,139.7967");
+  });
+
+  test("returns null for missing or empty location text", () => {
+    expect(
+      createGoogleMapsSearchLink({
+        title: "A title without location",
+        location: {
+          name: " "
+        }
+      })
+    ).toBeNull();
+    expect(createGoogleMapsSearchLink({ title: "Only a title" })).toBeNull();
+  });
+});

--- a/apps/api/src/providers/maps/mapsProvider.ts
+++ b/apps/api/src/providers/maps/mapsProvider.ts
@@ -1,0 +1,97 @@
+export type MapLinkLocationInput = {
+  address?: string | undefined;
+  city?: string | undefined;
+  latitude?: number | undefined;
+  longitude?: number | undefined;
+  name?: string | undefined;
+};
+
+export type MapLinkInput = {
+  location?: MapLinkLocationInput | undefined;
+  title?: string | undefined;
+};
+
+export type MapsProvider = {
+  createSearchLink: (input: MapLinkInput) => string | null;
+};
+
+const googleMapsSearchBaseUrl =
+  "https://www.google.com/maps/search/?api=1&query=";
+
+function cleanText(value: string | undefined) {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue && trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function addUniquePart(parts: string[], value: string | null) {
+  if (value === null) {
+    return;
+  }
+
+  if (!parts.some((part) => part.toLowerCase() === value.toLowerCase())) {
+    parts.push(value);
+  }
+}
+
+function getCoordinateQuery(location: MapLinkLocationInput | undefined) {
+  if (
+    location?.latitude === undefined ||
+    location.longitude === undefined ||
+    !Number.isFinite(location.latitude) ||
+    !Number.isFinite(location.longitude)
+  ) {
+    return null;
+  }
+
+  return `${location.latitude},${location.longitude}`;
+}
+
+export function buildGoogleMapsSearchQuery(input: MapLinkInput) {
+  const coordinateQuery = getCoordinateQuery(input.location);
+
+  if (coordinateQuery !== null) {
+    return coordinateQuery;
+  }
+
+  const locationParts = [
+    cleanText(input.location?.address),
+    cleanText(input.location?.name),
+    cleanText(input.location?.city)
+  ].filter((part): part is string => part !== null);
+
+  if (locationParts.length === 0) {
+    return null;
+  }
+
+  const queryParts: string[] = [];
+
+  addUniquePart(queryParts, cleanText(input.title));
+  for (const locationPart of locationParts) {
+    addUniquePart(queryParts, locationPart);
+  }
+
+  return queryParts.join(" ");
+}
+
+export function createGoogleMapsSearchUrl(query: string) {
+  const trimmedQuery = query.trim();
+
+  if (trimmedQuery.length === 0) {
+    return null;
+  }
+
+  return `${googleMapsSearchBaseUrl}${encodeURIComponent(trimmedQuery)}`;
+}
+
+export function createGoogleMapsSearchLink(input: MapLinkInput) {
+  const query = buildGoogleMapsSearchQuery(input);
+
+  return query === null ? null : createGoogleMapsSearchUrl(query);
+}
+
+export function createGoogleMapsProvider(): MapsProvider {
+  return {
+    createSearchLink: createGoogleMapsSearchLink
+  };
+}

--- a/apps/api/src/routes/enrichment.test.ts
+++ b/apps/api/src/routes/enrichment.test.ts
@@ -1,0 +1,98 @@
+import request from "supertest";
+import { describe, expect, test, vi } from "vitest";
+
+import { apiErrorSchema } from "@japan-travel-planner/shared";
+
+import { createApp } from "../app.js";
+import { defaultApiEnv } from "../config/env.js";
+import type { MapsProvider } from "../providers/maps/mapsProvider.js";
+
+function createEnrichmentTestApp(provider: MapsProvider) {
+  return createApp({
+    env: defaultApiEnv,
+    mapsProvider: provider
+  });
+}
+
+describe("POST /api/enrichment/maps/link", () => {
+  test("returns an external Google Maps search link", async () => {
+    const response = await request(createApp({ env: defaultApiEnv }))
+      .post("/api/enrichment/maps/link")
+      .send({
+        title: "Senso-ji morning visit",
+        location: {
+          name: "Senso-ji",
+          city: "Tokyo"
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      mapUrl:
+        "https://www.google.com/maps/search/?api=1&query=Senso-ji%20morning%20visit%20Senso-ji%20Tokyo"
+    });
+  });
+
+  test("returns null when no usable location is provided", async () => {
+    const response = await request(createApp({ env: defaultApiEnv }))
+      .post("/api/enrichment/maps/link")
+      .send({
+        title: "Only a title",
+        location: {
+          name: " "
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      mapUrl: null
+    });
+  });
+
+  test("returns structured validation errors for invalid map link input", async () => {
+    const response = await request(createApp({ env: defaultApiEnv }))
+      .post("/api/enrichment/maps/link")
+      .send({
+        location: {
+          latitude: 120,
+          longitude: 139.7967
+        }
+      });
+
+    expect(response.status).toBe(400);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "Request validation failed."
+    });
+    expect(response.body.error.fieldErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "location.latitude"
+        })
+      ])
+    );
+  });
+
+  test("degrades gracefully when the maps provider fails", async () => {
+    const mapsProvider = {
+      createSearchLink: vi.fn(() => {
+        throw new Error("provider unavailable");
+      })
+    } satisfies MapsProvider;
+    const response = await request(createEnrichmentTestApp(mapsProvider))
+      .post("/api/enrichment/maps/link")
+      .send({
+        title: "Senso-ji morning visit",
+        location: {
+          name: "Senso-ji",
+          city: "Tokyo"
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      mapUrl: null
+    });
+  });
+});

--- a/apps/api/src/routes/enrichment.ts
+++ b/apps/api/src/routes/enrichment.ts
@@ -1,0 +1,46 @@
+import { Router, type RequestHandler } from "express";
+import { z } from "zod";
+
+import { validateRequest } from "../middleware/validateRequest.js";
+import type { MapsProvider } from "../providers/maps/mapsProvider.js";
+import { createMapLink } from "../services/enrichment/mapEnrichment.js";
+
+const mapLinkBodySchema = z
+  .object({
+    title: z.string().optional(),
+    location: z
+      .object({
+        address: z.string().optional(),
+        city: z.string().optional(),
+        latitude: z.number().min(-90).max(90).optional(),
+        longitude: z.number().min(-180).max(180).optional(),
+        name: z.string().optional()
+      })
+      .strict()
+      .optional()
+  })
+  .strict();
+
+function asyncHandler(handler: RequestHandler): RequestHandler {
+  return (request, response, next) => {
+    Promise.resolve(handler(request, response, next)).catch(next);
+  };
+}
+
+export function createEnrichmentRouter(options: {
+  mapsProvider: MapsProvider;
+}) {
+  const router = Router();
+
+  router.post(
+    "/maps/link",
+    validateRequest(mapLinkBodySchema),
+    asyncHandler(async (request, response) => {
+      response.status(200).json({
+        mapUrl: createMapLink(request.body, options.mapsProvider)
+      });
+    })
+  );
+
+  return router;
+}

--- a/apps/api/src/services/enrichment/mapEnrichment.test.ts
+++ b/apps/api/src/services/enrichment/mapEnrichment.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Activity } from "@japan-travel-planner/shared";
+
+import type { MapsProvider } from "../../providers/maps/mapsProvider.js";
+import {
+  enrichActivityWithMapLink,
+  getActivityMapUrl
+} from "./mapEnrichment.js";
+
+const activity: Activity = {
+  title: "Senso-ji morning visit",
+  category: "culture",
+  timing: {
+    timeOfDay: "morning"
+  },
+  durationMinutes: 90,
+  location: {
+    name: "Senso-ji",
+    city: "Tokyo"
+  },
+  costLevel: "free",
+  notes: "Arrive before the busiest temple hours."
+};
+
+describe("map enrichment", () => {
+  test("creates an activity map URL from activity location", () => {
+    expect(getActivityMapUrl(activity)).toBe(
+      "https://www.google.com/maps/search/?api=1&query=Senso-ji%20morning%20visit%20Senso-ji%20Tokyo"
+    );
+  });
+
+  test("preserves existing activity map URLs", () => {
+    const provider = {
+      createSearchLink: vi.fn(() => "https://example.com/generated")
+    } satisfies MapsProvider;
+    const existingMapUrl = "https://www.google.com/maps/place/Senso-ji";
+
+    expect(
+      getActivityMapUrl(
+        {
+          ...activity,
+          location: {
+            ...activity.location,
+            mapUrl: existingMapUrl
+          }
+        },
+        provider
+      )
+    ).toBe(existingMapUrl);
+    expect(provider.createSearchLink).not.toHaveBeenCalled();
+  });
+
+  test("adds a generated map URL without mutating the source activity", () => {
+    const enrichedActivity = enrichActivityWithMapLink(activity);
+
+    expect(enrichedActivity.location.mapUrl).toContain(
+      "https://www.google.com/maps/search/"
+    );
+    expect(activity.location.mapUrl).toBeUndefined();
+  });
+
+  test("degrades gracefully when the provider fails", () => {
+    const provider = {
+      createSearchLink: vi.fn(() => {
+        throw new Error("provider unavailable");
+      })
+    } satisfies MapsProvider;
+
+    expect(getActivityMapUrl(activity, provider)).toBeNull();
+    expect(enrichActivityWithMapLink(activity, provider)).toEqual(activity);
+  });
+});

--- a/apps/api/src/services/enrichment/mapEnrichment.ts
+++ b/apps/api/src/services/enrichment/mapEnrichment.ts
@@ -1,0 +1,68 @@
+import type { Activity } from "@japan-travel-planner/shared";
+
+import {
+  createGoogleMapsProvider,
+  type MapLinkInput,
+  type MapsProvider
+} from "../../providers/maps/mapsProvider.js";
+
+const defaultMapsProvider = createGoogleMapsProvider();
+
+export function activityToMapLinkInput(activity: Activity): MapLinkInput {
+  return {
+    title: activity.title,
+    location: {
+      address: activity.location.address,
+      city: activity.location.city,
+      latitude: activity.location.latitude,
+      longitude: activity.location.longitude,
+      name: activity.location.name
+    }
+  };
+}
+
+export function createMapLink(
+  input: MapLinkInput,
+  provider: MapsProvider = defaultMapsProvider
+) {
+  try {
+    return provider.createSearchLink(input);
+  } catch {
+    return null;
+  }
+}
+
+export function getActivityMapUrl(
+  activity: Activity,
+  provider: MapsProvider = defaultMapsProvider
+) {
+  const existingMapUrl = activity.location.mapUrl?.trim();
+
+  if (existingMapUrl && existingMapUrl.length > 0) {
+    return existingMapUrl;
+  }
+
+  return createMapLink(activityToMapLinkInput(activity), provider);
+}
+
+export function enrichActivityWithMapLink(
+  activity: Activity,
+  provider: MapsProvider = defaultMapsProvider
+): Activity {
+  const mapUrl = getActivityMapUrl(activity, provider);
+
+  if (mapUrl === null) {
+    return {
+      ...activity,
+      location: { ...activity.location }
+    };
+  }
+
+  return {
+    ...activity,
+    location: {
+      ...activity.location,
+      mapUrl
+    }
+  };
+}

--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -299,6 +299,15 @@ test("traveler can plan and edit a mock itinerary", async ({ page }) => {
   await expect(
     dayOne.getByRole("heading", { name: "Morning walk through Ueno Park" })
   ).toBeVisible();
+  await expect(
+    dayOne.getByRole("link", { name: "Open in Google Maps" }).first()
+  ).toHaveAttribute(
+    "href",
+    "https://www.google.com/maps/search/?api=1&query=Ueno%20Park%20Tokyo"
+  );
+  await expect(
+    dayOne.getByRole("link", { name: "Open in Google Maps" }).first()
+  ).toHaveAttribute("target", "_blank");
 
   await page
     .getByRole("button", { name: "Edit Morning walk through Ueno Park" })
@@ -371,6 +380,12 @@ test("traveler can generate and edit an itinerary from a mocked AI API response"
   await expect(
     dayOne.getByRole("heading", { name: "Generated Senso-ji morning" })
   ).toBeVisible();
+  await expect(
+    dayOne.getByRole("link", { name: "Open in Google Maps" }).first()
+  ).toHaveAttribute(
+    "href",
+    "https://www.google.com/maps/search/?api=1&query=Generated%20Senso-ji%20morning%20Senso-ji%20Tokyo"
+  );
   await expect(
     page.getByRole("button", { name: "Save itinerary" })
   ).toBeEnabled();

--- a/apps/web/src/features/itinerary/ActivityCard.test.tsx
+++ b/apps/web/src/features/itinerary/ActivityCard.test.tsx
@@ -1,0 +1,66 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import type { Activity } from "../../../../../packages/shared/src/schemas/itinerary.js";
+import { ActivityCard } from "./ActivityCard.js";
+
+const activity = {
+  title: "Senso-ji morning visit",
+  category: "culture",
+  timing: {
+    timeOfDay: "morning"
+  },
+  durationMinutes: 90,
+  location: {
+    name: "Senso-ji",
+    city: "Tokyo"
+  },
+  costLevel: "free",
+  notes: "Arrive before the busiest temple hours."
+} satisfies Activity;
+
+describe("ActivityCard map links", () => {
+  test("renders an external Google Maps link when location text is available", () => {
+    const html = renderToString(<ActivityCard activity={activity} />);
+
+    expect(html).toContain("Open in Google Maps");
+    expect(html).toContain(
+      "https://www.google.com/maps/search/?api=1&amp;query=Senso-ji%20morning%20visit%20Senso-ji%20Tokyo"
+    );
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noreferrer"');
+  });
+
+  test("preserves existing activity map links", () => {
+    const existingMapUrl = "https://www.google.com/maps/place/Senso-ji";
+    const html = renderToString(
+      <ActivityCard
+        activity={{
+          ...activity,
+          location: {
+            ...activity.location,
+            mapUrl: existingMapUrl
+          }
+        }}
+      />
+    );
+
+    expect(html).toContain(existingMapUrl);
+  });
+
+  test("does not render a map link when location text is unavailable", () => {
+    const html = renderToString(
+      <ActivityCard
+        activity={{
+          ...activity,
+          location: {
+            name: " "
+          }
+        }}
+      />
+    );
+
+    expect(html).not.toContain("Open in Google Maps");
+    expect(html).not.toContain("https://www.google.com/maps/search/");
+  });
+});

--- a/apps/web/src/features/itinerary/ActivityCard.tsx
+++ b/apps/web/src/features/itinerary/ActivityCard.tsx
@@ -5,6 +5,7 @@ import type {
 } from "../../../../../packages/shared/src/schemas/itinerary.js";
 import { ReorderControls } from "./editing/ReorderControls.js";
 import type { ReorderDirection } from "./editing/useItineraryEditor.js";
+import { createActivityGoogleMapsUrl } from "./mapLinks.js";
 
 const categoryLabels: Record<ActivityCategory, string> = {
   sightseeing: "Sightseeing",
@@ -64,6 +65,8 @@ export function ActivityCard({ activity, editingControls }: ActivityCardProps) {
     activity.location.address ??
     activity.location.city ??
     activity.location.name;
+  const mapUrl =
+    activity.location.mapUrl ?? createActivityGoogleMapsUrl(activity);
 
   return (
     <article className="activity-card">
@@ -97,14 +100,14 @@ export function ActivityCard({ activity, editingControls }: ActivityCardProps) {
 
       <p className="activity-notes">{activity.notes}</p>
 
-      {activity.location.mapUrl ? (
+      {mapUrl ? (
         <a
           className="activity-map-link"
-          href={activity.location.mapUrl}
+          href={mapUrl}
           rel="noreferrer"
           target="_blank"
         >
-          Open map
+          Open in Google Maps
         </a>
       ) : null}
 

--- a/apps/web/src/features/itinerary/mapLinks.ts
+++ b/apps/web/src/features/itinerary/mapLinks.ts
@@ -1,0 +1,64 @@
+import type { Activity } from "../../../../../packages/shared/src/schemas/itinerary.js";
+
+const googleMapsSearchBaseUrl =
+  "https://www.google.com/maps/search/?api=1&query=";
+
+function cleanText(value: string | undefined) {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue && trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function addUniquePart(parts: string[], value: string | null) {
+  if (value === null) {
+    return;
+  }
+
+  if (!parts.some((part) => part.toLowerCase() === value.toLowerCase())) {
+    parts.push(value);
+  }
+}
+
+function getCoordinateQuery(activity: Activity) {
+  const { latitude, longitude } = activity.location;
+
+  if (
+    latitude === undefined ||
+    longitude === undefined ||
+    !Number.isFinite(latitude) ||
+    !Number.isFinite(longitude)
+  ) {
+    return null;
+  }
+
+  return `${latitude},${longitude}`;
+}
+
+export function createActivityGoogleMapsUrl(activity: Activity) {
+  const coordinateQuery = getCoordinateQuery(activity);
+
+  if (coordinateQuery !== null) {
+    return `${googleMapsSearchBaseUrl}${encodeURIComponent(coordinateQuery)}`;
+  }
+
+  const locationParts = [
+    cleanText(activity.location.address),
+    cleanText(activity.location.name),
+    cleanText(activity.location.city)
+  ].filter((part): part is string => part !== null);
+
+  if (locationParts.length === 0) {
+    return null;
+  }
+
+  const queryParts: string[] = [];
+
+  addUniquePart(queryParts, cleanText(activity.title));
+  for (const locationPart of locationParts) {
+    addUniquePart(queryParts, locationPart);
+  }
+
+  return `${googleMapsSearchBaseUrl}${encodeURIComponent(
+    queryParts.join(" ")
+  )}`;
+}


### PR DESCRIPTION
## Ticket scope

Implement T-026 / Ticket 26: Add Map Link Enrichment.

This PR adds MVP map context with external Google Maps search links only, aligned with ADR-003. It does not add embedded maps, route overviews, route planning, weather enrichment, provider caching, hotels, transit provider calls, sharing, PDF export, mobile, deployment, or observability work.

## Changes made

- Added a deterministic backend Google Maps search-link provider.
- Added a backend map enrichment service that can preserve existing map URLs, generate fallback links, and degrade to `null` on provider failure.
- Added `POST /api/enrichment/maps/link` for minimal backend map-link enrichment.
- Mounted the enrichment route in the Express app.
- Added a web-side deterministic link helper so itinerary display does not depend on API availability.
- Updated `ActivityCard` to render `Open in Google Maps` for existing `location.mapUrl` values or generated search links from activity location text.
- Added E2E assertions for mock itinerary links and generated itinerary fallback links.

## Map link generation design

- Links use `https://www.google.com/maps/search/?api=1&query=...`.
- Search queries are built from coordinates when both latitude and longitude are present.
- Otherwise, queries use available activity title plus location address/name/city.
- Query parts are trimmed, de-duplicated, and encoded with `encodeURIComponent`.
- Missing or empty location text returns `null` rather than throwing.

## Backend / provider-key handling

- No Google Maps API key is required for these external search links.
- `GOOGLE_MAPS_API_KEY` remains backend-only in `.env.example`; this PR does not add it to API config because it is not needed yet.
- No `VITE_GOOGLE_*` variables were added.
- Verified no `GOOGLE_MAPS_API_KEY` or `VITE_GOOGLE` strings appear in web source or the built web bundle.

## UI behavior

- Existing saved `location.mapUrl` values are preserved and rendered.
- Activities with usable location text but no saved `mapUrl` render a generated `Open in Google Maps` link.
- Activities without usable location text omit the link gracefully.
- Links open in a new tab with `target="_blank"` and `rel="noreferrer"`.

## Failure / degradation behavior

- Backend provider failures return `mapUrl: null` from the enrichment route instead of surfacing a 500.
- Itinerary rendering does not depend on the enrichment route; web link generation is deterministic and local.
- Missing map data does not block generated, saved, reopened, or mock itinerary display.

## Tests added/updated

- `apps/api/src/providers/maps/mapsProvider.test.ts`
- `apps/api/src/services/enrichment/mapEnrichment.test.ts`
- `apps/api/src/routes/enrichment.test.ts`
- `apps/web/src/features/itinerary/ActivityCard.test.tsx`
- `apps/web/e2e/trip-planning.spec.ts`

## Checks run

- `pnpm install` passed
- `pnpm lint` passed
- `pnpm typecheck` passed
- `pnpm test` passed
- `pnpm build` passed
- `pnpm --filter @japan-travel-planner/api test` passed
- `pnpm --filter @japan-travel-planner/api typecheck` passed
- `pnpm --filter @japan-travel-planner/api build` passed
- `pnpm --filter @japan-travel-planner/api exec prisma validate` passed
- `pnpm --filter @japan-travel-planner/api exec prisma generate` passed
- `pnpm --filter @japan-travel-planner/web test` passed
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit` passed
- `pnpm --filter @japan-travel-planner/web exec vite build` passed
- `pnpm --filter @japan-travel-planner/web test:e2e` passed
- `git diff --check` passed

## GitHub Actions

- CI `Install, lint, typecheck, test, and build` passed on PR #25.

## Manual checks run

- Started API with `env -u OPENAI_API_KEY pnpm dev:api`.
- Confirmed `GET http://localhost:3001/api/health` returned HTTP 200 with JSON status `ok`.
- Confirmed `POST http://localhost:3001/api/enrichment/maps/link` returned an encoded Google Maps URL for Japanese/special-character input.
- Started web with `pnpm dev:web` at `http://localhost:5173`.
- Opened the mock itinerary in the browser and confirmed eligible activities render `Open in Google Maps` links.
- Confirmed map links include encoded Google Maps search URLs, `target="_blank"`, and `rel="noreferrer"`.
- Clicked a map link and confirmed it opened a Google Maps search tab.
- Confirmed no horizontal overflow in the current browser viewport.
- Confirmed no `GOOGLE_MAPS_API_KEY` or `VITE_GOOGLE` string appears in the web source or built bundle.

## Real provider calls

- No real Google Maps API call was made.
- No real OpenAI API call was made.

## Known risks

- The web and backend both generate deterministic search URLs so the UI does not rely on the API route; this duplicates a small amount of link-generation logic until a later shared/provider abstraction is justified.
- The route is intentionally minimal and does not cache results; provider result caching remains Ticket 28.
- Existing AI prompt text still says map enrichment is not available yet; this PR only adds external map links and does not change AI generation behavior.

## Out of scope confirmation

Ticket 27 and later were not started. This PR does not add weather enrichment, provider result caching, embedded maps, route overviews, route planning, Google Routes API usage, hotel/transit provider integrations, sharing, PDF export, mobile work, deployment, observability, Prisma schema changes, migrations, OpenAI behavior changes, or server-only provider key exposure.