### PR TITLE
Add weather enrichment

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,6 +9,10 @@ import {
   createGoogleMapsProvider,
   type MapsProvider
 } from "./providers/maps/mapsProvider.js";
+import {
+  createOpenWeatherProvider,
+  type WeatherProvider
+} from "./providers/weather/weatherProvider.js";
 import { createEnrichmentRouter } from "./routes/enrichment.js";
 import { healthRouter } from "./routes/health.js";
 import { createItinerariesRouter } from "./routes/itineraries.js";
@@ -32,6 +36,7 @@ export type CreateAppOptions = {
   mapsProvider?: MapsProvider;
   sessionMiddleware?: RequestHandler;
   tripService?: TripService;
+  weatherProvider?: WeatherProvider;
 };
 
 export function createApp(options: CreateAppOptions = {}) {
@@ -65,6 +70,11 @@ export function createApp(options: CreateAppOptions = {}) {
     });
   const tripService = options.tripService ?? createTripService();
   const mapsProvider = options.mapsProvider ?? createGoogleMapsProvider();
+  const weatherProvider =
+    options.weatherProvider ??
+    createOpenWeatherProvider({
+      apiKey: env.weatherApiKey
+    });
   const app = express();
 
   app.use(
@@ -75,7 +85,10 @@ export function createApp(options: CreateAppOptions = {}) {
   );
   app.use(express.json());
   app.use("/api/health", healthRouter);
-  app.use("/api/enrichment", createEnrichmentRouter({ mapsProvider }));
+  app.use(
+    "/api/enrichment",
+    createEnrichmentRouter({ mapsProvider, weatherProvider })
+  );
   app.use(
     "/api/itineraries",
     createItinerariesRouter(aiItineraryService, {

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -15,6 +15,7 @@ describe("loadApiEnv", () => {
         API_PORT: "4001",
         OPENAI_API_KEY: "sk-test-api-key",
         OPENAI_MODEL: "gpt-test-model",
+        WEATHER_API_KEY: "weather-test-key",
         WEB_ORIGIN: "https://planner.example.com",
         JWT_SECRET: "test-session-secret-value"
       })
@@ -24,14 +25,16 @@ describe("loadApiEnv", () => {
       apiPort: 4001,
       openAiApiKey: "sk-test-api-key",
       openAiModel: "gpt-test-model",
+      weatherApiKey: "weather-test-key",
       webOrigin: "https://planner.example.com",
       jwtSecret: "test-session-secret-value"
     });
   });
 
-  test("does not require OPENAI_API_KEY during API env loading", () => {
+  test("does not require provider keys during API env loading", () => {
     expect(loadApiEnv({}).openAiApiKey).toBeUndefined();
     expect(loadApiEnv({}).openAiModel).toBe(defaultApiEnv.openAiModel);
+    expect(loadApiEnv({}).weatherApiKey).toBeUndefined();
   });
 
   test("fails clearly for invalid API_PORT", () => {

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -4,6 +4,7 @@ export type ApiEnvConfig = {
   apiPort: number;
   openAiApiKey: string | undefined;
   openAiModel: string;
+  weatherApiKey: string | undefined;
   webOrigin: string;
   jwtSecret: string;
 };
@@ -17,6 +18,7 @@ export const defaultApiEnv = {
   apiPort: 3001,
   openAiApiKey: undefined,
   openAiModel: defaultOpenAiModel,
+  weatherApiKey: undefined,
   webOrigin: "http://localhost:5173",
   jwtSecret: localDevelopmentJwtSecret
 } satisfies ApiEnvConfig;
@@ -27,6 +29,7 @@ type ApiEnvSource = {
   API_PORT?: string | undefined;
   OPENAI_API_KEY?: string | undefined;
   OPENAI_MODEL?: string | undefined;
+  WEATHER_API_KEY?: string | undefined;
   WEB_ORIGIN?: string | undefined;
   JWT_SECRET?: string | undefined;
   NODE_ENV?: string | undefined;
@@ -94,6 +97,12 @@ function parseOpenAiApiKey(value: string | undefined) {
   return rawApiKey && rawApiKey.length > 0 ? rawApiKey : undefined;
 }
 
+function parseWeatherApiKey(value: string | undefined) {
+  const rawApiKey = value?.trim();
+
+  return rawApiKey && rawApiKey.length > 0 ? rawApiKey : undefined;
+}
+
 function parseOpenAiModel(value: string | undefined) {
   const rawModel = value?.trim();
 
@@ -140,6 +149,7 @@ export function loadApiEnv(env: ApiEnvSource = process.env): ApiEnvConfig {
     apiPort: parseApiPort(env.API_PORT),
     openAiApiKey: parseOpenAiApiKey(env.OPENAI_API_KEY),
     openAiModel: parseOpenAiModel(env.OPENAI_MODEL),
+    weatherApiKey: parseWeatherApiKey(env.WEATHER_API_KEY),
     webOrigin: parseWebOrigin(env.WEB_ORIGIN),
     jwtSecret: parseJwtSecret(env.JWT_SECRET, env.NODE_ENV)
   };

--- a/apps/api/src/providers/weather/weatherProvider.test.ts
+++ b/apps/api/src/providers/weather/weatherProvider.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  WeatherProviderConfigurationError,
+  WeatherProviderError,
+  createOpenWeatherProvider
+} from "./weatherProvider.js";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "content-type": "application/json"
+    },
+    status
+  });
+}
+
+function createFetchMock(responses: Response[]) {
+  return vi.fn(async () => {
+    const response = responses.shift();
+
+    if (response === undefined) {
+      throw new Error("Unexpected weather provider request.");
+    }
+
+    return response;
+  }) as unknown as typeof fetch;
+}
+
+function getRequestedUrl(fetchMock: typeof fetch, index: number) {
+  const requestInput = vi.mocked(fetchMock).mock.calls[index]?.[0];
+
+  if (requestInput === undefined) {
+    throw new Error(`Missing fetch call ${index}.`);
+  }
+
+  return new URL(String(requestInput));
+}
+
+const dailySummaryResponse = {
+  date: "2026-04-06",
+  cloud_cover: {
+    afternoon: 45
+  },
+  humidity: {
+    afternoon: 61
+  },
+  precipitation: {
+    total: 1.24
+  },
+  temperature: {
+    min: 12.42,
+    max: 20.76
+  },
+  wind: {
+    max: {
+      speed: 5.24
+    }
+  }
+};
+
+describe("createOpenWeatherProvider", () => {
+  test("fetches and normalizes daily weather by city and date", async () => {
+    const fetchMock = createFetchMock([
+      jsonResponse([
+        {
+          name: "Tokyo",
+          lat: 35.6762,
+          lon: 139.6503,
+          country: "JP"
+        }
+      ]),
+      jsonResponse(dailySummaryResponse)
+    ]);
+    const provider = createOpenWeatherProvider({
+      apiKey: "weather-test-key",
+      fetch: fetchMock
+    });
+
+    const summary = await provider.getDailySummary({
+      city: "Tokyo",
+      countryCode: "JP",
+      date: "2026-04-06"
+    });
+
+    expect(summary).toEqual({
+      city: "Tokyo",
+      cloudCoverPercent: 45,
+      condition: "Precipitation possible",
+      coordinates: {
+        latitude: 35.6762,
+        longitude: 139.6503
+      },
+      date: "2026-04-06",
+      humidityPercent: 61,
+      note: "Precipitation possible, 12.4-20.8 C, 1.2 mm precipitation expected",
+      precipitationProbabilityPercent: null,
+      precipitationTotalMillimeters: 1.2,
+      temperatureMax: 20.8,
+      temperatureMin: 12.4,
+      temperatureUnit: "celsius",
+      windSpeed: 5.2,
+      windSpeedUnit: "meters_per_second"
+    });
+
+    const geocodeUrl = getRequestedUrl(fetchMock, 0);
+    const weatherUrl = getRequestedUrl(fetchMock, 1);
+
+    expect(geocodeUrl.pathname).toBe("/geo/1.0/direct");
+    expect(geocodeUrl.searchParams.get("q")).toBe("Tokyo,JP");
+    expect(geocodeUrl.searchParams.get("appid")).toBe("weather-test-key");
+    expect(weatherUrl.pathname).toBe("/data/3.0/onecall/day_summary");
+    expect(weatherUrl.searchParams.get("lat")).toBe("35.6762");
+    expect(weatherUrl.searchParams.get("lon")).toBe("139.6503");
+    expect(weatherUrl.searchParams.get("date")).toBe("2026-04-06");
+    expect(weatherUrl.searchParams.get("units")).toBe("metric");
+    expect(weatherUrl.searchParams.get("appid")).toBe("weather-test-key");
+  });
+
+  test("uses provided coordinates without geocoding", async () => {
+    const fetchMock = createFetchMock([jsonResponse(dailySummaryResponse)]);
+    const provider = createOpenWeatherProvider({
+      apiKey: "weather-test-key",
+      fetch: fetchMock
+    });
+
+    const summary = await provider.getDailySummary({
+      city: "Kyoto",
+      date: "2026-04-07",
+      latitude: 35.0116,
+      longitude: 135.7681,
+      units: "imperial"
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(summary).toMatchObject({
+      city: "Kyoto",
+      coordinates: {
+        latitude: 35.0116,
+        longitude: 135.7681
+      },
+      temperatureUnit: "fahrenheit",
+      windSpeedUnit: "miles_per_hour"
+    });
+  });
+
+  test("returns null when city geocoding has no result", async () => {
+    const fetchMock = createFetchMock([jsonResponse([])]);
+    const provider = createOpenWeatherProvider({
+      apiKey: "weather-test-key",
+      fetch: fetchMock
+    });
+
+    await expect(
+      provider.getDailySummary({
+        city: "Unknown Place",
+        date: "2026-04-06"
+      })
+    ).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails clearly when WEATHER_API_KEY is missing", async () => {
+    const fetchMock = createFetchMock([]);
+    const provider = createOpenWeatherProvider({
+      fetch: fetchMock
+    });
+
+    await expect(
+      provider.getDailySummary({
+        city: "Tokyo",
+        date: "2026-04-06"
+      })
+    ).rejects.toBeInstanceOf(WeatherProviderConfigurationError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("wraps provider and network failures safely", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network unavailable");
+    }) as unknown as typeof fetch;
+    const provider = createOpenWeatherProvider({
+      apiKey: "weather-test-key",
+      fetch: fetchMock
+    });
+
+    await expect(
+      provider.getDailySummary({
+        city: "Tokyo",
+        date: "2026-04-06"
+      })
+    ).rejects.toBeInstanceOf(WeatherProviderError);
+  });
+
+  test("normalizes sparse provider responses with missing weather fields", async () => {
+    const fetchMock = createFetchMock([
+      jsonResponse({
+        date: "2026-04-08",
+        cloud_cover: {
+          afternoon: 82
+        }
+      })
+    ]);
+    const provider = createOpenWeatherProvider({
+      apiKey: "weather-test-key",
+      fetch: fetchMock
+    });
+
+    const summary = await provider.getDailySummary({
+      date: "2026-04-08",
+      latitude: 35.0116,
+      longitude: 135.7681
+    });
+
+    expect(summary).toMatchObject({
+      city: null,
+      cloudCoverPercent: 82,
+      condition: "Cloudy",
+      humidityPercent: null,
+      note: "Cloudy, low precipitation expected",
+      precipitationProbabilityPercent: null,
+      precipitationTotalMillimeters: null,
+      temperatureMax: null,
+      temperatureMin: null,
+      windSpeed: null
+    });
+  });
+});

--- a/apps/api/src/providers/weather/weatherProvider.ts
+++ b/apps/api/src/providers/weather/weatherProvider.ts
@@ -1,0 +1,445 @@
+import { z } from "zod";
+
+export type WeatherUnits = "metric" | "imperial" | "standard";
+
+export type TemperatureUnit = "celsius" | "fahrenheit" | "kelvin";
+
+export type WindSpeedUnit = "meters_per_second" | "miles_per_hour";
+
+export type WeatherSummaryRequest = {
+  city?: string | undefined;
+  countryCode?: string | undefined;
+  date: string;
+  latitude?: number | undefined;
+  longitude?: number | undefined;
+  units?: WeatherUnits | undefined;
+};
+
+export type WeatherSummary = {
+  city: string | null;
+  cloudCoverPercent: number | null;
+  condition: string;
+  coordinates: {
+    latitude: number;
+    longitude: number;
+  };
+  date: string;
+  humidityPercent: number | null;
+  note: string;
+  precipitationProbabilityPercent: number | null;
+  precipitationTotalMillimeters: number | null;
+  temperatureMax: number | null;
+  temperatureMin: number | null;
+  temperatureUnit: TemperatureUnit;
+  windSpeed: number | null;
+  windSpeedUnit: WindSpeedUnit;
+};
+
+export type WeatherProvider = {
+  getDailySummary: (
+    input: WeatherSummaryRequest
+  ) => Promise<WeatherSummary | null>;
+};
+
+export type OpenWeatherProviderOptions = {
+  apiKey?: string | undefined;
+  fetch?: typeof fetch | undefined;
+  geocodingBaseUrl?: string | undefined;
+  weatherBaseUrl?: string | undefined;
+};
+
+type Coordinates = {
+  latitude: number;
+  longitude: number;
+};
+
+const defaultGeocodingBaseUrl =
+  "https://api.openweathermap.org/geo/1.0/direct";
+const defaultWeatherBaseUrl =
+  "https://api.openweathermap.org/data/3.0/onecall/day_summary";
+
+const geocodingResponseSchema = z.array(
+  z
+    .object({
+      country: z.string().optional(),
+      lat: z.number(),
+      lon: z.number(),
+      name: z.string().optional()
+    })
+    .passthrough()
+);
+
+const dailySummaryResponseSchema = z
+  .object({
+    cloud_cover: z
+      .object({
+        afternoon: z.number().nullable().optional()
+      })
+      .passthrough()
+      .optional(),
+    date: z.string().optional(),
+    humidity: z
+      .object({
+        afternoon: z.number().nullable().optional()
+      })
+      .passthrough()
+      .optional(),
+    precipitation: z
+      .object({
+        total: z.number().nullable().optional()
+      })
+      .passthrough()
+      .optional(),
+    temperature: z
+      .object({
+        max: z.number().nullable().optional(),
+        min: z.number().nullable().optional()
+      })
+      .passthrough()
+      .optional(),
+    wind: z
+      .object({
+        max: z
+          .object({
+            speed: z.number().nullable().optional()
+          })
+          .passthrough()
+          .optional()
+      })
+      .passthrough()
+      .optional()
+  })
+  .passthrough();
+
+type DailySummaryResponse = z.infer<typeof dailySummaryResponseSchema>;
+
+export class WeatherProviderConfigurationError extends Error {
+  constructor() {
+    super("Weather provider is not configured.");
+    this.name = "WeatherProviderConfigurationError";
+  }
+}
+
+export class WeatherProviderError extends Error {
+  constructor() {
+    super("Weather provider request failed.");
+    this.name = "WeatherProviderError";
+  }
+}
+
+function cleanApiKey(apiKey: string | undefined) {
+  const trimmedApiKey = apiKey?.trim();
+
+  return trimmedApiKey && trimmedApiKey.length > 0 ? trimmedApiKey : null;
+}
+
+function requireApiKey(apiKey: string | undefined) {
+  const configuredApiKey = cleanApiKey(apiKey);
+
+  if (configuredApiKey === null) {
+    throw new WeatherProviderConfigurationError();
+  }
+
+  return configuredApiKey;
+}
+
+function optionalNumber(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function roundToOneDecimal(value: number | null) {
+  return value === null ? null : Math.round(value * 10) / 10;
+}
+
+function getTemperatureUnit(units: WeatherUnits): TemperatureUnit {
+  if (units === "imperial") {
+    return "fahrenheit";
+  }
+
+  if (units === "standard") {
+    return "kelvin";
+  }
+
+  return "celsius";
+}
+
+function getWindSpeedUnit(units: WeatherUnits): WindSpeedUnit {
+  return units === "imperial" ? "miles_per_hour" : "meters_per_second";
+}
+
+function getTemperatureSymbol(unit: TemperatureUnit) {
+  if (unit === "fahrenheit") {
+    return "F";
+  }
+
+  if (unit === "kelvin") {
+    return "K";
+  }
+
+  return "C";
+}
+
+function formatTemperatureRange(
+  minTemperature: number | null,
+  maxTemperature: number | null,
+  unit: TemperatureUnit
+) {
+  const symbol = getTemperatureSymbol(unit);
+
+  if (minTemperature !== null && maxTemperature !== null) {
+    return `${minTemperature}-${maxTemperature} ${symbol}`;
+  }
+
+  if (minTemperature !== null) {
+    return `from ${minTemperature} ${symbol}`;
+  }
+
+  if (maxTemperature !== null) {
+    return `up to ${maxTemperature} ${symbol}`;
+  }
+
+  return null;
+}
+
+function deriveCondition(options: {
+  cloudCoverPercent: number | null;
+  precipitationTotalMillimeters: number | null;
+}) {
+  if (
+    options.precipitationTotalMillimeters !== null &&
+    options.precipitationTotalMillimeters > 0
+  ) {
+    return "Precipitation possible";
+  }
+
+  if (
+    options.cloudCoverPercent !== null &&
+    options.cloudCoverPercent >= 70
+  ) {
+    return "Cloudy";
+  }
+
+  if (
+    options.cloudCoverPercent !== null &&
+    options.cloudCoverPercent >= 35
+  ) {
+    return "Partly cloudy";
+  }
+
+  return "Mostly clear";
+}
+
+function createWeatherNote(options: {
+  condition: string;
+  precipitationTotalMillimeters: number | null;
+  temperatureMax: number | null;
+  temperatureMin: number | null;
+  temperatureUnit: TemperatureUnit;
+}) {
+  const temperatureRange = formatTemperatureRange(
+    options.temperatureMin,
+    options.temperatureMax,
+    options.temperatureUnit
+  );
+  const precipitationNote =
+    options.precipitationTotalMillimeters !== null &&
+    options.precipitationTotalMillimeters > 0
+      ? `${options.precipitationTotalMillimeters} mm precipitation expected`
+      : "low precipitation expected";
+
+  return [
+    options.condition,
+    temperatureRange,
+    precipitationNote
+  ]
+    .filter((part): part is string => part !== null)
+    .join(", ");
+}
+
+async function fetchJson(fetchImpl: typeof fetch, url: URL) {
+  let response: Response;
+
+  try {
+    response = await fetchImpl(url);
+  } catch {
+    throw new WeatherProviderError();
+  }
+
+  if (!response.ok) {
+    throw new WeatherProviderError();
+  }
+
+  try {
+    return (await response.json()) as unknown;
+  } catch {
+    throw new WeatherProviderError();
+  }
+}
+
+function getCoordinatesFromInput(input: WeatherSummaryRequest) {
+  if (
+    input.latitude === undefined ||
+    input.longitude === undefined ||
+    !Number.isFinite(input.latitude) ||
+    !Number.isFinite(input.longitude)
+  ) {
+    return null;
+  }
+
+  return {
+    latitude: input.latitude,
+    longitude: input.longitude
+  };
+}
+
+async function geocodeCity(options: {
+  apiKey: string;
+  city: string;
+  countryCode?: string | undefined;
+  fetchImpl: typeof fetch;
+  geocodingBaseUrl: string;
+}) {
+  const url = new URL(options.geocodingBaseUrl);
+  const query = [options.city.trim(), options.countryCode?.trim()]
+    .filter((part): part is string => Boolean(part && part.length > 0))
+    .join(",");
+
+  url.searchParams.set("q", query);
+  url.searchParams.set("limit", "1");
+  url.searchParams.set("appid", options.apiKey);
+
+  const body = await fetchJson(options.fetchImpl, url);
+  const parsedBody = geocodingResponseSchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    throw new WeatherProviderError();
+  }
+
+  const firstResult = parsedBody.data[0];
+
+  if (firstResult === undefined) {
+    return null;
+  }
+
+  return {
+    city: firstResult.name ?? options.city,
+    coordinates: {
+      latitude: firstResult.lat,
+      longitude: firstResult.lon
+    }
+  };
+}
+
+export function normalizeOpenWeatherDailySummary(options: {
+  city: string | null;
+  coordinates: Coordinates;
+  date: string;
+  response: DailySummaryResponse;
+  units: WeatherUnits;
+}): WeatherSummary {
+  const cloudCoverPercent = optionalNumber(
+    options.response.cloud_cover?.afternoon
+  );
+  const humidityPercent = optionalNumber(options.response.humidity?.afternoon);
+  const precipitationTotalMillimeters = roundToOneDecimal(
+    optionalNumber(options.response.precipitation?.total)
+  );
+  const temperatureUnit = getTemperatureUnit(options.units);
+  const temperatureMax = roundToOneDecimal(
+    optionalNumber(options.response.temperature?.max)
+  );
+  const temperatureMin = roundToOneDecimal(
+    optionalNumber(options.response.temperature?.min)
+  );
+  const windSpeed = roundToOneDecimal(
+    optionalNumber(options.response.wind?.max?.speed)
+  );
+  const condition = deriveCondition({
+    cloudCoverPercent,
+    precipitationTotalMillimeters
+  });
+
+  return {
+    city: options.city,
+    cloudCoverPercent,
+    condition,
+    coordinates: options.coordinates,
+    date: options.response.date ?? options.date,
+    humidityPercent,
+    note: createWeatherNote({
+      condition,
+      precipitationTotalMillimeters,
+      temperatureMax,
+      temperatureMin,
+      temperatureUnit
+    }),
+    precipitationProbabilityPercent: null,
+    precipitationTotalMillimeters,
+    temperatureMax,
+    temperatureMin,
+    temperatureUnit,
+    windSpeed,
+    windSpeedUnit: getWindSpeedUnit(options.units)
+  };
+}
+
+export function createOpenWeatherProvider(
+  options: OpenWeatherProviderOptions = {}
+): WeatherProvider {
+  const fetchImpl = options.fetch ?? fetch;
+  const geocodingBaseUrl =
+    options.geocodingBaseUrl ?? defaultGeocodingBaseUrl;
+  const weatherBaseUrl = options.weatherBaseUrl ?? defaultWeatherBaseUrl;
+
+  return {
+    async getDailySummary(input) {
+      const apiKey = requireApiKey(options.apiKey);
+      const units = input.units ?? "metric";
+      let coordinates = getCoordinatesFromInput(input);
+      let city = input.city?.trim() || null;
+
+      if (coordinates === null && city !== null) {
+        const geocodedLocation = await geocodeCity({
+          apiKey,
+          city,
+          countryCode: input.countryCode,
+          fetchImpl,
+          geocodingBaseUrl
+        });
+
+        if (geocodedLocation === null) {
+          return null;
+        }
+
+        city = geocodedLocation.city;
+        coordinates = geocodedLocation.coordinates;
+      }
+
+      if (coordinates === null) {
+        return null;
+      }
+
+      const url = new URL(weatherBaseUrl);
+      url.searchParams.set("lat", String(coordinates.latitude));
+      url.searchParams.set("lon", String(coordinates.longitude));
+      url.searchParams.set("date", input.date);
+      url.searchParams.set("units", units);
+      url.searchParams.set("appid", apiKey);
+
+      const body = await fetchJson(fetchImpl, url);
+      const parsedBody = dailySummaryResponseSchema.safeParse(body);
+
+      if (!parsedBody.success) {
+        throw new WeatherProviderError();
+      }
+
+      return normalizeOpenWeatherDailySummary({
+        city,
+        coordinates,
+        date: input.date,
+        response: parsedBody.data,
+        units
+      });
+    }
+  };
+}

--- a/apps/api/src/routes/enrichment.test.ts
+++ b/apps/api/src/routes/enrichment.test.ts
@@ -6,11 +6,46 @@ import { apiErrorSchema } from "@japan-travel-planner/shared";
 import { createApp } from "../app.js";
 import { defaultApiEnv } from "../config/env.js";
 import type { MapsProvider } from "../providers/maps/mapsProvider.js";
+import {
+  WeatherProviderError,
+  type WeatherProvider,
+  type WeatherSummary
+} from "../providers/weather/weatherProvider.js";
 
-function createEnrichmentTestApp(provider: MapsProvider) {
+const defaultMapsProvider = {
+  createSearchLink: vi.fn(() => null)
+} satisfies MapsProvider;
+
+const weatherSummary = {
+  city: "Tokyo",
+  cloudCoverPercent: 45,
+  condition: "Partly cloudy",
+  coordinates: {
+    latitude: 35.6762,
+    longitude: 139.6503
+  },
+  date: "2026-04-06",
+  humidityPercent: 61,
+  note: "Partly cloudy, 12-20 C, low precipitation expected",
+  precipitationProbabilityPercent: null,
+  precipitationTotalMillimeters: 0,
+  temperatureMax: 20,
+  temperatureMin: 12,
+  temperatureUnit: "celsius",
+  windSpeed: 5,
+  windSpeedUnit: "meters_per_second"
+} satisfies WeatherSummary;
+
+function createEnrichmentTestApp(options: {
+  mapsProvider?: MapsProvider | undefined;
+  weatherProvider?: WeatherProvider | undefined;
+}) {
   return createApp({
     env: defaultApiEnv,
-    mapsProvider: provider
+    mapsProvider: options.mapsProvider ?? defaultMapsProvider,
+    ...(options.weatherProvider !== undefined
+      ? { weatherProvider: options.weatherProvider }
+      : {})
   });
 }
 
@@ -80,7 +115,9 @@ describe("POST /api/enrichment/maps/link", () => {
         throw new Error("provider unavailable");
       })
     } satisfies MapsProvider;
-    const response = await request(createEnrichmentTestApp(mapsProvider))
+    const response = await request(
+      createEnrichmentTestApp({ mapsProvider })
+    )
       .post("/api/enrichment/maps/link")
       .send({
         title: "Senso-ji morning visit",
@@ -94,5 +131,128 @@ describe("POST /api/enrichment/maps/link", () => {
     expect(response.body).toEqual({
       mapUrl: null
     });
+  });
+});
+
+describe("POST /api/enrichment/weather/summary", () => {
+  test("returns an available weather summary", async () => {
+    const weatherProvider = {
+      getDailySummary: vi.fn(async () => weatherSummary)
+    } satisfies WeatherProvider;
+    const response = await request(
+      createEnrichmentTestApp({ weatherProvider })
+    )
+      .post("/api/enrichment/weather/summary")
+      .send({
+        city: "Tokyo",
+        countryCode: "jp",
+        date: "2026-04-06"
+      });
+
+    expect(response.status).toBe(200);
+    expect(weatherProvider.getDailySummary).toHaveBeenCalledWith({
+      city: "Tokyo",
+      countryCode: "JP",
+      date: "2026-04-06",
+      units: "metric"
+    });
+    expect(response.body).toEqual({
+      status: "available",
+      weatherSummary
+    });
+  });
+
+  test("returns a structured missing config error when WEATHER_API_KEY is absent", async () => {
+    const response = await request(createApp({ env: defaultApiEnv }))
+      .post("/api/enrichment/weather/summary")
+      .send({
+        city: "Tokyo",
+        date: "2026-04-06"
+      });
+
+    expect(response.status).toBe(503);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toEqual({
+      code: "WEATHER_PROVIDER_CONFIGURATION_ERROR",
+      message: "Weather enrichment is not configured."
+    });
+  });
+
+  test("degrades provider failure to unavailable weather", async () => {
+    const weatherProvider = {
+      getDailySummary: vi.fn(async () => {
+        throw new WeatherProviderError();
+      })
+    } satisfies WeatherProvider;
+    const response = await request(
+      createEnrichmentTestApp({ weatherProvider })
+    )
+      .post("/api/enrichment/weather/summary")
+      .send({
+        date: "2026-04-06",
+        latitude: 35.6762,
+        longitude: 139.6503
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: "unavailable",
+      weatherSummary: null
+    });
+  });
+
+  test("returns missing weather when city or coordinates cannot resolve", async () => {
+    const weatherProvider = {
+      getDailySummary: vi.fn(async () => null)
+    } satisfies WeatherProvider;
+    const response = await request(
+      createEnrichmentTestApp({ weatherProvider })
+    )
+      .post("/api/enrichment/weather/summary")
+      .send({
+        city: "Unknown Place",
+        date: "2026-04-06"
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: "missing",
+      weatherSummary: null
+    });
+  });
+
+  test("returns structured validation errors for invalid weather input", async () => {
+    const response = await request(
+      createEnrichmentTestApp({
+        weatherProvider: {
+          getDailySummary: vi.fn(async () => weatherSummary)
+        }
+      })
+    )
+      .post("/api/enrichment/weather/summary")
+      .send({
+        date: "04-06-2026",
+        latitude: 35.6762
+      });
+
+    expect(response.status).toBe(400);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "Request validation failed."
+    });
+    expect(response.body.error.fieldErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "date"
+        }),
+        expect.objectContaining({
+          path: "longitude"
+        }),
+        expect.objectContaining({
+          path: "city"
+        })
+      ])
+    );
   });
 });

