### PR TITLE
Add provider result caching

### DIFF
--- a/apps/api/prisma/migrations/202606250001_add_provider_result_cache/migration.sql
+++ b/apps/api/prisma/migrations/202606250001_add_provider_result_cache/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "ProviderResult" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "operation" TEXT NOT NULL,
+    "cacheKey" TEXT NOT NULL,
+    "requestHash" TEXT NOT NULL,
+    "requestJson" JSONB NOT NULL,
+    "responseJson" JSONB NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProviderResult_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProviderResult_cacheKey_key" ON "ProviderResult"("cacheKey");
+
+-- CreateIndex
+CREATE INDEX "ProviderResult_provider_idx" ON "ProviderResult"("provider");
+
+-- CreateIndex
+CREATE INDEX "ProviderResult_provider_operation_idx" ON "ProviderResult"("provider", "operation");
+
+-- CreateIndex
+CREATE INDEX "ProviderResult_expiresAt_idx" ON "ProviderResult"("expiresAt");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -131,3 +131,20 @@ model ShareLink {
 
   @@index([tripId])
 }
+
+model ProviderResult {
+  id           String   @id @default(cuid())
+  provider     String
+  operation    String
+  cacheKey     String   @unique
+  requestHash  String
+  requestJson  Json
+  responseJson Json
+  expiresAt    DateTime
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([provider])
+  @@index([provider, operation])
+  @@index([expiresAt])
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -26,6 +26,10 @@ import {
   recordAiUsageSafely,
   type AiUsageLogger
 } from "./services/aiItinerary/usageLogger.js";
+import {
+  createProviderResultCache,
+  type ProviderResultCache
+} from "./services/enrichment/cache.js";
 import { createTripService, type TripService } from "./services/tripService.js";
 
 export type CreateAppOptions = {
@@ -34,6 +38,7 @@ export type CreateAppOptions = {
   aiItineraryService?: AiItineraryService;
   aiUsageLogger?: AiUsageLogger;
   mapsProvider?: MapsProvider;
+  providerResultCache?: ProviderResultCache;
   sessionMiddleware?: RequestHandler;
   tripService?: TripService;
   weatherProvider?: WeatherProvider;
@@ -70,6 +75,8 @@ export function createApp(options: CreateAppOptions = {}) {
     });
   const tripService = options.tripService ?? createTripService();
   const mapsProvider = options.mapsProvider ?? createGoogleMapsProvider();
+  const providerResultCache =
+    options.providerResultCache ?? createProviderResultCache();
   const weatherProvider =
     options.weatherProvider ??
     createOpenWeatherProvider({
@@ -87,7 +94,11 @@ export function createApp(options: CreateAppOptions = {}) {
   app.use("/api/health", healthRouter);
   app.use(
     "/api/enrichment",
-    createEnrichmentRouter({ mapsProvider, weatherProvider })
+    createEnrichmentRouter({
+      mapsProvider,
+      providerResultCache,
+      weatherProvider
+    })
   );
   app.use(
     "/api/itineraries",

--- a/apps/api/src/repositories/providerResultRepository.test.ts
+++ b/apps/api/src/repositories/providerResultRepository.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { createPrismaProviderResultRepository } from "./providerResultRepository.js";
+
+function createFakeProviderResultClient() {
+  type RecordValue = {
+    id: string;
+    provider: string;
+    operation: string;
+    cacheKey: string;
+    requestHash: string;
+    requestJson: unknown;
+    responseJson: unknown;
+    expiresAt: Date;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+
+  const records = new Map<string, RecordValue>();
+  let nextId = 1;
+
+  const providerResult = {
+    findFirst: vi.fn(async (query: { where: { cacheKey: string; expiresAt: { gt: Date } } }) => {
+      const record = records.get(query.where.cacheKey);
+
+      if (!record || record.expiresAt <= query.where.expiresAt.gt) {
+        return null;
+      }
+
+      return structuredClone(record);
+    }),
+    upsert: vi.fn(
+      async (query: {
+        where: { cacheKey: string };
+        create: Omit<RecordValue, "id" | "createdAt" | "updatedAt">;
+        update: Omit<RecordValue, "id" | "cacheKey" | "createdAt" | "updatedAt">;
+      }) => {
+        const existingRecord = records.get(query.where.cacheKey);
+        const timestamp = new Date("2026-06-25T00:00:00.000Z");
+        const record =
+          existingRecord === undefined
+            ? {
+                id: `provider-result-${nextId++}`,
+                ...query.create,
+                createdAt: timestamp,
+                updatedAt: timestamp
+              }
+            : {
+                ...existingRecord,
+                ...query.update,
+                updatedAt: timestamp
+              };
+
+        records.set(query.where.cacheKey, record);
+
+        return structuredClone(record);
+      }
+    )
+  };
+
+  return {
+    client: {
+      providerResult
+    } as unknown as PrismaClient,
+    providerResult
+  };
+}
+
+const freshExpiresAt = new Date("2026-06-25T04:00:00.000Z");
+const expiredExpiresAt = new Date("2026-06-24T23:00:00.000Z");
+const now = new Date("2026-06-25T00:00:00.000Z");
+
+describe("provider result repository", () => {
+  test("can store and retrieve a usable provider result", async () => {
+    const { client } = createFakeProviderResultClient();
+    const repository = createPrismaProviderResultRepository(client);
+
+    await repository.upsert({
+      provider: "openweather",
+      operation: "weather.summary",
+      cacheKey: "openweather:weather.summary:test-hash",
+      requestHash: "test-hash",
+      requestJson: {
+        city: "tokyo",
+        date: "2026-04-06"
+      },
+      responseJson: {
+        status: "available"
+      },
+      expiresAt: freshExpiresAt
+    });
+
+    const result = await repository.findUsable(
+      "openweather:weather.summary:test-hash",
+      now
+    );
+
+    expect(result).toMatchObject({
+      provider: "openweather",
+      operation: "weather.summary",
+      requestHash: "test-hash",
+      responseJson: {
+        status: "available"
+      }
+    });
+  });
+
+  test("does not treat expired provider results as usable", async () => {
+    const { client } = createFakeProviderResultClient();
+    const repository = createPrismaProviderResultRepository(client);
+
+    await repository.upsert({
+      provider: "openweather",
+      operation: "weather.summary",
+      cacheKey: "openweather:weather.summary:expired-hash",
+      requestHash: "expired-hash",
+      requestJson: {
+        city: "tokyo"
+      },
+      responseJson: {
+        status: "available"
+      },
+      expiresAt: expiredExpiresAt
+    });
+
+    await expect(
+      repository.findUsable("openweather:weather.summary:expired-hash", now)
+    ).resolves.toBeNull();
+  });
+
+  test("upsert refreshes cached response and expiration", async () => {
+    const { client } = createFakeProviderResultClient();
+    const repository = createPrismaProviderResultRepository(client);
+
+    await repository.upsert({
+      provider: "openweather",
+      operation: "weather.summary",
+      cacheKey: "openweather:weather.summary:refresh-hash",
+      requestHash: "refresh-hash",
+      requestJson: {
+        city: "tokyo"
+      },
+      responseJson: {
+        status: "missing"
+      },
+      expiresAt: expiredExpiresAt
+    });
+    await repository.upsert({
+      provider: "openweather",
+      operation: "weather.summary",
+      cacheKey: "openweather:weather.summary:refresh-hash",
+      requestHash: "refresh-hash",
+      requestJson: {
+        city: "tokyo"
+      },
+      responseJson: {
+        status: "available"
+      },
+      expiresAt: freshExpiresAt
+    });
+
+    const result = await repository.findUsable(
+      "openweather:weather.summary:refresh-hash",
+      now
+    );
+
+    expect(result).toMatchObject({
+      responseJson: {
+        status: "available"
+      },
+      expiresAt: freshExpiresAt
+    });
+  });
+});

--- a/apps/api/src/repositories/providerResultRepository.ts
+++ b/apps/api/src/repositories/providerResultRepository.ts
@@ -1,0 +1,112 @@
+import { prisma } from "../db/client.js";
+import {
+  Prisma,
+  type PrismaClient
+} from "../generated/prisma/client.js";
+
+export type ProviderResultRecord = {
+  id: string;
+  provider: string;
+  operation: string;
+  cacheKey: string;
+  requestHash: string;
+  requestJson: unknown;
+  responseJson: unknown;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type ProviderResultWriteInput = {
+  provider: string;
+  operation: string;
+  cacheKey: string;
+  requestHash: string;
+  requestJson: unknown;
+  responseJson: unknown;
+  expiresAt: Date;
+};
+
+export type ProviderResultRepository = {
+  findUsable(
+    cacheKey: string,
+    now?: Date
+  ): Promise<ProviderResultRecord | null>;
+  upsert(input: ProviderResultWriteInput): Promise<ProviderResultRecord>;
+};
+
+type PrismaProviderResult = {
+  id: string;
+  provider: string;
+  operation: string;
+  cacheKey: string;
+  requestHash: string;
+  requestJson: unknown;
+  responseJson: unknown;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function toInputJson(value: unknown) {
+  return value as Prisma.InputJsonValue;
+}
+
+function mapProviderResult(result: PrismaProviderResult): ProviderResultRecord {
+  return {
+    id: result.id,
+    provider: result.provider,
+    operation: result.operation,
+    cacheKey: result.cacheKey,
+    requestHash: result.requestHash,
+    requestJson: result.requestJson,
+    responseJson: result.responseJson,
+    expiresAt: result.expiresAt,
+    createdAt: result.createdAt,
+    updatedAt: result.updatedAt
+  };
+}
+
+export function createPrismaProviderResultRepository(
+  client: PrismaClient = prisma
+): ProviderResultRepository {
+  return {
+    async findUsable(cacheKey, now = new Date()) {
+      const result = await client.providerResult.findFirst({
+        where: {
+          cacheKey,
+          expiresAt: {
+            gt: now
+          }
+        }
+      });
+
+      return result === null
+        ? null
+        : mapProviderResult(result as PrismaProviderResult);
+    },
+
+    async upsert(input) {
+      const data = {
+        provider: input.provider,
+        operation: input.operation,
+        requestHash: input.requestHash,
+        requestJson: toInputJson(input.requestJson),
+        responseJson: toInputJson(input.responseJson),
+        expiresAt: input.expiresAt
+      };
+      const result = await client.providerResult.upsert({
+        where: {
+          cacheKey: input.cacheKey
+        },
+        create: {
+          cacheKey: input.cacheKey,
+          ...data
+        },
+        update: data
+      });
+
+      return mapProviderResult(result as PrismaProviderResult);
+    }
+  };
+}

--- a/apps/api/src/routes/enrichment.test.ts
+++ b/apps/api/src/routes/enrichment.test.ts
@@ -11,10 +11,15 @@ import {
   type WeatherProvider,
   type WeatherSummary
 } from "../providers/weather/weatherProvider.js";
-
-const defaultMapsProvider = {
-  createSearchLink: vi.fn(() => null)
-} satisfies MapsProvider;
+import type {
+  ProviderResultRecord,
+  ProviderResultRepository,
+  ProviderResultWriteInput
+} from "../repositories/providerResultRepository.js";
+import {
+  createProviderResultCache,
+  type ProviderResultCache
+} from "../services/enrichment/cache.js";
 
 const weatherSummary = {
   city: "Tokyo",
@@ -38,20 +43,65 @@ const weatherSummary = {
 
 function createEnrichmentTestApp(options: {
   mapsProvider?: MapsProvider | undefined;
+  providerResultCache?: ProviderResultCache | undefined;
   weatherProvider?: WeatherProvider | undefined;
-}) {
+} = {}) {
   return createApp({
     env: defaultApiEnv,
-    mapsProvider: options.mapsProvider ?? defaultMapsProvider,
+    providerResultCache:
+      options.providerResultCache ?? createMemoryProviderResultCache(),
+    ...(options.mapsProvider !== undefined
+      ? { mapsProvider: options.mapsProvider }
+      : {}),
     ...(options.weatherProvider !== undefined
       ? { weatherProvider: options.weatherProvider }
       : {})
   });
 }
 
+class InMemoryProviderResultRepository implements ProviderResultRepository {
+  private readonly records = new Map<string, ProviderResultRecord>();
+  private nextId = 1;
+
+  async findUsable(cacheKey: string, now = new Date()) {
+    const record = this.records.get(cacheKey);
+
+    if (record === undefined || record.expiresAt <= now) {
+      return null;
+    }
+
+    return structuredClone(record);
+  }
+
+  async upsert(input: ProviderResultWriteInput) {
+    const timestamp = new Date("2026-06-25T00:00:00.000Z");
+    const existingRecord = this.records.get(input.cacheKey);
+    const record: ProviderResultRecord = {
+      id: existingRecord?.id ?? `provider-result-${this.nextId++}`,
+      provider: input.provider,
+      operation: input.operation,
+      cacheKey: input.cacheKey,
+      requestHash: input.requestHash,
+      requestJson: structuredClone(input.requestJson),
+      responseJson: structuredClone(input.responseJson),
+      expiresAt: input.expiresAt,
+      createdAt: existingRecord?.createdAt ?? timestamp,
+      updatedAt: timestamp
+    };
+
+    this.records.set(input.cacheKey, record);
+
+    return structuredClone(record);
+  }
+}
+
+function createMemoryProviderResultCache() {
+  return createProviderResultCache(new InMemoryProviderResultRepository());
+}
+
 describe("POST /api/enrichment/maps/link", () => {
   test("returns an external Google Maps search link", async () => {
-    const response = await request(createApp({ env: defaultApiEnv }))
+    const response = await request(createEnrichmentTestApp())
       .post("/api/enrichment/maps/link")
       .send({
         title: "Senso-ji morning visit",
@@ -69,7 +119,7 @@ describe("POST /api/enrichment/maps/link", () => {
   });
 
   test("returns null when no usable location is provided", async () => {
-    const response = await request(createApp({ env: defaultApiEnv }))
+    const response = await request(createEnrichmentTestApp())
       .post("/api/enrichment/maps/link")
       .send({
         title: "Only a title",
@@ -85,7 +135,7 @@ describe("POST /api/enrichment/maps/link", () => {
   });
 
   test("returns structured validation errors for invalid map link input", async () => {
-    const response = await request(createApp({ env: defaultApiEnv }))
+    const response = await request(createEnrichmentTestApp())
       .post("/api/enrichment/maps/link")
       .send({
         location: {
@@ -163,7 +213,7 @@ describe("POST /api/enrichment/weather/summary", () => {
   });
 
   test("returns a structured missing config error when WEATHER_API_KEY is absent", async () => {
-    const response = await request(createApp({ env: defaultApiEnv }))
+    const response = await request(createEnrichmentTestApp())
       .post("/api/enrichment/weather/summary")
       .send({
         city: "Tokyo",
@@ -254,5 +304,36 @@ describe("POST /api/enrichment/weather/summary", () => {
         })
       ])
     );
+  });
+
+  test("uses cached weather for a second identical enrichment request", async () => {
+    const weatherProvider = {
+      getDailySummary: vi.fn(async () => weatherSummary)
+    } satisfies WeatherProvider;
+    const app = createEnrichmentTestApp({ weatherProvider });
+    const payload = {
+      city: "Tokyo",
+      date: "2026-04-06"
+    };
+
+    const firstResponse = await request(app)
+      .post("/api/enrichment/weather/summary")
+      .send(payload);
+    const secondResponse = await request(app)
+      .post("/api/enrichment/weather/summary")
+      .send({
+        city: "  tokyo ",
+        date: "2026-04-06",
+        units: "metric"
+      });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.body).toEqual(firstResponse.body);
+    expect(secondResponse.body).toEqual({
+      status: "available",
+      weatherSummary
+    });
+    expect(weatherProvider.getDailySummary).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/routes/enrichment.ts
+++ b/apps/api/src/routes/enrichment.ts
@@ -8,8 +8,9 @@ import {
   WeatherProviderConfigurationError,
   type WeatherProvider
 } from "../providers/weather/weatherProvider.js";
-import { createMapLink } from "../services/enrichment/mapEnrichment.js";
-import { createWeatherSummary } from "../services/enrichment/weatherEnrichment.js";
+import type { ProviderResultCache } from "../services/enrichment/cache.js";
+import { createCachedMapLink } from "../services/enrichment/mapEnrichment.js";
+import { createCachedWeatherSummary } from "../services/enrichment/weatherEnrichment.js";
 
 const mapLinkBodySchema = z
   .object({
@@ -73,6 +74,7 @@ function asyncHandler(handler: RequestHandler): RequestHandler {
 
 export function createEnrichmentRouter(options: {
   mapsProvider: MapsProvider;
+  providerResultCache: ProviderResultCache;
   weatherProvider: WeatherProvider;
 }) {
   const router = Router();
@@ -82,7 +84,11 @@ export function createEnrichmentRouter(options: {
     validateRequest(mapLinkBodySchema),
     asyncHandler(async (request, response) => {
       response.status(200).json({
-        mapUrl: createMapLink(request.body, options.mapsProvider)
+        mapUrl: await createCachedMapLink(
+          request.body,
+          options.mapsProvider,
+          options.providerResultCache
+        )
       });
     })
   );
@@ -92,9 +98,10 @@ export function createEnrichmentRouter(options: {
     validateRequest(weatherSummaryBodySchema),
     asyncHandler(async (request, response) => {
       try {
-        const result = await createWeatherSummary(
+        const result = await createCachedWeatherSummary(
           request.body,
-          options.weatherProvider
+          options.weatherProvider,
+          options.providerResultCache
         );
 
         response.status(200).json(result);

--- a/apps/api/src/services/enrichment/cache.test.ts
+++ b/apps/api/src/services/enrichment/cache.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type {
+  ProviderResultRecord,
+  ProviderResultRepository,
+  ProviderResultWriteInput
+} from "../../repositories/providerResultRepository.js";
+import {
+  createProviderResultCache,
+  createProviderResultCacheIdentity,
+  getOrSetProviderResult
+} from "./cache.js";
+
+class InMemoryProviderResultRepository implements ProviderResultRepository {
+  private readonly records = new Map<string, ProviderResultRecord>();
+  private nextId = 1;
+  failRead = false;
+  failWrite = false;
+
+  async findUsable(cacheKey: string, now = new Date()) {
+    if (this.failRead) {
+      throw new Error("cache read failed");
+    }
+
+    const record = this.records.get(cacheKey);
+
+    if (record === undefined || record.expiresAt <= now) {
+      return null;
+    }
+
+    return structuredClone(record);
+  }
+
+  async upsert(input: ProviderResultWriteInput) {
+    if (this.failWrite) {
+      throw new Error("cache write failed");
+    }
+
+    const existingRecord = this.records.get(input.cacheKey);
+    const timestamp = new Date("2026-06-25T00:00:00.000Z");
+    const record: ProviderResultRecord = {
+      id: existingRecord?.id ?? `provider-result-${this.nextId++}`,
+      provider: input.provider,
+      operation: input.operation,
+      cacheKey: input.cacheKey,
+      requestHash: input.requestHash,
+      requestJson: structuredClone(input.requestJson),
+      responseJson: structuredClone(input.responseJson),
+      expiresAt: input.expiresAt,
+      createdAt: existingRecord?.createdAt ?? timestamp,
+      updatedAt: timestamp
+    };
+
+    this.records.set(input.cacheKey, record);
+
+    return structuredClone(record);
+  }
+
+  async writeExpired(input: ProviderResultWriteInput) {
+    return this.upsert(input);
+  }
+}
+
+const now = new Date("2026-06-25T00:00:00.000Z");
+const ttlMs = 60 * 60 * 1000;
+
+describe("provider result cache keys", () => {
+  test("creates stable cache keys for equivalent normalized inputs", () => {
+    const firstIdentity = createProviderResultCacheIdentity({
+      provider: "OpenWeather",
+      operation: "weather.summary",
+      input: {
+        city: "  Tokyo   Station ",
+        date: "2026-04-06",
+        units: "metric"
+      }
+    });
+    const secondIdentity = createProviderResultCacheIdentity({
+      provider: "openweather",
+      operation: "weather.summary",
+      input: {
+        units: "metric",
+        date: "2026-04-06",
+        city: "tokyo station"
+      }
+    });
+
+    expect(firstIdentity).toEqual(secondIdentity);
+  });
+
+  test("changes cache keys when provider, query, date, or location changes", () => {
+    const baseIdentity = createProviderResultCacheIdentity({
+      provider: "openweather",
+      operation: "weather.summary",
+      input: {
+        city: "Tokyo",
+        date: "2026-04-06"
+      }
+    });
+    const variants = [
+      createProviderResultCacheIdentity({
+        provider: "google-maps",
+        operation: "weather.summary",
+        input: {
+          city: "Tokyo",
+          date: "2026-04-06"
+        }
+      }),
+      createProviderResultCacheIdentity({
+        provider: "openweather",
+        operation: "weather.summary",
+        input: {
+          city: "Kyoto",
+          date: "2026-04-06"
+        }
+      }),
+      createProviderResultCacheIdentity({
+        provider: "openweather",
+        operation: "weather.summary",
+        input: {
+          city: "Tokyo",
+          date: "2026-04-07"
+        }
+      }),
+      createProviderResultCacheIdentity({
+        provider: "openweather",
+        operation: "weather.summary",
+        input: {
+          date: "2026-04-06",
+          latitude: 35.0116,
+          longitude: 135.7681
+        }
+      })
+    ];
+
+    expect(new Set(variants.map((variant) => variant.cacheKey))).not.toContain(
+      baseIdentity.cacheKey
+    );
+  });
+
+  test("does not include API keys or secrets in cache identity", () => {
+    const identity = createProviderResultCacheIdentity({
+      provider: "openweather",
+      operation: "weather.summary",
+      input: {
+        city: "Tokyo",
+        apiKey: "super-secret-weather-key",
+        headers: {
+          authorization: "Bearer hidden-token"
+        }
+      }
+    });
+
+    expect(identity.cacheKey).not.toContain("super-secret-weather-key");
+    expect(identity.cacheKey).not.toContain("hidden-token");
+    expect(JSON.stringify(identity.normalizedInput)).not.toContain(
+      "super-secret-weather-key"
+    );
+    expect(JSON.stringify(identity.normalizedInput)).not.toContain(
+      "hidden-token"
+    );
+  });
+});
+
+describe("provider result cache", () => {
+  test("uses cached provider response on repeated equivalent requests", async () => {
+    const repository = new InMemoryProviderResultRepository();
+    const cache = createProviderResultCache(repository);
+    const load = vi.fn(async () => ({
+      status: "available",
+      weatherSummary: {
+        city: "Tokyo"
+      }
+    }));
+    const options = {
+      provider: "openweather",
+      operation: "weather.summary",
+      input: {
+        city: "Tokyo",
+        date: "2026-04-06"
+      },
+      ttlMs,
+      load,
+      now
+    };
+
+    const firstResult = await cache.getOrSet(options);
+    const secondResult = await cache.getOrSet(options);
+
+    expect(firstResult.source).toBe("provider");
+    expect(secondResult.source).toBe("cache");
+    expect(secondResult.value).toEqual(firstResult.value);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  test("refreshes expired cache entries", async () => {
+    const repository = new InMemoryProviderResultRepository();
+    const identity = createProviderResultCacheIdentity({
+      provider: "openweather",
+      operation: "weather.summary",
+      input: {
+        city: "Tokyo",
+        date: "2026-04-06"
+      }
+    });
+    await repository.writeExpired({
+      provider: "openweather",
+      operation: "weather.summary",
+      cacheKey: identity.cacheKey,
+      requestHash: identity.requestHash,
+      requestJson: identity.normalizedInput,
+      responseJson: {
+        status: "missing",
+        weatherSummary: null
+      },
+      expiresAt: new Date(now.getTime() - 1000)
+    });
+
+    const load = vi.fn(async () => ({
+      status: "available",
+      weatherSummary: {
+        city: "Tokyo"
+      }
+    }));
+    const result = await getOrSetProviderResult(repository, {
+      provider: "openweather",
+      operation: "weather.summary",
+      input: {
+        city: "Tokyo",
+        date: "2026-04-06"
+      },
+      ttlMs,
+      load,
+      now
+    });
+
+    expect(result.source).toBe("provider");
+    expect(result.value).toEqual({
+      status: "available",
+      weatherSummary: {
+        city: "Tokyo"
+      }
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  test("continues when cache reads fail", async () => {
+    const repository = new InMemoryProviderResultRepository();
+    repository.failRead = true;
+    const load = vi.fn(async () => "fresh-provider-value");
+
+    const result = await getOrSetProviderResult(repository, {
+      provider: "google-maps",
+      operation: "maps.link",
+      input: {
+        title: "Senso-ji",
+        location: {
+          city: "Tokyo"
+        }
+      },
+      ttlMs,
+      load,
+      now
+    });
+
+    expect(result).toMatchObject({
+      source: "provider",
+      value: "fresh-provider-value"
+    });
+  });
+
+  test("continues when cache writes fail", async () => {
+    const repository = new InMemoryProviderResultRepository();
+    repository.failWrite = true;
+    const load = vi.fn(async () => "fresh-provider-value");
+
+    const result = await getOrSetProviderResult(repository, {
+      provider: "google-maps",
+      operation: "maps.link",
+      input: {
+        title: "Senso-ji",
+        location: {
+          city: "Tokyo"
+        }
+      },
+      ttlMs,
+      load,
+      now
+    });
+
+    expect(result).toMatchObject({
+      source: "provider",
+      value: "fresh-provider-value"
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/enrichment/cache.ts
+++ b/apps/api/src/services/enrichment/cache.ts
@@ -1,0 +1,214 @@
+import { createHash } from "node:crypto";
+
+import {
+  createPrismaProviderResultRepository,
+  type ProviderResultRepository
+} from "../../repositories/providerResultRepository.js";
+
+export type ProviderCacheSource = "cache" | "provider";
+
+export type JsonSafeValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonSafeValue[]
+  | { [key: string]: JsonSafeValue };
+
+export type ProviderResultCacheIdentity = {
+  cacheKey: string;
+  normalizedInput: JsonSafeValue;
+  requestHash: string;
+};
+
+export type ProviderResultCacheGetOrSetOptions<TValue> = {
+  provider: string;
+  operation: string;
+  input: unknown;
+  ttlMs: number;
+  load: () => Promise<TValue>;
+  isCachedValue?: ((value: unknown) => value is TValue) | undefined;
+  now?: Date | undefined;
+  shouldCache?: ((value: TValue) => boolean) | undefined;
+};
+
+export type ProviderResultCacheGetOrSetResult<TValue> = {
+  cacheKey: string;
+  source: ProviderCacheSource;
+  value: TValue;
+};
+
+export type ProviderResultCache = {
+  getOrSet<TValue>(
+    options: ProviderResultCacheGetOrSetOptions<TValue>
+  ): Promise<ProviderResultCacheGetOrSetResult<TValue>>;
+};
+
+const secretFieldPattern =
+  /(?:api[_-]?key|authorization|auth|cookie|header|password|secret|token)/i;
+
+function normalizeText(value: string) {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date)
+  );
+}
+
+function normalizeCacheInput(value: unknown): JsonSafeValue {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    return normalizeText(value);
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? Number(value.toFixed(6)) : null;
+  }
+
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeCacheInput(item));
+  }
+
+  if (isPlainObject(value)) {
+    const normalizedEntries = Object.entries(value)
+      .filter(([key, entryValue]) => {
+        if (entryValue === undefined) {
+          return false;
+        }
+
+        return !secretFieldPattern.test(key);
+      })
+      .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+      .map(([key, entryValue]) => [key, normalizeCacheInput(entryValue)]);
+
+    return Object.fromEntries(normalizedEntries) as JsonSafeValue;
+  }
+
+  return String(value);
+}
+
+export function stableStringify(value: JsonSafeValue): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value).sort(([leftKey], [rightKey]) =>
+    leftKey.localeCompare(rightKey)
+  );
+
+  return `{${entries
+    .map(
+      ([key, entryValue]) =>
+        `${JSON.stringify(key)}:${stableStringify(entryValue)}`
+    )
+    .join(",")}}`;
+}
+
+function hashCachePayload(value: JsonSafeValue) {
+  return createHash("sha256").update(stableStringify(value)).digest("hex");
+}
+
+export function createProviderResultCacheIdentity(options: {
+  provider: string;
+  operation: string;
+  input: unknown;
+}): ProviderResultCacheIdentity {
+  const normalizedInput = normalizeCacheInput(options.input);
+  const payload = {
+    input: normalizedInput,
+    operation: normalizeText(options.operation),
+    provider: normalizeText(options.provider)
+  } satisfies JsonSafeValue;
+  const requestHash = hashCachePayload(payload);
+
+  return {
+    cacheKey: `${payload.provider}:${payload.operation}:${requestHash}`,
+    normalizedInput,
+    requestHash
+  };
+}
+
+function getExpiresAt(now: Date, ttlMs: number) {
+  return new Date(now.getTime() + ttlMs);
+}
+
+export async function getOrSetProviderResult<TValue>(
+  repository: ProviderResultRepository,
+  options: ProviderResultCacheGetOrSetOptions<TValue>
+): Promise<ProviderResultCacheGetOrSetResult<TValue>> {
+  const now = options.now ?? new Date();
+  const identity = createProviderResultCacheIdentity(options);
+
+  try {
+    const cachedResult = await repository.findUsable(identity.cacheKey, now);
+
+    if (
+      cachedResult !== null &&
+      (options.isCachedValue === undefined ||
+        options.isCachedValue(cachedResult.responseJson))
+    ) {
+      return {
+        cacheKey: identity.cacheKey,
+        source: "cache",
+        value: cachedResult.responseJson as TValue
+      };
+    }
+  } catch {
+    // Cache misses and read failures should not block provider enrichment.
+  }
+
+  const value = await options.load();
+  const shouldCache = options.shouldCache?.(value) ?? true;
+
+  if (shouldCache) {
+    try {
+      await repository.upsert({
+        provider: options.provider,
+        operation: options.operation,
+        cacheKey: identity.cacheKey,
+        requestHash: identity.requestHash,
+        requestJson: identity.normalizedInput,
+        responseJson: value,
+        expiresAt: getExpiresAt(now, options.ttlMs)
+      });
+    } catch {
+      // Provider data is still useful when cache persistence is unavailable.
+    }
+  }
+
+  return {
+    cacheKey: identity.cacheKey,
+    source: "provider",
+    value
+  };
+}
+
+export function createProviderResultCache(
+  repository: ProviderResultRepository = createPrismaProviderResultRepository()
+): ProviderResultCache {
+  return {
+    getOrSet(options) {
+      return getOrSetProviderResult(repository, options);
+    }
+  };
+}

--- a/apps/api/src/services/enrichment/mapEnrichment.test.ts
+++ b/apps/api/src/services/enrichment/mapEnrichment.test.ts
@@ -3,7 +3,14 @@ import { describe, expect, test, vi } from "vitest";
 import type { Activity } from "@japan-travel-planner/shared";
 
 import type { MapsProvider } from "../../providers/maps/mapsProvider.js";
+import type {
+  ProviderResultRecord,
+  ProviderResultRepository,
+  ProviderResultWriteInput
+} from "../../repositories/providerResultRepository.js";
+import { createProviderResultCache } from "./cache.js";
 import {
+  createCachedMapLink,
   enrichActivityWithMapLink,
   getActivityMapUrl
 } from "./mapEnrichment.js";
@@ -22,6 +29,42 @@ const activity: Activity = {
   costLevel: "free",
   notes: "Arrive before the busiest temple hours."
 };
+
+class InMemoryProviderResultRepository implements ProviderResultRepository {
+  private readonly records = new Map<string, ProviderResultRecord>();
+  private nextId = 1;
+
+  async findUsable(cacheKey: string, now = new Date()) {
+    const record = this.records.get(cacheKey);
+
+    if (record === undefined || record.expiresAt <= now) {
+      return null;
+    }
+
+    return structuredClone(record);
+  }
+
+  async upsert(input: ProviderResultWriteInput) {
+    const timestamp = new Date("2026-06-25T00:00:00.000Z");
+    const existingRecord = this.records.get(input.cacheKey);
+    const record: ProviderResultRecord = {
+      id: existingRecord?.id ?? `provider-result-${this.nextId++}`,
+      provider: input.provider,
+      operation: input.operation,
+      cacheKey: input.cacheKey,
+      requestHash: input.requestHash,
+      requestJson: structuredClone(input.requestJson),
+      responseJson: structuredClone(input.responseJson),
+      expiresAt: input.expiresAt,
+      createdAt: existingRecord?.createdAt ?? timestamp,
+      updatedAt: timestamp
+    };
+
+    this.records.set(input.cacheKey, record);
+
+    return structuredClone(record);
+  }
+}
 
 describe("map enrichment", () => {
   test("creates an activity map URL from activity location", () => {
@@ -69,5 +112,41 @@ describe("map enrichment", () => {
 
     expect(getActivityMapUrl(activity, provider)).toBeNull();
     expect(enrichActivityWithMapLink(activity, provider)).toEqual(activity);
+  });
+
+  test("uses cached map links for repeated equivalent inputs", async () => {
+    const provider = {
+      createSearchLink: vi.fn(() => "https://example.com/maps/senso-ji")
+    } satisfies MapsProvider;
+    const cache = createProviderResultCache(
+      new InMemoryProviderResultRepository()
+    );
+
+    const firstResult = await createCachedMapLink(
+      {
+        title: "Senso-ji morning visit",
+        location: {
+          city: "Tokyo",
+          name: "Senso-ji"
+        }
+      },
+      provider,
+      cache
+    );
+    const secondResult = await createCachedMapLink(
+      {
+        title: "  senso-ji   morning visit ",
+        location: {
+          name: "Senso-ji",
+          city: "tokyo"
+        }
+      },
+      provider,
+      cache
+    );
+
+    expect(firstResult).toBe("https://example.com/maps/senso-ji");
+    expect(secondResult).toBe(firstResult);
+    expect(provider.createSearchLink).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/services/enrichment/mapEnrichment.ts
+++ b/apps/api/src/services/enrichment/mapEnrichment.ts
@@ -5,8 +5,11 @@ import {
   type MapLinkInput,
   type MapsProvider
 } from "../../providers/maps/mapsProvider.js";
+import type { ProviderResultCache } from "./cache.js";
 
 const defaultMapsProvider = createGoogleMapsProvider();
+
+export const mapLinkCacheTtlMs = 30 * 24 * 60 * 60 * 1000;
 
 export function activityToMapLinkInput(activity: Activity): MapLinkInput {
   return {
@@ -30,6 +33,54 @@ export function createMapLink(
   } catch {
     return null;
   }
+}
+
+function isCachedMapLink(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+export function normalizeMapLinkCacheInput(input: MapLinkInput) {
+  return {
+    ...(input.title !== undefined ? { title: input.title } : {}),
+    ...(input.location !== undefined
+      ? {
+          location: {
+            ...(input.location.address !== undefined
+              ? { address: input.location.address }
+              : {}),
+            ...(input.location.city !== undefined
+              ? { city: input.location.city }
+              : {}),
+            ...(input.location.latitude !== undefined
+              ? { latitude: input.location.latitude }
+              : {}),
+            ...(input.location.longitude !== undefined
+              ? { longitude: input.location.longitude }
+              : {}),
+            ...(input.location.name !== undefined
+              ? { name: input.location.name }
+              : {})
+          }
+        }
+      : {})
+  };
+}
+
+export async function createCachedMapLink(
+  input: MapLinkInput,
+  provider: MapsProvider,
+  cache: ProviderResultCache
+) {
+  const result = await cache.getOrSet({
+    provider: "google-maps",
+    operation: "maps.link",
+    input: normalizeMapLinkCacheInput(input),
+    ttlMs: mapLinkCacheTtlMs,
+    load: async () => createMapLink(input, provider),
+    isCachedValue: isCachedMapLink
+  });
+
+  return result.value;
 }
 
 export function getActivityMapUrl(

--- a/apps/api/src/services/enrichment/weatherEnrichment.test.ts
+++ b/apps/api/src/services/enrichment/weatherEnrichment.test.ts
@@ -6,7 +6,20 @@ import {
   type WeatherProvider,
   type WeatherSummary
 } from "../../providers/weather/weatherProvider.js";
-import { createWeatherSummary } from "./weatherEnrichment.js";
+import type {
+  ProviderResultRecord,
+  ProviderResultRepository,
+  ProviderResultWriteInput
+} from "../../repositories/providerResultRepository.js";
+import {
+  createProviderResultCache,
+  createProviderResultCacheIdentity
+} from "./cache.js";
+import {
+  createCachedWeatherSummary,
+  createWeatherSummary,
+  normalizeWeatherSummaryCacheInput
+} from "./weatherEnrichment.js";
 
 const weatherSummary = {
   city: "Tokyo",
@@ -32,6 +45,52 @@ const request = {
   city: "Tokyo",
   date: "2026-04-06"
 };
+
+class InMemoryProviderResultRepository implements ProviderResultRepository {
+  private readonly records = new Map<string, ProviderResultRecord>();
+  private nextId = 1;
+  failRead = false;
+  failWrite = false;
+
+  async findUsable(cacheKey: string, now = new Date()) {
+    if (this.failRead) {
+      throw new Error("cache read failed");
+    }
+
+    const record = this.records.get(cacheKey);
+
+    if (record === undefined || record.expiresAt <= now) {
+      return null;
+    }
+
+    return structuredClone(record);
+  }
+
+  async upsert(input: ProviderResultWriteInput) {
+    if (this.failWrite) {
+      throw new Error("cache write failed");
+    }
+
+    const timestamp = new Date("2026-06-25T00:00:00.000Z");
+    const existingRecord = this.records.get(input.cacheKey);
+    const record: ProviderResultRecord = {
+      id: existingRecord?.id ?? `provider-result-${this.nextId++}`,
+      provider: input.provider,
+      operation: input.operation,
+      cacheKey: input.cacheKey,
+      requestHash: input.requestHash,
+      requestJson: structuredClone(input.requestJson),
+      responseJson: structuredClone(input.responseJson),
+      expiresAt: input.expiresAt,
+      createdAt: existingRecord?.createdAt ?? timestamp,
+      updatedAt: timestamp
+    };
+
+    this.records.set(input.cacheKey, record);
+
+    return structuredClone(record);
+  }
+}
 
 describe("weather enrichment", () => {
   test("returns available weather from the provider", async () => {
@@ -79,5 +138,83 @@ describe("weather enrichment", () => {
     await expect(createWeatherSummary(request, provider)).rejects.toBeInstanceOf(
       WeatherProviderConfigurationError
     );
+  });
+
+  test("uses cached weather on a second identical request", async () => {
+    const provider = {
+      getDailySummary: vi.fn(async () => weatherSummary)
+    } satisfies WeatherProvider;
+    const cache = createProviderResultCache(
+      new InMemoryProviderResultRepository()
+    );
+
+    const firstResult = await createCachedWeatherSummary(
+      request,
+      provider,
+      cache
+    );
+    const secondResult = await createCachedWeatherSummary(
+      { city: "  Tokyo ", date: "2026-04-06", units: "metric" },
+      provider,
+      cache
+    );
+
+    expect(firstResult).toEqual({
+      status: "available",
+      weatherSummary
+    });
+    expect(secondResult).toEqual(firstResult);
+    expect(provider.getDailySummary).toHaveBeenCalledTimes(1);
+  });
+
+  test("refreshes expired cached weather", async () => {
+    const repository = new InMemoryProviderResultRepository();
+    const cache = createProviderResultCache(repository);
+    const identity = createProviderResultCacheIdentity({
+      provider: "openweather",
+      operation: "weather.summary",
+      input: normalizeWeatherSummaryCacheInput(request)
+    });
+    await repository.upsert({
+      provider: "openweather",
+      operation: "weather.summary",
+      cacheKey: identity.cacheKey,
+      requestHash: identity.requestHash,
+      requestJson: identity.normalizedInput,
+      responseJson: {
+        status: "missing",
+        weatherSummary: null
+      },
+      expiresAt: new Date("2026-06-24T00:00:00.000Z")
+    });
+    const provider = {
+      getDailySummary: vi.fn(async () => weatherSummary)
+    } satisfies WeatherProvider;
+
+    const result = await createCachedWeatherSummary(request, provider, cache);
+
+    expect(result).toEqual({
+      status: "available",
+      weatherSummary
+    });
+    expect(provider.getDailySummary).toHaveBeenCalledTimes(1);
+  });
+
+  test("cache read and write failures do not break provider success", async () => {
+    const repository = new InMemoryProviderResultRepository();
+    repository.failRead = true;
+    repository.failWrite = true;
+    const cache = createProviderResultCache(repository);
+    const provider = {
+      getDailySummary: vi.fn(async () => weatherSummary)
+    } satisfies WeatherProvider;
+
+    await expect(
+      createCachedWeatherSummary(request, provider, cache)
+    ).resolves.toEqual({
+      status: "available",
+      weatherSummary
+    });
+    expect(provider.getDailySummary).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/services/enrichment/weatherEnrichment.ts
+++ b/apps/api/src/services/enrichment/weatherEnrichment.ts
@@ -5,6 +5,9 @@ import {
   type WeatherSummary,
   type WeatherSummaryRequest
 } from "../../providers/weather/weatherProvider.js";
+import type { ProviderResultCache } from "./cache.js";
+
+export const weatherSummaryCacheTtlMs = 4 * 60 * 60 * 1000;
 
 export type WeatherEnrichmentResult =
   | {
@@ -51,4 +54,72 @@ export async function createWeatherSummary(
       weatherSummary: null
     };
   }
+}
+
+function isWeatherSummary(value: unknown): value is WeatherSummary {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const summary = value as Partial<WeatherSummary>;
+
+  return (
+    typeof summary.condition === "string" &&
+    typeof summary.date === "string" &&
+    typeof summary.note === "string" &&
+    typeof summary.temperatureUnit === "string" &&
+    typeof summary.windSpeedUnit === "string"
+  );
+}
+
+export function isWeatherEnrichmentResult(
+  value: unknown
+): value is WeatherEnrichmentResult {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const result = value as Partial<WeatherEnrichmentResult>;
+
+  if (result.status === "available") {
+    return isWeatherSummary(result.weatherSummary);
+  }
+
+  return (
+    (result.status === "missing" || result.status === "unavailable") &&
+    result.weatherSummary === null
+  );
+}
+
+export function normalizeWeatherSummaryCacheInput(
+  input: WeatherSummaryRequest
+) {
+  return {
+    ...(input.city !== undefined ? { city: input.city } : {}),
+    ...(input.countryCode !== undefined
+      ? { countryCode: input.countryCode }
+      : {}),
+    date: input.date,
+    ...(input.latitude !== undefined ? { latitude: input.latitude } : {}),
+    ...(input.longitude !== undefined ? { longitude: input.longitude } : {}),
+    units: input.units ?? "metric"
+  };
+}
+
+export async function createCachedWeatherSummary(
+  input: WeatherSummaryRequest,
+  provider: WeatherProvider,
+  cache: ProviderResultCache
+): Promise<WeatherEnrichmentResult> {
+  const result = await cache.getOrSet({
+    provider: "openweather",
+    operation: "weather.summary",
+    input: normalizeWeatherSummaryCacheInput(input),
+    ttlMs: weatherSummaryCacheTtlMs,
+    load: () => createWeatherSummary(input, provider),
+    isCachedValue: isWeatherEnrichmentResult,
+    shouldCache: (weatherResult) => weatherResult.status !== "unavailable"
+  });
+
+  return result.value;
 }


### PR DESCRIPTION
## Ticket scope
- Implements T-028 / Ticket 28: Add Provider Result Caching.
- Adds provider result persistence and cache wrappers for deterministic map enrichment and weather enrichment.
- Does not start Ticket 29 or later. No public share links, PDF export, hotels, transit, LINE, mobile, deployment, or observability work.

## Changes made
- Added a Prisma `ProviderResult` model and migration for cached provider request/response records.
- Added a provider result repository that can find unexpired cache records and upsert refreshed results.
- Added a provider result cache service with stable cache-key generation, TTL handling, secret-field redaction, and graceful read/write degradation.
- Integrated caching into map link enrichment and weather summary enrichment.
- Injected the provider cache through the Express app/router so tests can use an in-memory cache instead of a database.
- Added repository, cache, service, and route tests for hit/miss/expiry/degradation behavior.

## ProviderResult schema / migration summary
- `ProviderResult` stores `provider`, `operation`, unique `cacheKey`, `requestHash`, redacted `requestJson`, cached `responseJson`, `expiresAt`, `createdAt`, and `updatedAt`.
- Indexes added for `provider`, `(provider, operation)`, and `expiresAt`.
- Migration file added at `apps/api/prisma/migrations/202606250001_add_provider_result_cache/migration.sql`.
- Migration was not applied to a real local database in this environment; Prisma validate/generate and tests were run.

## Cache key design
- Cache keys are scoped as `provider:operation:sha256(normalizedInput)`.
- Input normalization trims/collapses/lowercases strings, sorts object keys, rounds numbers to 6 decimals, and preserves array order.
- Secret-like fields such as API keys, auth headers, cookies, passwords, secrets, and tokens are omitted before hashing/storage.

## Expiration policy
- Weather summaries use a 4 hour TTL.
- Google Maps search links use a 30 day TTL because they are deterministic URLs.
- Expired records are treated as misses and refreshed via the provider path.

## Cache hit / miss behavior
- On hit: returns the cached provider response without calling the provider.
- On miss or expired entry: calls the provider, stores a refreshed cache record, and returns the provider response.
- Weather `unavailable` failure responses are not cached.

## Failure / degradation behavior
- Cache read failures fall back to calling the provider.
- Cache write failures do not fail the request if the provider succeeds.
- Provider failures keep the existing error behavior. Missing weather configuration still returns the structured weather configuration error when no cache entry is available.

## Secret redaction / cached response safety
- Cache key input and stored `requestJson` omit secret-like fields.
- Cached responses only contain the normalized map/weather enrichment outputs returned by existing service layers.
- No provider API keys are exposed to the web app or frontend bundle.

## Tests / checks run
- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec prisma validate && pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit`
- `pnpm --filter @japan-travel-planner/web exec vite build`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `git diff --check`

## Manual checks run
- Started the API with `pnpm dev:api`.
- Verified `GET http://localhost:3001/api/health` returned HTTP 200 and JSON `status: ok`.
- Verified weather enrichment without `WEATHER_API_KEY` returned the existing structured configuration error.
- Verified maps enrichment returned a deterministic Google Maps search URL.
- Verified no weather/maps provider key strings in web source/dist search.
- Started the web app with `pnpm dev:web` and browser-checked empty state, mock itinerary submission, weather UI rendering, Google Maps links, local edit dirty state, and revert behavior.

## Real provider calls
- Real Google Maps API calls: no.
- Real OpenWeather API calls: no.
- Real OpenAI calls: no.

## Known risks
- Cache cleanup is not automated yet; expired records remain until a future maintenance path removes them.
- TTLs are fixed constants for now.
- Local migration was not applied against a real PostgreSQL instance in this environment.
- Cache storage is bypassed if the database is unavailable, but provider success still returns normally.

## Ticket boundary confirmation
- Ticket 29 and later were not started.