--- a/apps/api/src/routes/enrichment.ts
+++ b/apps/api/src/routes/enrichment.ts
@@ -1,9 +1,15 @@
 import { Router, type RequestHandler } from "express";
 import { z } from "zod";
 
+import { ApiError } from "../errors/ApiError.js";
 import { validateRequest } from "../middleware/validateRequest.js";
 import type { MapsProvider } from "../providers/maps/mapsProvider.js";
+import {
+  WeatherProviderConfigurationError,
+  type WeatherProvider
+} from "../providers/weather/weatherProvider.js";
 import { createMapLink } from "../services/enrichment/mapEnrichment.js";
+import { createWeatherSummary } from "../services/enrichment/weatherEnrichment.js";
 
 const mapLinkBodySchema = z
   .object({
@@ -21,6 +27,44 @@ const mapLinkBodySchema = z
   })
   .strict();
 
+const weatherSummaryBodySchema = z
+  .object({
+    city: z.string().trim().min(1).optional(),
+    countryCode: z
+      .string()
+      .trim()
+      .regex(/^[A-Za-z]{2}$/, "Expected a two-letter ISO country code.")
+      .transform((countryCode) => countryCode.toUpperCase())
+      .optional(),
+    date: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Expected a YYYY-MM-DD date."),
+    latitude: z.number().min(-90).max(90).optional(),
+    longitude: z.number().min(-180).max(180).optional(),
+    units: z.enum(["metric", "imperial", "standard"]).default("metric")
+  })
+  .strict()
+  .superRefine((body, context) => {
+    const hasLatitude = body.latitude !== undefined;
+    const hasLongitude = body.longitude !== undefined;
+
+    if (hasLatitude !== hasLongitude) {
+      context.addIssue({
+        code: "custom",
+        message: "Provide both latitude and longitude.",
+        path: hasLatitude ? ["longitude"] : ["latitude"]
+      });
+    }
+
+    if (!body.city && !(hasLatitude && hasLongitude)) {
+      context.addIssue({
+        code: "custom",
+        message: "Provide either city or latitude and longitude.",
+        path: ["city"]
+      });
+    }
+  });
+
 function asyncHandler(handler: RequestHandler): RequestHandler {
   return (request, response, next) => {
     Promise.resolve(handler(request, response, next)).catch(next);
@@ -29,6 +73,7 @@ function asyncHandler(handler: RequestHandler): RequestHandler {
 
 export function createEnrichmentRouter(options: {
   mapsProvider: MapsProvider;
+  weatherProvider: WeatherProvider;
 }) {
   const router = Router();
 
@@ -39,6 +84,31 @@ export function createEnrichmentRouter(options: {
       response.status(200).json({
         mapUrl: createMapLink(request.body, options.mapsProvider)
       });
+    })
+  );
+
+  router.post(
+    "/weather/summary",
+    validateRequest(weatherSummaryBodySchema),
+    asyncHandler(async (request, response) => {
+      try {
+        const result = await createWeatherSummary(
+          request.body,
+          options.weatherProvider
+        );
+
+        response.status(200).json(result);
+      } catch (error) {
+        if (error instanceof WeatherProviderConfigurationError) {
+          throw new ApiError({
+            code: "WEATHER_PROVIDER_CONFIGURATION_ERROR",
+            message: "Weather enrichment is not configured.",
+            statusCode: 503
+          });
+        }
+
+        throw error;
+      }
     })
   );
 

--- a/apps/api/src/services/enrichment/weatherEnrichment.test.ts
+++ b/apps/api/src/services/enrichment/weatherEnrichment.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  WeatherProviderConfigurationError,
+  WeatherProviderError,
+  type WeatherProvider,
+  type WeatherSummary
+} from "../../providers/weather/weatherProvider.js";
+import { createWeatherSummary } from "./weatherEnrichment.js";
+
+const weatherSummary = {
+  city: "Tokyo",
+  cloudCoverPercent: 45,
+  condition: "Partly cloudy",
+  coordinates: {
+    latitude: 35.6762,
+    longitude: 139.6503
+  },
+  date: "2026-04-06",
+  humidityPercent: 61,
+  note: "Partly cloudy, 12-20 C, low precipitation expected",
+  precipitationProbabilityPercent: null,
+  precipitationTotalMillimeters: 0,
+  temperatureMax: 20,
+  temperatureMin: 12,
+  temperatureUnit: "celsius",
+  windSpeed: 5,
+  windSpeedUnit: "meters_per_second"
+} satisfies WeatherSummary;
+
+const request = {
+  city: "Tokyo",
+  date: "2026-04-06"
+};
+
+describe("weather enrichment", () => {
+  test("returns available weather from the provider", async () => {
+    const provider = {
+      getDailySummary: vi.fn(async () => weatherSummary)
+    } satisfies WeatherProvider;
+
+    await expect(createWeatherSummary(request, provider)).resolves.toEqual({
+      status: "available",
+      weatherSummary
+    });
+  });
+
+  test("returns missing when the provider cannot resolve weather", async () => {
+    const provider = {
+      getDailySummary: vi.fn(async () => null)
+    } satisfies WeatherProvider;
+
+    await expect(createWeatherSummary(request, provider)).resolves.toEqual({
+      status: "missing",
+      weatherSummary: null
+    });
+  });
+
+  test("degrades provider failures without leaking raw errors", async () => {
+    const provider = {
+      getDailySummary: vi.fn(async () => {
+        throw new WeatherProviderError();
+      })
+    } satisfies WeatherProvider;
+
+    await expect(createWeatherSummary(request, provider)).resolves.toEqual({
+      status: "unavailable",
+      weatherSummary: null
+    });
+  });
+
+  test("preserves configuration errors for route-level structured responses", async () => {
+    const provider = {
+      getDailySummary: vi.fn(async () => {
+        throw new WeatherProviderConfigurationError();
+      })
+    } satisfies WeatherProvider;
+
+    await expect(createWeatherSummary(request, provider)).rejects.toBeInstanceOf(
+      WeatherProviderConfigurationError
+    );
+  });
+});

--- a/apps/api/src/services/enrichment/weatherEnrichment.ts
+++ b/apps/api/src/services/enrichment/weatherEnrichment.ts
@@ -1,0 +1,54 @@
+import {
+  WeatherProviderConfigurationError,
+  WeatherProviderError,
+  type WeatherProvider,
+  type WeatherSummary,
+  type WeatherSummaryRequest
+} from "../../providers/weather/weatherProvider.js";
+
+export type WeatherEnrichmentResult =
+  | {
+      status: "available";
+      weatherSummary: WeatherSummary;
+    }
+  | {
+      status: "missing" | "unavailable";
+      weatherSummary: null;
+    };
+
+export async function createWeatherSummary(
+  input: WeatherSummaryRequest,
+  provider: WeatherProvider
+): Promise<WeatherEnrichmentResult> {
+  try {
+    const weatherSummary = await provider.getDailySummary(input);
+
+    if (weatherSummary === null) {
+      return {
+        status: "missing",
+        weatherSummary: null
+      };
+    }
+
+    return {
+      status: "available",
+      weatherSummary
+    };
+  } catch (error) {
+    if (error instanceof WeatherProviderConfigurationError) {
+      throw error;
+    }
+
+    if (error instanceof WeatherProviderError) {
+      return {
+        status: "unavailable",
+        weatherSummary: null
+      };
+    }
+
+    return {
+      status: "unavailable",
+      weatherSummary: null
+    };
+  }
+}

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -568,6 +568,55 @@ select {
   padding-left: 12px;
 }
 
+.trip-day-weather-missing {
+  color: #657480;
+  font-style: italic;
+}
+
+.weather-summary-detail {
+  display: grid;
+  gap: 10px;
+}
+
+.weather-summary-condition,
+.weather-summary-note {
+  margin: 0;
+}
+
+.weather-summary-condition {
+  color: #172026;
+  font-weight: 800;
+}
+
+.weather-summary-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+}
+
+.weather-summary-meta div {
+  min-width: 120px;
+  border: 1px solid #dce4ea;
+  border-radius: 6px;
+  background: #f8fafb;
+  padding: 9px 10px;
+}
+
+.weather-summary-meta dt {
+  color: #657480;
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.weather-summary-meta dd {
+  margin: 4px 0 0;
+  color: #172026;
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+
 .activity-list {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/apps/web/src/features/itinerary/ItineraryView.test.tsx
+++ b/apps/web/src/features/itinerary/ItineraryView.test.tsx
@@ -43,6 +43,24 @@ describe("ItineraryView", () => {
     expect(html).toContain("ready for generated or mock trip data");
   });
 
+  test("renders itinerary days when weather summaries are missing", () => {
+    const itineraryWithoutWeather = {
+      ...mockItinerary,
+      days: mockItinerary.days.map((day) => ({
+        date: day.date,
+        city: day.city,
+        ...(day.summary !== undefined ? { summary: day.summary } : {}),
+        activities: day.activities
+      }))
+    };
+    const html = renderToString(
+      <ItineraryView itinerary={itineraryWithoutWeather} />
+    );
+
+    expect(html).toContain("Morning walk through Ueno Park");
+    expect(html).not.toContain("Weather unavailable");
+  });
+
   test("renders a loading state", () => {
     const html = renderToString(
       <ItineraryView itinerary={mockItinerary} isLoading />

--- a/apps/web/src/features/itinerary/TripDayPanel.tsx
+++ b/apps/web/src/features/itinerary/TripDayPanel.tsx
@@ -4,6 +4,7 @@ import type {
 } from "../../../../../packages/shared/src/schemas/itinerary.js";
 
 import { ActivityCard } from "./ActivityCard.js";
+import { WeatherSummary } from "./WeatherSummary.js";
 import type { ReorderDirection } from "./editing/useItineraryEditor.js";
 
 export type TripDayEditingControls = {
@@ -47,9 +48,7 @@ export function TripDayPanel({ day, dayNumber, editing }: TripDayPanelProps) {
       </div>
 
       {day.summary ? <p className="trip-day-summary">{day.summary}</p> : null}
-      {day.weatherSummary ? (
-        <p className="trip-day-weather">{day.weatherSummary}</p>
-      ) : null}
+      <WeatherSummary summary={day.weatherSummary} />
 
       <div className="activity-list">
         {day.activities.map((activity, index) => {

--- a/apps/web/src/features/itinerary/WeatherSummary.test.tsx
+++ b/apps/web/src/features/itinerary/WeatherSummary.test.tsx
@@ -1,0 +1,48 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { WeatherSummary } from "./WeatherSummary.js";
+
+describe("WeatherSummary", () => {
+  test("renders an available day weather summary string", () => {
+    const html = renderToString(
+      <WeatherSummary summary="Mild spring weather; bring a light jacket." />
+    );
+
+    expect(html).toContain("Weather summary");
+    expect(html).toContain("Mild spring weather; bring a light jacket.");
+  });
+
+  test("renders structured weather details", () => {
+    const html = renderToString(
+      <WeatherSummary
+        details={{
+          condition: "Partly cloudy",
+          note: "Comfortable for walking between temples.",
+          precipitationProbabilityPercent: 20,
+          temperatureMax: 21,
+          temperatureMin: 12,
+          temperatureUnit: "celsius"
+        }}
+      />
+    );
+
+    expect(html).toContain("Partly cloudy");
+    expect(html).toContain("12-21 C");
+    expect(html).toContain("20% precipitation chance");
+    expect(html).toContain("Comfortable for walking between temples.");
+  });
+
+  test("omits missing weather by default", () => {
+    const html = renderToString(<WeatherSummary summary={null} />);
+
+    expect(html).toBe("");
+  });
+
+  test("renders a subtle missing state when requested", () => {
+    const html = renderToString(<WeatherSummary showMissingState />);
+
+    expect(html).toContain("Weather unavailable");
+    expect(html).toContain("trip-day-weather-missing");
+  });
+});

--- a/apps/web/src/features/itinerary/WeatherSummary.tsx
+++ b/apps/web/src/features/itinerary/WeatherSummary.tsx
@@ -1,0 +1,124 @@
+export type WeatherSummaryDetails = {
+  condition: string;
+  note?: string | null | undefined;
+  precipitationProbabilityPercent?: number | null | undefined;
+  precipitationTotalMillimeters?: number | null | undefined;
+  temperatureMax?: number | null | undefined;
+  temperatureMin?: number | null | undefined;
+  temperatureUnit?: "celsius" | "fahrenheit" | "kelvin" | undefined;
+};
+
+export type WeatherSummaryProps = {
+  details?: WeatherSummaryDetails | null | undefined;
+  showMissingState?: boolean | undefined;
+  summary?: string | null | undefined;
+};
+
+function getTemperatureSymbol(
+  unit: WeatherSummaryDetails["temperatureUnit"] = "celsius"
+) {
+  if (unit === "fahrenheit") {
+    return "F";
+  }
+
+  if (unit === "kelvin") {
+    return "K";
+  }
+
+  return "C";
+}
+
+function formatTemperatureRange(details: WeatherSummaryDetails) {
+  const minTemperature = details.temperatureMin;
+  const maxTemperature = details.temperatureMax;
+  const symbol = getTemperatureSymbol(details.temperatureUnit);
+
+  if (minTemperature !== null && minTemperature !== undefined) {
+    if (maxTemperature !== null && maxTemperature !== undefined) {
+      return `${minTemperature}-${maxTemperature} ${symbol}`;
+    }
+
+    return `From ${minTemperature} ${symbol}`;
+  }
+
+  if (maxTemperature !== null && maxTemperature !== undefined) {
+    return `Up to ${maxTemperature} ${symbol}`;
+  }
+
+  return null;
+}
+
+function formatPrecipitation(details: WeatherSummaryDetails) {
+  if (
+    details.precipitationProbabilityPercent !== null &&
+    details.precipitationProbabilityPercent !== undefined
+  ) {
+    return `${details.precipitationProbabilityPercent}% precipitation chance`;
+  }
+
+  if (
+    details.precipitationTotalMillimeters !== null &&
+    details.precipitationTotalMillimeters !== undefined
+  ) {
+    return `${details.precipitationTotalMillimeters} mm precipitation`;
+  }
+
+  return "Precipitation unknown";
+}
+
+export function WeatherSummary({
+  details,
+  showMissingState = false,
+  summary
+}: WeatherSummaryProps) {
+  const trimmedSummary = summary?.trim();
+
+  if (trimmedSummary && trimmedSummary.length > 0) {
+    return (
+      <p className="trip-day-weather" aria-label="Weather summary">
+        {trimmedSummary}
+      </p>
+    );
+  }
+
+  if (details) {
+    const temperatureRange = formatTemperatureRange(details);
+
+    return (
+      <section
+        className="trip-day-weather weather-summary-detail"
+        aria-label="Weather summary"
+      >
+        <p className="weather-summary-condition">{details.condition}</p>
+        <dl className="weather-summary-meta">
+          {temperatureRange ? (
+            <div>
+              <dt>Temperature</dt>
+              <dd>{temperatureRange}</dd>
+            </div>
+          ) : null}
+          <div>
+            <dt>Precipitation</dt>
+            <dd>{formatPrecipitation(details)}</dd>
+          </div>
+        </dl>
+        {details.note ? (
+          <p className="weather-summary-note">{details.note}</p>
+        ) : null}
+      </section>
+    );
+  }
+
+  if (!showMissingState) {
+    return null;
+  }
+
+  return (
+    <p
+      className="trip-day-weather trip-day-weather-missing"
+      aria-label="Weather unavailable"
+    >
+      Weather unavailable
+    </p>
+  );
+}


### PR DESCRIPTION
## Ticket scope
- Implements T-027 / Ticket 27: Add Weather Enrichment.
- Adds backend-only weather enrichment for city/date or coordinate/date inputs.
- Does not start Ticket 28 provider caching or later tickets.

## Changes made
- Added an injectable OpenWeather weather provider.
- Added weather enrichment service logic for available, missing, unavailable, and missing-config outcomes.
- Added `POST /api/enrichment/weather/summary` alongside the existing maps enrichment route.
- Added `WEATHER_API_KEY` parsing to API env config without requiring it at startup.
- Added a presentational web `WeatherSummary` component and integrated it into `TripDayPanel`.
- Added API/provider/service/component/regression tests.

## Weather provider design
- Uses OpenWeather One Call 3.0 daily aggregation for date-level summaries.
- Uses OpenWeather Geocoding API when a request supplies city/date without coordinates.
- Provider is dependency-injected and mocked in tests.
- No caching was added; caching remains Ticket 28.

## Backend-only key handling
- Reads `WEATHER_API_KEY` in `apps/api/src/config/env.ts`.
- Missing `WEATHER_API_KEY` does not block API startup.
- Missing provider config returns a structured `WEATHER_PROVIDER_CONFIGURATION_ERROR` only when weather enrichment is requested.
- No `VITE_WEATHER_*` variables were added.

## Weather normalization shape
- Normalizes provider data to condition, date, city, coordinates, temperature min/max + unit, precipitation total, precipitation probability placeholder, humidity, cloud cover, wind speed + unit, and a concise note.
- Daily aggregation does not provide precipitation probability, so `precipitationProbabilityPercent` is currently `null`.

## API enrichment route behavior
- Adds `POST /api/enrichment/weather/summary`.
- Accepts either city/date or latitude/longitude/date.
- Validates request body and returns shared-format validation errors.
- Returns `available`, `missing`, or `unavailable` weather responses.
- Does not leak API keys, raw provider errors, or stack traces.

## UI behavior and missing-weather handling
- `WeatherSummary` renders existing day-level weather strings.
- Structured weather details are supported for future API wiring.
- Missing weather is omitted cleanly by default, with an optional subtle missing state.
- Existing itinerary display, map links, editing, mock mode, and save/reopen flows are preserved.

## Failure/degradation behavior
- Provider/network failure returns non-blocking unavailable weather.
- Missing geocoding result returns missing weather.
- Itinerary display continues when weather data is absent.

## Tests added/updated
- Provider tests for mocked success, missing key, provider/network failure, no geocoding result, coordinate input, and sparse response normalization.
- Service tests for available, missing, unavailable, and config error behavior.
- Route tests for success, missing config, provider failure, missing weather, and validation errors.
- Component tests for available weather, structured details, omitted missing state, and subtle missing state.
- Itinerary regression test for days without weather summaries.

## Checks run
- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit`
- `pnpm --filter @japan-travel-planner/web exec vite build`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `git diff --check`

## Manual checks run
- Started API with `pnpm dev:api`.
- `GET /api/health` returned HTTP 200 with status ok.
- `POST /api/enrichment/weather/summary` without `WEATHER_API_KEY` returned structured missing-config response.
- Existing `POST /api/enrichment/maps/link` still returned a Google Maps URL.
- Started web with `pnpm dev:web`.
- Browser check confirmed initial empty state before submit.
- Browser check submitted mock preview and confirmed itinerary display.
- Browser check confirmed weather text renders on itinerary day.
- Browser check confirmed Google Maps links still render.
- Browser check edited an activity, saw dirty state, and reverted local edits.
- Browser check at 390px width found no horizontal overflow.
- Checked web source and built bundle for `WEATHER_API_KEY`, `VITE_WEATHER`, and `weather-test-key`; no matches.

## Real provider calls
- Real OpenWeather API call made: no.
- Real OpenAI API call made: no.

## Known risks
- City-only geocoding depends on OpenWeather result quality; callers should pass coordinates when available for better precision.
- One Call daily aggregation does not expose precipitation probability, so probability remains `null` until a future provider/endpoint supplies it.
- Weather data is not cached in this ticket by design; repeated real requests will hit the provider until Ticket 28 adds caching.

## Ticket 28+ confirmation
- Ticket 28 and later tickets were not started.
- No provider result caching, hotels, transit, sharing, PDF export, mobile app, deployment, or observability work was added.
