### PR TITLE
Add public read-only share links

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,6 +16,7 @@ import {
 import { createEnrichmentRouter } from "./routes/enrichment.js";
 import { healthRouter } from "./routes/health.js";
 import { createItinerariesRouter } from "./routes/itineraries.js";
+import { createShareRouter } from "./routes/share.js";
 import { createTripsRouter } from "./routes/trips.js";
 import {
   createAiItineraryService,
@@ -30,6 +31,7 @@ import {
   createProviderResultCache,
   type ProviderResultCache
 } from "./services/enrichment/cache.js";
+import { createShareService, type ShareService } from "./services/shareService.js";
 import { createTripService, type TripService } from "./services/tripService.js";
 
 export type CreateAppOptions = {
@@ -40,6 +42,7 @@ export type CreateAppOptions = {
   mapsProvider?: MapsProvider;
   providerResultCache?: ProviderResultCache;
   sessionMiddleware?: RequestHandler;
+  shareService?: ShareService;
   tripService?: TripService;
   weatherProvider?: WeatherProvider;
 };
@@ -74,6 +77,7 @@ export function createApp(options: CreateAppOptions = {}) {
       windowMs: env.aiGenerationRateLimitWindowMs
     });
   const tripService = options.tripService ?? createTripService();
+  const shareService = options.shareService ?? createShareService();
   const mapsProvider = options.mapsProvider ?? createGoogleMapsProvider();
   const providerResultCache =
     options.providerResultCache ?? createProviderResultCache();
@@ -107,7 +111,12 @@ export function createApp(options: CreateAppOptions = {}) {
       usageLogger: aiUsageLogger
     })
   );
-  app.use("/api/trips", sessionMiddleware, createTripsRouter(tripService));
+  app.use("/api/share", createShareRouter(shareService));
+  app.use(
+    "/api/trips",
+    sessionMiddleware,
+    createTripsRouter(tripService, shareService)
+  );
   app.use(errorHandler);
 
   return app;

--- a/apps/api/src/repositories/shareRepository.ts
+++ b/apps/api/src/repositories/shareRepository.ts
@@ -1,0 +1,137 @@
+import { prisma } from "../db/client.js";
+import type { PrismaClient } from "../generated/prisma/client.js";
+
+import {
+  mapTrip,
+  tripWithDaysInclude,
+  type TripResponse
+} from "./tripRepository.js";
+
+export type SharePermission = "read_only";
+
+export type ShareLinkRecord = {
+  id: string;
+  tripId: string;
+  token: string;
+  permission: SharePermission;
+  expiresAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type SharedTripRecord = {
+  share: ShareLinkRecord;
+  trip: TripResponse;
+};
+
+export type ShareRepository = {
+  createReadOnlyLink(
+    tripId: string,
+    token: string,
+    expiresAt?: Date | null
+  ): Promise<ShareLinkRecord>;
+  findActiveReadOnlyByTripId(
+    tripId: string,
+    now?: Date
+  ): Promise<ShareLinkRecord | null>;
+  findReadOnlyTripByToken(
+    token: string,
+    now?: Date
+  ): Promise<SharedTripRecord | null>;
+};
+
+type PrismaShareLinkRecord = {
+  id: string;
+  tripId: string;
+  token: string;
+  permission: string;
+  expiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function mapShareLink(shareLink: PrismaShareLinkRecord): ShareLinkRecord {
+  return {
+    id: shareLink.id,
+    tripId: shareLink.tripId,
+    token: shareLink.token,
+    permission: "read_only",
+    expiresAt: shareLink.expiresAt?.toISOString() ?? null,
+    createdAt: shareLink.createdAt.toISOString(),
+    updatedAt: shareLink.updatedAt.toISOString()
+  };
+}
+
+function activeReadOnlyWhere(now: Date) {
+  return {
+    permission: "read_only",
+    OR: [
+      {
+        expiresAt: null
+      },
+      {
+        expiresAt: {
+          gt: now
+        }
+      }
+    ]
+  };
+}
+
+export function createPrismaShareRepository(
+  client: PrismaClient = prisma
+): ShareRepository {
+  return {
+    async createReadOnlyLink(tripId, token, expiresAt = null) {
+      const shareLink = await client.shareLink.create({
+        data: {
+          expiresAt,
+          permission: "read_only",
+          token,
+          tripId
+        }
+      });
+
+      return mapShareLink(shareLink as PrismaShareLinkRecord);
+    },
+
+    async findActiveReadOnlyByTripId(tripId, now = new Date()) {
+      const shareLink = await client.shareLink.findFirst({
+        where: {
+          tripId,
+          ...activeReadOnlyWhere(now)
+        },
+        orderBy: {
+          createdAt: "asc"
+        }
+      });
+
+      return shareLink === null
+        ? null
+        : mapShareLink(shareLink as PrismaShareLinkRecord);
+    },
+
+    async findReadOnlyTripByToken(token, now = new Date()) {
+      const shareLink = await client.shareLink.findFirst({
+        where: {
+          token,
+          ...activeReadOnlyWhere(now)
+        },
+        include: {
+          trip: {
+            include: tripWithDaysInclude
+          }
+        }
+      });
+
+      if (shareLink === null) {
+        return null;
+      }
+
+      return {
+        share: mapShareLink(shareLink as PrismaShareLinkRecord),
+        trip: mapTrip(shareLink.trip)
+      };
+    }
+  };
+}

--- a/apps/api/src/repositories/tripRepository.ts
+++ b/apps/api/src/repositories/tripRepository.ts
@@ -146,7 +146,7 @@ type PrismaTripWithDays = {
   }>;
 };
 
-const tripWithDaysInclude = {
+export const tripWithDaysInclude = {
   days: {
     orderBy: {
       orderIndex: "asc" as const
@@ -253,7 +253,7 @@ function buildTripUpdateData(input: UpdateTripInput) {
   };
 }
 
-function mapTrip(trip: PrismaTripWithDays): TripResponse {
+export function mapTrip(trip: PrismaTripWithDays): TripResponse {
   return {
     id: trip.id,
     title: trip.title,

--- a/apps/api/src/routes/share.test.ts
+++ b/apps/api/src/routes/share.test.ts
@@ -1,0 +1,465 @@
+import request, { type Response } from "supertest";
+import { describe, expect, test } from "vitest";
+
+import { apiErrorSchema } from "../../../../packages/shared/src/schemas/apiError.js";
+
+import { createApp } from "../app.js";
+import { defaultApiEnv } from "../config/env.js";
+import type {
+  ShareLinkRecord,
+  SharePermission,
+  ShareRepository,
+  SharedTripRecord
+} from "../repositories/shareRepository.js";
+import type {
+  CreateTripInput,
+  TripOwner,
+  TripRepository,
+  TripResponse,
+  UpdateTripInput
+} from "../repositories/tripRepository.js";
+import { ShareService } from "../services/shareService.js";
+import { TripService } from "../services/tripService.js";
+
+const validCreateTripPayload = {
+  title: "Tokyo And Kyoto Spring Highlights",
+  startDate: "2026-04-06",
+  endDate: "2026-04-08",
+  cities: ["Tokyo", "Kyoto"],
+  interests: ["temples", "local food"],
+  pace: "balanced",
+  budget: "moderate",
+  constraints: ["Avoid late-night activities"],
+  days: [
+    {
+      date: "2026-04-06",
+      city: "Tokyo",
+      summary: "Explore old Tokyo and classic food stops.",
+      weatherSummary: "Mild spring weather.",
+      activities: [
+        {
+          title: "Senso-ji and Nakamise-dori",
+          category: "culture",
+          timing: {
+            startTime: "09:30",
+            endTime: "11:30",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 120,
+          location: {
+            name: "Senso-ji",
+            address: "2 Chome-3-1 Asakusa, Taito City, Tokyo",
+            city: "Tokyo",
+            latitude: 35.7148,
+            longitude: 139.7967,
+            mapUrl:
+              "https://www.google.com/maps/search/?api=1&query=Senso-ji%20Tokyo"
+          },
+          costLevel: "free",
+          notes: "Arrive early for lighter crowds."
+        }
+      ]
+    }
+  ]
+} satisfies CreateTripInput;
+
+function getSetCookieHeaders(response: Response) {
+  const setCookie = response.headers["set-cookie"];
+
+  if (Array.isArray(setCookie)) {
+    return setCookie;
+  }
+
+  if (typeof setCookie === "string") {
+    return [setCookie];
+  }
+
+  return [];
+}
+
+function expectSharedErrorResponse(responseBody: unknown) {
+  expect(apiErrorSchema.safeParse(responseBody).success).toBe(true);
+}
+
+class InMemoryTripRepository implements TripRepository {
+  private readonly owners = new Map<string, TripOwner>();
+  private readonly tripOwners = new Map<string, string>();
+  private readonly trips = new Map<string, TripResponse>();
+  private nextOwnerId = 1;
+  private nextTripId = 1;
+  private nextDayId = 1;
+  private nextActivityId = 1;
+
+  async findOrCreateOwner(anonymousSessionId: string) {
+    const existingOwner = this.owners.get(anonymousSessionId);
+
+    if (existingOwner !== undefined) {
+      return existingOwner;
+    }
+
+    const owner = {
+      id: `owner-${this.nextOwnerId++}`
+    };
+
+    this.owners.set(anonymousSessionId, owner);
+
+    return owner;
+  }
+
+  async listTrips(ownerId: string) {
+    return Array.from(this.trips.values())
+      .filter((trip) => this.tripOwners.get(trip.id) === ownerId)
+      .map((trip) => structuredClone(trip));
+  }
+
+  async createTrip(ownerId: string, input: CreateTripInput) {
+    const trip = this.tripFromInput(`trip-${this.nextTripId++}`, input);
+
+    this.trips.set(trip.id, trip);
+    this.tripOwners.set(trip.id, ownerId);
+
+    return structuredClone(trip);
+  }
+
+  async findTrip(ownerId: string, tripId: string) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return null;
+    }
+
+    return this.findAnyTrip(tripId);
+  }
+
+  findAnyTrip(tripId: string) {
+    const trip = this.trips.get(tripId);
+
+    return trip === undefined ? null : structuredClone(trip);
+  }
+
+  async updateTrip(ownerId: string, tripId: string, input: UpdateTripInput) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return null;
+    }
+
+    const existingTrip = this.trips.get(tripId);
+
+    if (existingTrip === undefined) {
+      return null;
+    }
+
+    const updatedTrip: TripResponse = {
+      ...structuredClone(existingTrip),
+      ...(input.title !== undefined ? { title: input.title } : {}),
+      ...(input.startDate !== undefined ? { startDate: input.startDate } : {}),
+      ...(input.endDate !== undefined ? { endDate: input.endDate } : {}),
+      ...(input.cities !== undefined ? { cities: input.cities } : {}),
+      ...(input.interests !== undefined ? { interests: input.interests } : {}),
+      ...(input.pace !== undefined ? { pace: input.pace } : {}),
+      ...(input.budget !== undefined ? { budget: input.budget } : {}),
+      ...(input.constraints !== undefined
+        ? { constraints: input.constraints }
+        : {}),
+      ...(input.days !== undefined
+        ? {
+            days: input.days.map((day) => ({
+              id: `day-${this.nextDayId++}`,
+              ...day,
+              activities: day.activities.map((activity) => ({
+                ...activity,
+                id: activity.id ?? `activity-${this.nextActivityId++}`
+              }))
+            }))
+          }
+        : {}),
+      updatedAt: new Date("2026-01-02T00:00:00.000Z").toISOString()
+    };
+
+    this.trips.set(tripId, updatedTrip);
+
+    return structuredClone(updatedTrip);
+  }
+
+  async deleteTrip(ownerId: string, tripId: string) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return false;
+    }
+
+    this.tripOwners.delete(tripId);
+    return this.trips.delete(tripId);
+  }
+
+  private tripFromInput(id: string, input: CreateTripInput): TripResponse {
+    const timestamp = new Date("2026-01-01T00:00:00.000Z").toISOString();
+
+    return {
+      id,
+      ...structuredClone(input),
+      days: input.days.map((day) => ({
+        id: `day-${this.nextDayId++}`,
+        ...day,
+        activities: day.activities.map((activity) => ({
+          ...activity,
+          id: activity.id ?? `activity-${this.nextActivityId++}`
+        }))
+      })),
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+  }
+}
+
+class InMemoryShareRepository implements ShareRepository {
+  private readonly shares = new Map<string, ShareLinkRecord>();
+  private nextShareId = 1;
+
+  constructor(private readonly trips: InMemoryTripRepository) {}
+
+  seedShare(
+    options: {
+      permission?: SharePermission | "write";
+      token: string;
+      tripId: string;
+    } & Partial<Pick<ShareLinkRecord, "expiresAt">>
+  ) {
+    const timestamp = new Date("2026-01-01T00:00:00.000Z").toISOString();
+    const share: ShareLinkRecord = {
+      id: `share-${this.nextShareId++}`,
+      tripId: options.tripId,
+      token: options.token,
+      permission:
+        options.permission === undefined || options.permission === "read_only"
+          ? "read_only"
+          : ("write" as SharePermission),
+      expiresAt: options.expiresAt ?? null,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+
+    this.shares.set(share.token, share);
+
+    return structuredClone(share);
+  }
+
+  async createReadOnlyLink(tripId: string, token: string) {
+    return this.seedShare({
+      token,
+      tripId
+    });
+  }
+
+  async findActiveReadOnlyByTripId(tripId: string, now = new Date()) {
+    const share = Array.from(this.shares.values()).find(
+      (candidate) =>
+        candidate.tripId === tripId &&
+        candidate.permission === "read_only" &&
+        (candidate.expiresAt === null || new Date(candidate.expiresAt) > now)
+    );
+
+    return share === undefined ? null : structuredClone(share);
+  }
+
+  async findReadOnlyTripByToken(token: string, now = new Date()) {
+    const share = this.shares.get(token);
+
+    if (
+      share === undefined ||
+      share.permission !== "read_only" ||
+      (share.expiresAt !== null && new Date(share.expiresAt) <= now)
+    ) {
+      return null;
+    }
+
+    const trip = this.trips.findAnyTrip(share.tripId);
+
+    return trip === null
+      ? null
+      : ({
+          share: structuredClone(share),
+          trip
+        } satisfies SharedTripRecord);
+  }
+}
+
+function createShareTestApp() {
+  const tripRepository = new InMemoryTripRepository();
+  const shareRepository = new InMemoryShareRepository(tripRepository);
+  const shareService = new ShareService(tripRepository, shareRepository, {
+    now: () => new Date("2026-01-02T00:00:00.000Z"),
+    tokenFactory: () => "public-share-token-1234567890abcdef"
+  });
+
+  return {
+    app: createApp({
+      env: defaultApiEnv,
+      shareService,
+      tripService: new TripService(tripRepository)
+    }),
+    shareRepository
+  };
+}
+
+async function createSavedTrip() {
+  const { app, shareRepository } = createShareTestApp();
+  const owner = request.agent(app);
+  const createResponse = await owner
+    .post("/api/trips")
+    .send(validCreateTripPayload);
+
+  expect(createResponse.status).toBe(201);
+
+  return {
+    app,
+    owner,
+    shareRepository,
+    trip: createResponse.body.trip as TripResponse
+  };
+}
+
+describe("public share links", () => {
+  test("owner can create and reuse a read-only share link for a saved trip", async () => {
+    const { owner, trip } = await createSavedTrip();
+
+    const createShareResponse = await owner.post(`/api/trips/${trip.id}/share`);
+    const reuseShareResponse = await owner.post(`/api/trips/${trip.id}/share`);
+
+    expect(createShareResponse.status).toBe(201);
+    expect(reuseShareResponse.status).toBe(200);
+    expect(createShareResponse.body).toEqual({
+      share: {
+        token: "public-share-token-1234567890abcdef",
+        permission: "read_only",
+        expiresAt: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z"
+      }
+    });
+    expect(reuseShareResponse.body).toEqual(createShareResponse.body);
+    expect(createShareResponse.body.share.token).not.toContain(trip.id);
+  });
+
+  test("another owner cannot create a share link for someone else's trip", async () => {
+    const { app, trip } = await createSavedTrip();
+    const otherTraveler = request.agent(app);
+
+    const response = await otherTraveler.post(`/api/trips/${trip.id}/share`);
+
+    expect(response.status).toBe(404);
+    expectSharedErrorResponse(response.body);
+    expect(response.body).toEqual({
+      error: {
+        code: "TRIP_NOT_FOUND",
+        message: "Trip was not found."
+      }
+    });
+  });
+
+  test("valid share token returns read-only trip data without owner fields", async () => {
+    const { app, owner, trip } = await createSavedTrip();
+    const createShareResponse = await owner.post(`/api/trips/${trip.id}/share`);
+
+    const response = await request(app).get(
+      `/api/share/${createShareResponse.body.share.token}`
+    );
+
+    expect(response.status).toBe(200);
+    expect(getSetCookieHeaders(response)).toEqual([]);
+    expect(response.body).toMatchObject({
+      share: {
+        token: "public-share-token-1234567890abcdef",
+        permission: "read_only",
+        expiresAt: null
+      },
+      trip: {
+        id: trip.id,
+        title: validCreateTripPayload.title,
+        days: [
+          expect.objectContaining({
+            city: "Tokyo",
+            activities: [
+              expect.objectContaining({
+                title: "Senso-ji and Nakamise-dori",
+                location: expect.objectContaining({
+                  mapUrl:
+                    "https://www.google.com/maps/search/?api=1&query=Senso-ji%20Tokyo"
+                })
+              })
+            ]
+          })
+        ]
+      }
+    });
+    expect(JSON.stringify(response.body)).not.toContain("anonymousSessionId");
+    expect(JSON.stringify(response.body)).not.toContain("userId");
+    expect(response.body.share).not.toHaveProperty("id");
+    expect(response.body.share).not.toHaveProperty("tripId");
+  });
+
+  test("invalid, expired, and non-read-only tokens return safe structured errors", async () => {
+    const { app, shareRepository, trip } = await createSavedTrip();
+
+    shareRepository.seedShare({
+      token: "expired-share-token-1234567890",
+      tripId: trip.id,
+      expiresAt: "2026-01-01T00:00:00.000Z"
+    });
+    shareRepository.seedShare({
+      token: "write-share-token-1234567890",
+      tripId: trip.id,
+      permission: "write"
+    });
+
+    for (const token of [
+      "not-valid",
+      "expired-share-token-1234567890",
+      "write-share-token-1234567890"
+    ]) {
+      const response = await request(app).get(`/api/share/${token}`);
+
+      expect(response.status).toBe(404);
+      expectSharedErrorResponse(response.body);
+      expect(response.body).toEqual({
+        error: {
+          code: "SHARE_LINK_NOT_FOUND",
+          message: "Share link was not found."
+        }
+      });
+    }
+  });
+
+  test("private trip IDs and share tokens cannot bypass owner-scoped editing", async () => {
+    const { app, owner, trip } = await createSavedTrip();
+    const createShareResponse = await owner.post(`/api/trips/${trip.id}/share`);
+    const otherTraveler = request.agent(app);
+
+    const privateGetResponse = await otherTraveler.get(`/api/trips/${trip.id}`);
+    const patchWithShareTokenResponse = await request(app)
+      .patch(`/api/trips/${trip.id}`)
+      .set("Authorization", `Bearer ${createShareResponse.body.share.token}`)
+      .send({
+        title: "Edited Through Share Token"
+      });
+    const deleteWithShareTokenResponse = await request(app).delete(
+      `/api/trips/${trip.id}`
+    );
+    const publicPatchResponse = await request(app)
+      .patch(`/api/share/${createShareResponse.body.share.token}`)
+      .send({
+        title: "Edited Through Public Share"
+      });
+
+    expect(privateGetResponse.status).toBe(404);
+    expect(patchWithShareTokenResponse.status).toBe(404);
+    expect(deleteWithShareTokenResponse.status).toBe(404);
+    expect(publicPatchResponse.status).toBe(404);
+  });
+
+  test("GET /api/health still returns HTTP 200", async () => {
+    const { app } = createShareTestApp();
+
+    const response = await request(app).get("/api/health");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      status: "ok"
+    });
+  });
+});

--- a/apps/api/src/routes/share.ts
+++ b/apps/api/src/routes/share.ts
@@ -1,0 +1,39 @@
+import { Router, type RequestHandler } from "express";
+
+import { ApiError } from "../errors/ApiError.js";
+import type { ShareService } from "../services/shareService.js";
+
+function asyncHandler(handler: RequestHandler): RequestHandler {
+  return (request, response, next) => {
+    Promise.resolve(handler(request, response, next)).catch(next);
+  };
+}
+
+function getShareToken(value: string | string[] | undefined) {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+
+  throw new ApiError({
+    statusCode: 404,
+    code: "SHARE_LINK_NOT_FOUND",
+    message: "Share link was not found."
+  });
+}
+
+export function createShareRouter(shareService: ShareService) {
+  const router = Router();
+
+  router.get(
+    "/:shareToken",
+    asyncHandler(async (request, response) => {
+      const sharedTrip = await shareService.getSharedTrip(
+        getShareToken(request.params.shareToken)
+      );
+
+      response.status(200).json(sharedTrip);
+    })
+  );
+
+  return router;
+}

--- a/apps/api/src/routes/trips.ts
+++ b/apps/api/src/routes/trips.ts
@@ -8,6 +8,7 @@ import type {
   CreateTripInput,
   UpdateTripInput
 } from "../repositories/tripRepository.js";
+import type { ShareService } from "../services/shareService.js";
 import type { TripService } from "../services/tripService.js";
 
 const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
@@ -141,7 +142,10 @@ function getTripId(value: string | string[] | undefined) {
   });
 }
 
-export function createTripsRouter(tripService: TripService) {
+export function createTripsRouter(
+  tripService: TripService,
+  shareService: ShareService
+) {
   const router = Router();
 
   router.get(
@@ -178,6 +182,19 @@ export function createTripsRouter(tripService: TripService) {
       );
 
       response.status(200).json({ trip });
+    })
+  );
+
+  router.post(
+    "/:tripId/share",
+    asyncHandler(async (request, response) => {
+      const session = requireAnonymousSession(request);
+      const result = await shareService.createShareLink(
+        session.id,
+        getTripId(request.params.tripId)
+      );
+
+      response.status(result.reused ? 200 : 201).json({ share: result.share });
     })
   );
 

--- a/apps/api/src/services/shareService.test.ts
+++ b/apps/api/src/services/shareService.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { ApiError } from "../errors/ApiError.js";
+import type {
+  ShareLinkRecord,
+  SharePermission,
+  ShareRepository,
+  SharedTripRecord
+} from "../repositories/shareRepository.js";
+import type {
+  CreateTripInput,
+  TripOwner,
+  TripRepository,
+  TripResponse,
+  UpdateTripInput
+} from "../repositories/tripRepository.js";
+
+import { createShareToken, ShareService } from "./shareService.js";
+
+const trip: TripResponse = {
+  id: "trip-1",
+  title: "Tokyo And Kyoto Spring Highlights",
+  startDate: "2026-04-06",
+  endDate: "2026-04-08",
+  cities: ["Tokyo", "Kyoto"],
+  interests: ["temples", "local food"],
+  pace: "balanced",
+  budget: "moderate",
+  constraints: ["Avoid late-night activities"],
+  days: [
+    {
+      id: "day-1",
+      date: "2026-04-06",
+      city: "Tokyo",
+      activities: [
+        {
+          id: "activity-1",
+          title: "Senso-ji and Nakamise-dori",
+          category: "culture",
+          timing: {
+            startTime: "09:30",
+            endTime: "11:30",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 120,
+          location: {
+            name: "Senso-ji",
+            city: "Tokyo"
+          },
+          costLevel: "free",
+          notes: "Arrive early for lighter crowds."
+        }
+      ]
+    }
+  ],
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z"
+};
+
+class InMemoryTripRepository implements TripRepository {
+  private readonly owners = new Map<string, TripOwner>();
+  private readonly tripOwners = new Map<string, string>();
+  private readonly trips = new Map<string, TripResponse>();
+
+  setTrip(ownerSessionId: string, nextTrip: TripResponse) {
+    const owner = {
+      id: `owner-${ownerSessionId}`
+    };
+
+    this.owners.set(ownerSessionId, owner);
+    this.trips.set(nextTrip.id, structuredClone(nextTrip));
+    this.tripOwners.set(nextTrip.id, owner.id);
+  }
+
+  async findOrCreateOwner(anonymousSessionId: string) {
+    const existingOwner = this.owners.get(anonymousSessionId);
+
+    if (existingOwner !== undefined) {
+      return existingOwner;
+    }
+
+    const owner = {
+      id: `owner-${anonymousSessionId}`
+    };
+
+    this.owners.set(anonymousSessionId, owner);
+
+    return owner;
+  }
+
+  async listTrips(ownerId: string) {
+    return Array.from(this.trips.values()).filter(
+      (candidate) => this.tripOwners.get(candidate.id) === ownerId
+    );
+  }
+
+  async createTrip(
+    ownerId: string,
+    input: CreateTripInput
+  ): Promise<TripResponse> {
+    void ownerId;
+    void input;
+    throw new Error("createTrip is not used by share service tests.");
+  }
+
+  async findTrip(ownerId: string, tripId: string) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return null;
+    }
+
+    const existingTrip = this.trips.get(tripId);
+
+    return existingTrip === undefined ? null : structuredClone(existingTrip);
+  }
+
+  async updateTrip(
+    ownerId: string,
+    tripId: string,
+    input: UpdateTripInput
+  ): Promise<TripResponse | null> {
+    void ownerId;
+    void tripId;
+    void input;
+    throw new Error("updateTrip is not used by share service tests.");
+  }
+
+  async deleteTrip(ownerId: string, tripId: string): Promise<boolean> {
+    void ownerId;
+    void tripId;
+    throw new Error("deleteTrip is not used by share service tests.");
+  }
+}
+
+class InMemoryShareRepository implements ShareRepository {
+  private readonly shares = new Map<string, ShareLinkRecord>();
+  private nextShareId = 1;
+
+  constructor(private readonly trips: InMemoryTripRepository) {}
+
+  seedShare(
+    options: {
+      permission?: SharePermission | "write";
+      token: string;
+      tripId: string;
+    } & Partial<Pick<ShareLinkRecord, "expiresAt">>
+  ) {
+    const timestamp = new Date("2026-01-01T00:00:00.000Z").toISOString();
+    const share: ShareLinkRecord = {
+      id: `share-${this.nextShareId++}`,
+      tripId: options.tripId,
+      token: options.token,
+      permission:
+        options.permission === "read_only" || options.permission === undefined
+          ? "read_only"
+          : ("write" as SharePermission),
+      expiresAt: options.expiresAt ?? null,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+
+    this.shares.set(share.token, share);
+
+    return share;
+  }
+
+  async createReadOnlyLink(tripId: string, token: string) {
+    return this.seedShare({
+      token,
+      tripId
+    });
+  }
+
+  async findActiveReadOnlyByTripId(tripId: string, now = new Date()) {
+    return (
+      Array.from(this.shares.values()).find(
+        (share) =>
+          share.tripId === tripId &&
+          share.permission === "read_only" &&
+          (share.expiresAt === null || new Date(share.expiresAt) > now)
+      ) ?? null
+    );
+  }
+
+  async findReadOnlyTripByToken(token: string, now = new Date()) {
+    const share = this.shares.get(token);
+
+    if (
+      share === undefined ||
+      share.permission !== "read_only" ||
+      (share.expiresAt !== null && new Date(share.expiresAt) <= now)
+    ) {
+      return null;
+    }
+
+    const sharedTrip = await this.trips.findTrip(
+      `owner-owner-session`,
+      share.tripId
+    );
+
+    if (sharedTrip === null) {
+      return null;
+    }
+
+    return {
+      share,
+      trip: sharedTrip
+    } satisfies SharedTripRecord;
+  }
+}
+
+function createTestService(options: {
+  tokenFactory?: () => string;
+} = {}) {
+  const tripRepository = new InMemoryTripRepository();
+  const shareRepository = new InMemoryShareRepository(tripRepository);
+
+  tripRepository.setTrip("owner-session", trip);
+
+  return {
+    service: new ShareService(tripRepository, shareRepository, {
+      now: () => new Date("2026-01-02T00:00:00.000Z"),
+      tokenFactory: options.tokenFactory ?? (() => "share-token-1234567890")
+    }),
+    shareRepository,
+    tripRepository
+  };
+}
+
+describe("createShareToken", () => {
+  test("creates high-entropy URL-safe tokens that are not trip-derived", () => {
+    const firstToken = createShareToken();
+    const secondToken = createShareToken();
+
+    expect(firstToken).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+    expect(secondToken).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+    expect(firstToken).not.toBe(secondToken);
+    expect(firstToken).not.toContain("trip-1");
+  });
+});
+
+describe("ShareService", () => {
+  test("creates a read-only share link for the trip owner", async () => {
+    const { service } = createTestService({
+      tokenFactory: () => "share-token-1234567890abcdef"
+    });
+
+    const result = await service.createShareLink("owner-session", "trip-1");
+
+    expect(result).toEqual({
+      reused: false,
+      share: expect.objectContaining({
+        token: "share-token-1234567890abcdef",
+        permission: "read_only",
+        expiresAt: null
+      })
+    });
+    expect(result.share).not.toHaveProperty("id");
+    expect(result.share).not.toHaveProperty("tripId");
+  });
+
+  test("reuses an existing active read-only link for the same trip", async () => {
+    const tokenFactory = vi.fn(() => "new-token-should-not-be-used");
+    const { service, shareRepository } = createTestService({
+      tokenFactory
+    });
+
+    shareRepository.seedShare({
+      token: "existing-share-token-1234567890",
+      tripId: "trip-1"
+    });
+
+    const result = await service.createShareLink("owner-session", "trip-1");
+
+    expect(result.reused).toBe(true);
+    expect(result.share.token).toBe("existing-share-token-1234567890");
+    expect(tokenFactory).not.toHaveBeenCalled();
+  });
+
+  test("does not let another owner create a share link", async () => {
+    const { service } = createTestService();
+
+    await expect(
+      service.createShareLink("different-session", "trip-1")
+    ).rejects.toMatchObject({
+      code: "TRIP_NOT_FOUND",
+      statusCode: 404
+    });
+  });
+
+  test("returns shared trip data for a valid read-only token", async () => {
+    const { service, shareRepository } = createTestService();
+
+    shareRepository.seedShare({
+      token: "valid-share-token-1234567890",
+      tripId: "trip-1"
+    });
+
+    const result = await service.getSharedTrip(
+      "valid-share-token-1234567890"
+    );
+
+    expect(result.trip).toMatchObject({
+      id: "trip-1",
+      title: trip.title
+    });
+    expect(result.share).toMatchObject({
+      token: "valid-share-token-1234567890",
+      permission: "read_only"
+    });
+  });
+
+  test("returns safe not-found errors for invalid and expired tokens", async () => {
+    const { service, shareRepository } = createTestService();
+
+    shareRepository.seedShare({
+      token: "expired-share-token-1234567890",
+      tripId: "trip-1",
+      expiresAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    await expect(service.getSharedTrip("short")).rejects.toBeInstanceOf(
+      ApiError
+    );
+    await expect(service.getSharedTrip("short")).rejects.toMatchObject({
+      code: "SHARE_LINK_NOT_FOUND",
+      statusCode: 404
+    });
+    await expect(
+      service.getSharedTrip("expired-share-token-1234567890")
+    ).rejects.toMatchObject({
+      code: "SHARE_LINK_NOT_FOUND",
+      statusCode: 404
+    });
+  });
+});

--- a/apps/api/src/services/shareService.ts
+++ b/apps/api/src/services/shareService.ts
@@ -1,0 +1,141 @@
+import { randomBytes } from "node:crypto";
+
+import { ApiError } from "../errors/ApiError.js";
+import {
+  createPrismaShareRepository,
+  type ShareLinkRecord,
+  type ShareRepository,
+  type SharedTripRecord
+} from "../repositories/shareRepository.js";
+import {
+  createPrismaTripRepository,
+  type TripRepository
+} from "../repositories/tripRepository.js";
+
+export type PublicShareLink = Omit<ShareLinkRecord, "id" | "tripId">;
+
+export type CreateShareLinkResult = {
+  reused: boolean;
+  share: PublicShareLink;
+};
+
+export type SharedTripResult = {
+  share: PublicShareLink;
+  trip: SharedTripRecord["trip"];
+};
+
+export type ShareServiceOptions = {
+  now?: () => Date;
+  tokenFactory?: () => string;
+};
+
+const shareTokenPattern = /^[A-Za-z0-9_-]{20,}$/;
+
+export function createShareToken() {
+  return randomBytes(32).toString("base64url");
+}
+
+function toPublicShareLink(share: ShareLinkRecord): PublicShareLink {
+  return {
+    token: share.token,
+    permission: share.permission,
+    expiresAt: share.expiresAt,
+    createdAt: share.createdAt,
+    updatedAt: share.updatedAt
+  };
+}
+
+function createNotFoundError() {
+  return new ApiError({
+    statusCode: 404,
+    code: "SHARE_LINK_NOT_FOUND",
+    message: "Share link was not found."
+  });
+}
+
+function assertUsableShareToken(token: string) {
+  if (!shareTokenPattern.test(token)) {
+    throw createNotFoundError();
+  }
+}
+
+export class ShareService {
+  private readonly now: () => Date;
+  private readonly tokenFactory: () => string;
+
+  constructor(
+    private readonly tripRepository: TripRepository,
+    private readonly shareRepository: ShareRepository,
+    options: ShareServiceOptions = {}
+  ) {
+    this.now = options.now ?? (() => new Date());
+    this.tokenFactory = options.tokenFactory ?? createShareToken;
+  }
+
+  async createShareLink(
+    anonymousSessionId: string,
+    tripId: string
+  ): Promise<CreateShareLinkResult> {
+    const owner = await this.tripRepository.findOrCreateOwner(
+      anonymousSessionId
+    );
+    const trip = await this.tripRepository.findTrip(owner.id, tripId);
+
+    if (trip === null) {
+      throw new ApiError({
+        statusCode: 404,
+        code: "TRIP_NOT_FOUND",
+        message: "Trip was not found."
+      });
+    }
+
+    const existingShareLink =
+      await this.shareRepository.findActiveReadOnlyByTripId(
+        trip.id,
+        this.now()
+      );
+
+    if (existingShareLink !== null) {
+      return {
+        reused: true,
+        share: toPublicShareLink(existingShareLink)
+      };
+    }
+
+    const share = await this.shareRepository.createReadOnlyLink(
+      trip.id,
+      this.tokenFactory()
+    );
+
+    return {
+      reused: false,
+      share: toPublicShareLink(share)
+    };
+  }
+
+  async getSharedTrip(shareToken: string): Promise<SharedTripResult> {
+    assertUsableShareToken(shareToken);
+
+    const sharedTrip = await this.shareRepository.findReadOnlyTripByToken(
+      shareToken,
+      this.now()
+    );
+
+    if (sharedTrip === null) {
+      throw createNotFoundError();
+    }
+
+    return {
+      share: toPublicShareLink(sharedTrip.share),
+      trip: sharedTrip.trip
+    };
+  }
+}
+
+export function createShareService(
+  tripRepository: TripRepository = createPrismaTripRepository(),
+  shareRepository: ShareRepository = createPrismaShareRepository(),
+  options: ShareServiceOptions = {}
+) {
+  return new ShareService(tripRepository, shareRepository, options);
+}

--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -3,9 +3,11 @@ import { expect, test, type Page, type Route } from "@playwright/test";
 const corsHeaders = {
   "access-control-allow-credentials": "true",
   "access-control-allow-headers": "content-type",
-  "access-control-allow-methods": "GET, POST, PATCH, OPTIONS",
+  "access-control-allow-methods": "GET, POST, PATCH, DELETE, OPTIONS",
   "access-control-allow-origin": "http://127.0.0.1:5173"
 };
+
+const publicShareToken = "public-share-token-1234567890abcdef";
 
 const generatedItineraryFixture = {
   title: "AI Generated Tokyo And Kyoto Route",
@@ -171,6 +173,7 @@ async function routeTripPersistence(
   options: { failFirstSave?: boolean } = {}
 ) {
   let savedTrip: ReturnType<typeof createTripRecordFromPayload> | null = null;
+  let shareCreatedForTripId: string | null = null;
   let saveAttempts = 0;
   let lastSavedPayload: TripWritePayload | null = null;
   let lastUpdatedPayload: TripWritePayload | null = null;
@@ -257,9 +260,79 @@ async function routeTripPersistence(
     });
   });
 
+  await page.route("**/api/trips/generated-trip-1/share", async (route) => {
+    if (isOptionsRequest(route)) {
+      await fulfillOptions(route);
+      return;
+    }
+
+    expect(route.request().method()).toBe("POST");
+    shareCreatedForTripId = "generated-trip-1";
+
+    await route.fulfill({
+      contentType: "application/json",
+      headers: corsHeaders,
+      json: {
+        share: {
+          token: publicShareToken,
+          permission: "read_only",
+          expiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z"
+        }
+      },
+      status: 201
+    });
+  });
+
+  await page.route("**/api/share/*", async (route) => {
+    if (isOptionsRequest(route)) {
+      await fulfillOptions(route);
+      return;
+    }
+
+    expect(route.request().method()).toBe("GET");
+
+    if (
+      route.request().url().endsWith(`/api/share/${publicShareToken}`) &&
+      savedTrip &&
+      shareCreatedForTripId === savedTrip.id
+    ) {
+      await route.fulfill({
+        contentType: "application/json",
+        headers: corsHeaders,
+        json: {
+          share: {
+            token: publicShareToken,
+            permission: "read_only",
+            expiresAt: null,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z"
+          },
+          trip: savedTrip
+        },
+        status: 200
+      });
+      return;
+    }
+
+    await route.fulfill({
+      contentType: "application/json",
+      headers: corsHeaders,
+      json: {
+        error: {
+          code: "SHARE_LINK_NOT_FOUND",
+          message: "Share link was not found."
+        }
+      },
+      status: 404
+    });
+  });
+
   return {
     getLastSavedPayload: () => lastSavedPayload,
     getLastUpdatedPayload: () => lastUpdatedPayload,
+    getShareCreatedForTripId: () => shareCreatedForTripId,
     getSaveAttempts: () => saveAttempts
   };
 }
@@ -550,4 +623,51 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
     "Generated Asakusa lunch",
     patchedEditedTitle
   ]);
+
+  await page.getByRole("button", { name: "Create public link" }).click();
+  expect(persistence.getShareCreatedForTripId()).toBe("generated-trip-1");
+
+  const shareUrlInput = page.getByLabel("Share URL");
+  await expect(shareUrlInput).toHaveValue(
+    new RegExp(`/share/${publicShareToken}$`)
+  );
+
+  const shareUrl = await shareUrlInput.inputValue();
+  await page.goto(new URL(shareUrl).pathname);
+
+  await expect(
+    page.getByRole("heading", {
+      level: 1,
+      name: "AI Generated Tokyo And Kyoto Route"
+    })
+  ).toBeVisible();
+  await expect(
+    page
+      .getByRole("region", { name: "Day 1: Tokyo" })
+      .getByRole("heading", { name: "Generated Asakusa lunch" })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Open in Google Maps" }).first()
+  ).toHaveAttribute(
+    "href",
+    "https://www.google.com/maps/search/?api=1&query=Generated%20Asakusa%20lunch%20Asakusa%20Tokyo"
+  );
+  await expect(page.getByRole("button", { name: /Edit/ })).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Save itinerary" })
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Revert local edits" })
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Generate AI itinerary" })
+  ).toHaveCount(0);
+  await expect(page.getByRole("region", { name: "Save and reopen" })).toHaveCount(
+    0
+  );
+
+  await page.goto("/share/invalid-public-share-token-1234567890");
+  await expect(
+    page.getByRole("heading", { name: "Share link not available" })
+  ).toBeVisible();
 });

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -360,6 +360,77 @@ select {
   letter-spacing: 0;
 }
 
+.share-controls {
+  display: grid;
+  gap: 14px;
+  border-top: 1px solid #d8e0e6;
+  padding-top: 18px;
+}
+
+.share-controls h3 {
+  margin: 8px 0 0;
+  color: #172026;
+  font-size: 1.05rem;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+.share-help {
+  margin: 0;
+  color: #52616d;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.share-controls > button,
+.share-url-field button {
+  width: 100%;
+  border: 1px solid #0d3b4f;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #0d3b4f;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 11px 14px;
+}
+
+.share-controls > button:disabled {
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+
+.share-url-field {
+  display: grid;
+  gap: 7px;
+}
+
+.share-url-field label {
+  color: #172026;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.share-url-field div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.share-url-field input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid #cfd9df;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #172026;
+  padding: 10px 11px;
+}
+
+.share-url-field button {
+  width: auto;
+  min-width: 80px;
+}
+
 .mode-toggle,
 .storage-actions {
   display: grid;
@@ -800,6 +871,24 @@ select {
   color: #52616d;
   font-size: 1rem;
   line-height: 1.6;
+}
+
+.shared-app-shell {
+  display: block;
+}
+
+.shared-main {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+.shared-hero {
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 420px);
+}
+
+.shared-error {
+  border-color: #efb6ae;
+  background: #fff7f5;
 }
 
 @media (max-width: 820px) {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,7 +1,7 @@
 import { renderToString } from "react-dom/server";
 import { describe, expect, test } from "vitest";
 
-import { App } from "./App";
+import { App, getShareTokenFromPathname } from "./App";
 
 describe("App", () => {
   test("renders the responsive trip planner shell", () => {
@@ -15,7 +15,18 @@ describe("App", () => {
     expect(html).toContain("Save and reopen");
     expect(html).toContain("Revert local edits");
     expect(html).toContain("Refresh saved trips");
+    expect(html).toContain("Read-only share link");
+    expect(html).toContain("Save this itinerary before creating a public share link.");
     expect(html).toContain("No itinerary yet");
     expect(html).toContain("API");
+  });
+
+  test("parses public share route tokens without adding a router dependency", () => {
+    expect(
+      getShareTokenFromPathname(
+        "/share/public-share-token-1234567890abcdef"
+      )
+    ).toBe("public-share-token-1234567890abcdef");
+    expect(getShareTokenFromPathname("/")).toBeNull();
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import {
   useItineraryEditor
 } from "./features/itinerary/editing/useItineraryEditor.js";
 import { useGeneratedItinerary } from "./features/itinerary/useGeneratedItinerary.js";
+import { ShareControls } from "./features/sharing/ShareControls.js";
 import { TripIntakeForm } from "./features/trip-intake/index.js";
 import {
   getDefaultTripDataMode,
@@ -16,6 +17,7 @@ import {
   type TripDataMode
 } from "./features/trips/useTrips.js";
 import { mockItinerary } from "./mocks/index.js";
+import { SharedTripPage } from "./routes/SharedTripPage.js";
 
 const navigationItems = ["Planner", "Trips", "Account"];
 
@@ -26,11 +28,31 @@ function isApiBusy(status: ReturnType<typeof useTrips>["status"]) {
     status === "creating" ||
     status === "loading" ||
     status === "reopening" ||
-    status === "saving"
+    status === "saving" ||
+    status === "sharing"
   );
 }
 
+export function getShareTokenFromPathname(pathname: string) {
+  if (!pathname.startsWith("/share/")) {
+    return null;
+  }
+
+  const token = pathname.slice("/share/".length).split("/")[0] ?? "";
+
+  try {
+    return decodeURIComponent(token);
+  } catch {
+    return token;
+  }
+}
+
+function getCurrentPathname() {
+  return typeof window === "undefined" ? "/" : window.location.pathname;
+}
+
 export function App() {
+  const shareToken = getShareTokenFromPathname(getCurrentPathname());
   const [activeRequest, setActiveRequest] = useState<TripRequest | null>(null);
   const [dataMode, setDataMode] = useState<TripDataMode>(
     getDefaultTripDataMode
@@ -54,6 +76,21 @@ export function App() {
       : "Save itinerary";
   const storageMessage =
     localError ?? generatedItinerary.errorMessage ?? trips.errorMessage;
+  const selectedShareLink = trips.selectedTripId
+    ? trips.shareLinksByTripId[trips.selectedTripId]
+    : undefined;
+  const shareDisabledReason =
+    dataMode === "mock"
+      ? "Switch to API mode and save the trip before sharing."
+      : !trips.selectedTripId
+        ? "Save this itinerary before creating a public share link."
+        : itineraryEditor.isDirty
+          ? "Save local edits before sharing the itinerary."
+          : undefined;
+
+  if (shareToken !== null) {
+    return <SharedTripPage shareToken={shareToken} />;
+  }
 
   const workspacePanels = [
     {
@@ -184,6 +221,17 @@ export function App() {
     setLocalError(null);
     generatedItinerary.clearError();
     await trips.loadSavedTrips();
+  }
+
+  async function handleCreateShareLink() {
+    if (!trips.selectedTripId) {
+      setLocalError("Save this itinerary before creating a public share link.");
+      return;
+    }
+
+    setLocalError(null);
+    generatedItinerary.clearError();
+    await trips.createShareLink(trips.selectedTripId);
   }
 
   function handleModeChange(nextMode: TripDataMode) {
@@ -376,6 +424,14 @@ export function App() {
               >
                 Reopen trip
               </button>
+
+              <ShareControls
+                disabledReason={shareDisabledReason}
+                isSharing={trips.status === "sharing"}
+                onCreateShareLink={handleCreateShareLink}
+                shareLink={selectedShareLink}
+                tripId={trips.selectedTripId}
+              />
             </section>
           </div>
 

--- a/apps/web/src/features/sharing/ShareControls.test.tsx
+++ b/apps/web/src/features/sharing/ShareControls.test.tsx
@@ -1,0 +1,61 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { createShareUrl, ShareControls } from "./ShareControls.js";
+
+const shareLink = {
+  token: "public-share-token-1234567890abcdef",
+  permission: "read_only" as const,
+  expiresAt: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z"
+};
+
+describe("ShareControls", () => {
+  test("is explanatory and disabled before a saved trip exists", () => {
+    const html = renderToString(
+      <ShareControls
+        disabledReason="Save this itinerary before creating a public share link."
+        onCreateShareLink={() => undefined}
+        tripId={null}
+      />
+    );
+
+    expect(html).toContain("Read-only share link");
+    expect(html).toContain(
+      "Save this itinerary before creating a public share link."
+    );
+    expect(html).toContain("disabled");
+    expect(html).not.toContain("Share URL");
+  });
+
+  test("renders a copyable public share URL for a saved trip", () => {
+    const html = renderToString(
+      <ShareControls
+        onCreateShareLink={() => undefined}
+        shareLink={shareLink}
+        tripId="trip-1"
+      />
+    );
+
+    expect(html).toContain("Share URL");
+    expect(html).toContain(
+      "http://localhost:5173/share/public-share-token-1234567890abcdef"
+    );
+    expect(html).toContain("readOnly");
+    expect(html).toContain("Copy");
+  });
+});
+
+describe("createShareUrl", () => {
+  test("creates an app-local public share route", () => {
+    expect(
+      createShareUrl(
+        "public-share-token-1234567890abcdef",
+        "https://travel.example.com/"
+      )
+    ).toBe(
+      "https://travel.example.com/share/public-share-token-1234567890abcdef"
+    );
+  });
+});

--- a/apps/web/src/features/sharing/ShareControls.tsx
+++ b/apps/web/src/features/sharing/ShareControls.tsx
@@ -1,0 +1,78 @@
+import type { ShareLinkRecord } from "../../lib/api/types.js";
+
+export type ShareControlsProps = {
+  disabledReason?: string | undefined;
+  isSharing?: boolean | undefined;
+  onCreateShareLink: () => void;
+  shareLink?: ShareLinkRecord | undefined;
+  tripId?: string | null | undefined;
+};
+
+export function createShareUrl(token: string, origin?: string) {
+  const resolvedOrigin =
+    origin ??
+    (typeof window === "undefined"
+      ? "http://localhost:5173"
+      : window.location.origin);
+
+  return `${resolvedOrigin.replace(/\/$/, "")}/share/${encodeURIComponent(
+    token
+  )}`;
+}
+
+export function ShareControls({
+  disabledReason,
+  isSharing = false,
+  onCreateShareLink,
+  shareLink,
+  tripId
+}: ShareControlsProps) {
+  const shareUrl = shareLink ? createShareUrl(shareLink.token) : null;
+  const canCreateShareLink = Boolean(tripId) && !isSharing && !disabledReason;
+
+  async function copyShareUrl() {
+    if (!shareUrl || typeof navigator === "undefined") {
+      return;
+    }
+
+    await navigator.clipboard?.writeText(shareUrl);
+  }
+
+  return (
+    <section aria-labelledby="share-controls-title" className="share-controls">
+      <header>
+        <p className="section-kicker">Public sharing</p>
+        <h3 id="share-controls-title">Read-only share link</h3>
+      </header>
+
+      <p className="share-help">
+        {disabledReason ??
+          "Create a public read-only link for this saved itinerary."}
+      </p>
+
+      <button
+        disabled={!canCreateShareLink}
+        onClick={onCreateShareLink}
+        type="button"
+      >
+        {isSharing
+          ? "Creating share link"
+          : shareLink
+            ? "View share link"
+            : "Create public link"}
+      </button>
+
+      {shareUrl ? (
+        <div className="share-url-field">
+          <label htmlFor="share-url">Share URL</label>
+          <div>
+            <input id="share-url" readOnly type="url" value={shareUrl} />
+            <button onClick={copyShareUrl} type="button">
+              Copy
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/trips/useTrips.test.ts
+++ b/apps/web/src/features/trips/useTrips.test.ts
@@ -7,6 +7,7 @@ import {
 import type { TripRecord } from "../../lib/api/types.js";
 import { mockItinerary, mockTripRequest } from "../../mocks/index.js";
 import {
+  createShareLink,
   createSavedTrip,
   getTripErrorMessage,
   reopenSavedTrip,
@@ -41,6 +42,13 @@ function createTripRecord(overrides: Partial<TripRecord> = {}): TripRecord {
 
 function createMockClient(trip = createTripRecord()): TripApiClient {
   return {
+    createShareLink: vi.fn(async () => ({
+      token: "public-share-token-1234567890abcdef",
+      permission: "read_only" as const,
+      expiresAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    })),
     createTrip: vi.fn(async () => trip),
     generateItinerary: vi.fn(async () => ({
       itinerary: mockItinerary,
@@ -51,6 +59,16 @@ function createMockClient(trip = createTripRecord()): TripApiClient {
         repaired: false,
         tokenUsage: null
       }
+    })),
+    getSharedTrip: vi.fn(async () => ({
+      share: {
+        token: "public-share-token-1234567890abcdef",
+        permission: "read_only" as const,
+        expiresAt: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z"
+      },
+      trip
     })),
     getTrip: vi.fn(async () => trip),
     listTrips: vi.fn(async () => [trip]),
@@ -243,6 +261,18 @@ describe("trip API workflow helpers", () => {
 
     expect(client.getTrip).toHaveBeenCalledWith("trip-1");
     expect(result.itinerary.title).toBe("Reopened spring route");
+  });
+
+  test("creates read-only share links through the API client", async () => {
+    const client = createMockClient();
+
+    const shareLink = await createShareLink(client, "trip-1");
+
+    expect(client.createShareLink).toHaveBeenCalledWith("trip-1");
+    expect(shareLink).toMatchObject({
+      token: "public-share-token-1234567890abcdef",
+      permission: "read_only"
+    });
   });
 
   test("formats API field errors for visible UI feedback", () => {

--- a/apps/web/src/features/trips/useTrips.ts
+++ b/apps/web/src/features/trips/useTrips.ts
@@ -11,6 +11,7 @@ import {
   toTripWritePayload,
   tripRecordToItinerary,
   tripRecordToTripRequest,
+  type ShareLinkRecord,
   type TripRecord
 } from "../../lib/api/types.js";
 
@@ -23,7 +24,8 @@ export type TripOperationStatus =
   | "loading"
   | "reopening"
   | "saved"
-  | "saving";
+  | "saving"
+  | "sharing";
 
 export type TripOperationResult = {
   itinerary: Itinerary;
@@ -99,6 +101,13 @@ export async function reopenSavedTrip(
   };
 }
 
+export async function createShareLink(
+  client: TripApiClient,
+  tripId: string
+) {
+  return client.createShareLink(tripId);
+}
+
 function upsertTrip(trips: TripRecord[], trip: TripRecord) {
   const existingIndex = trips.findIndex(
     (candidate) => candidate.id === trip.id
@@ -119,6 +128,9 @@ export function useTrips(options: { client?: TripApiClient } = {}) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [savedTrips, setSavedTrips] = useState<TripRecord[]>([]);
   const [selectedTripId, setSelectedTripId] = useState<string | null>(null);
+  const [shareLinksByTripId, setShareLinksByTripId] = useState<
+    Record<string, ShareLinkRecord>
+  >({});
   const [status, setStatus] = useState<TripOperationStatus>("idle");
 
   function rememberTrip(trip: TripRecord) {
@@ -151,6 +163,25 @@ export function useTrips(options: { client?: TripApiClient } = {}) {
       runOperation("creating", () =>
         createSavedTrip(client, request, itinerary)
       ),
+    createShareLink: async (tripId: string) => {
+      setStatus("sharing");
+      setErrorMessage(null);
+
+      try {
+        const shareLink = await createShareLink(client, tripId);
+
+        setShareLinksByTripId((currentShareLinks) => ({
+          ...currentShareLinks,
+          [tripId]: shareLink
+        }));
+        setStatus("saved");
+        return shareLink;
+      } catch (error) {
+        setErrorMessage(getTripErrorMessage(error));
+        setStatus("error");
+        return null;
+      }
+    },
     errorMessage,
     loadSavedTrips: async () => {
       setStatus("loading");
@@ -184,6 +215,7 @@ export function useTrips(options: { client?: TripApiClient } = {}) {
     savedTrips,
     selectedTripId,
     selectTrip: setSelectedTripId,
+    shareLinksByTripId,
     status
   };
 }

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -85,6 +85,25 @@ describe("createTripApiClient", () => {
         trip: createTripRecord({
           title: "Updated API Trip"
         })
+      }),
+      jsonResponse({
+        share: {
+          token: "public-share-token-1234567890abcdef",
+          permission: "read_only",
+          expiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z"
+        }
+      }),
+      jsonResponse({
+        share: {
+          token: "public-share-token-1234567890abcdef",
+          permission: "read_only",
+          expiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z"
+        },
+        trip
       })
     ];
     const fetchMock = vi.fn(
@@ -114,12 +133,31 @@ describe("createTripApiClient", () => {
     ).resolves.toMatchObject({
       title: "Updated API Trip"
     });
+    await expect(client.createShareLink("trip-1")).resolves.toMatchObject({
+      token: "public-share-token-1234567890abcdef",
+      permission: "read_only"
+    });
+    await expect(
+      client.getSharedTrip("public-share-token-1234567890abcdef")
+    ).resolves.toMatchObject({
+      share: {
+        permission: "read_only"
+      },
+      trip: {
+        id: "trip-1"
+      }
+    });
 
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
       "http://localhost:3001/api/trips",
       "http://localhost:3001/api/trips/trip-1",
-      "http://localhost:3001/api/trips/trip-1"
+      "http://localhost:3001/api/trips/trip-1",
+      "http://localhost:3001/api/trips/trip-1/share",
+      "http://localhost:3001/api/share/public-share-token-1234567890abcdef"
     ]);
+    expect(fetchMock.mock.calls.map(([, init]) => init?.method ?? "GET")).toEqual(
+      ["GET", "GET", "PATCH", "POST", "GET"]
+    );
     expect(
       fetchMock.mock.calls.every(([, init]) => init?.credentials === "include")
     ).toBe(true);

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -5,6 +5,8 @@ import {
 import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
 import type {
   GenerateItineraryResponse,
+  ShareLinkRecord,
+  SharedTripRecord,
   TripRecord,
   TripWritePayload
 } from "./types.js";
@@ -39,10 +41,12 @@ export class TripApiClientError extends Error {
 }
 
 export type TripApiClient = {
+  createShareLink: (tripId: string) => Promise<ShareLinkRecord>;
   createTrip: (payload: TripWritePayload) => Promise<TripRecord>;
   generateItinerary: (
     payload: TripRequest
   ) => Promise<GenerateItineraryResponse>;
+  getSharedTrip: (shareToken: string) => Promise<SharedTripRecord>;
   getTrip: (tripId: string) => Promise<TripRecord>;
   listTrips: () => Promise<TripRecord[]>;
   updateTrip: (
@@ -138,6 +142,17 @@ export function createTripApiClient(
   }
 
   return {
+    async createShareLink(tripId) {
+      const response = await requestJson<{ share: ShareLinkRecord }>(
+        `/api/trips/${encodeURIComponent(tripId)}/share`,
+        {
+          method: "POST"
+        }
+      );
+
+      return response.share;
+    },
+
     async createTrip(payload) {
       const response = await requestJson<{ trip: TripRecord }>("/api/trips", {
         body: JSON.stringify(payload),
@@ -163,6 +178,12 @@ export function createTripApiClient(
       );
 
       return response.trip;
+    },
+
+    async getSharedTrip(shareToken) {
+      return requestJson<SharedTripRecord>(
+        `/api/share/${encodeURIComponent(shareToken)}`
+      );
     },
 
     async listTrips() {

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -37,6 +37,21 @@ export type TripRecord = Omit<Itinerary, "days"> &
 
 export type TripWritePayload = TripRequest & Itinerary;
 
+export type SharePermission = "read_only";
+
+export type ShareLinkRecord = {
+  token: string;
+  permission: SharePermission;
+  expiresAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type SharedTripRecord = {
+  share: ShareLinkRecord;
+  trip: TripRecord;
+};
+
 export function tripRecordToItinerary(trip: TripRecord): Itinerary {
   return {
     title: trip.title,

--- a/apps/web/src/routes/SharedTripPage.test.tsx
+++ b/apps/web/src/routes/SharedTripPage.test.tsx
@@ -1,0 +1,76 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { mockItinerary, mockTripRequest } from "../mocks/index.js";
+
+import { SharedTripPage } from "./SharedTripPage.js";
+
+const sharedTrip = {
+  share: {
+    token: "public-share-token-1234567890abcdef",
+    permission: "read_only" as const,
+    expiresAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  },
+  trip: {
+    id: "trip-1",
+    title: mockItinerary.title,
+    startDate: mockTripRequest.startDate,
+    endDate: mockTripRequest.endDate,
+    cities: [...mockTripRequest.cities],
+    interests: [...mockTripRequest.interests],
+    pace: mockTripRequest.pace,
+    budget: mockTripRequest.budget,
+    constraints: [...mockTripRequest.constraints],
+    days: mockItinerary.days.map((day, dayIndex) => ({
+      id: `day-${dayIndex + 1}`,
+      ...day,
+      activities: day.activities.map((activity, activityIndex) => ({
+        ...activity,
+        id: activity.id ?? `activity-${dayIndex + 1}-${activityIndex + 1}`
+      }))
+    })),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  }
+};
+
+describe("SharedTripPage", () => {
+  test("renders a shared itinerary as read-only", () => {
+    const html = renderToString(
+      <SharedTripPage
+        initialSharedTrip={sharedTrip}
+        shareToken="public-share-token-1234567890abcdef"
+      />
+    );
+
+    expect(html).toContain("Shared itinerary");
+    expect(html).toContain(mockItinerary.title);
+    expect(html).toContain("Morning walk through Ueno Park");
+    expect(html).toContain("Open in Google Maps");
+    expect(html).toContain("Read-only");
+    expect(html).not.toContain("Edit");
+    expect(html).not.toContain("Delete");
+    expect(html).not.toContain("Add activity");
+    expect(html).not.toContain("Save itinerary");
+    expect(html).not.toContain("Revert local edits");
+    expect(html).not.toContain("Generate AI itinerary");
+    expect(html).not.toContain("Trip storage");
+  });
+
+  test("renders a recoverable error state for unavailable share links", () => {
+    const html = renderToString(
+      <SharedTripPage
+        initialErrorMessage="Share link was not found."
+        initialSharedTrip={null}
+        shareToken="missing-share-token-1234567890"
+      />
+    );
+
+    expect(html).toContain("Share link not available");
+    expect(html).toContain("Share link was not found.");
+    expect(html).not.toContain("Save itinerary");
+    expect(html).not.toContain("Generate AI itinerary");
+  });
+});

--- a/apps/web/src/routes/SharedTripPage.tsx
+++ b/apps/web/src/routes/SharedTripPage.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { ItineraryView } from "../features/itinerary/ItineraryView.js";
+import {
+  createTripApiClient,
+  TripApiClientError,
+  type TripApiClient
+} from "../lib/api/client.js";
+import {
+  tripRecordToItinerary,
+  type SharedTripRecord
+} from "../lib/api/types.js";
+
+export type SharedTripPageProps = {
+  client?: TripApiClient | undefined;
+  initialErrorMessage?: string | null | undefined;
+  initialSharedTrip?: SharedTripRecord | null | undefined;
+  shareToken: string;
+};
+
+function getSharedTripErrorMessage(error: unknown) {
+  if (error instanceof TripApiClientError) {
+    return error.message;
+  }
+
+  return "This share link could not be opened.";
+}
+
+function formatSharePermission(permission: SharedTripRecord["share"]["permission"]) {
+  return permission === "read_only" ? "Read-only" : permission;
+}
+
+export function SharedTripPage({
+  client,
+  initialErrorMessage = null,
+  initialSharedTrip,
+  shareToken
+}: SharedTripPageProps) {
+  const defaultClient = useMemo(() => createTripApiClient(), []);
+  const apiClient = client ?? defaultClient;
+  const [errorMessage, setErrorMessage] = useState<string | null>(
+    initialErrorMessage
+  );
+  const [sharedTrip, setSharedTrip] = useState<SharedTripRecord | null>(
+    initialSharedTrip ?? null
+  );
+  const [isLoading, setIsLoading] = useState(initialSharedTrip === undefined);
+  const itinerary = sharedTrip ? tripRecordToItinerary(sharedTrip.trip) : null;
+
+  useEffect(() => {
+    if (initialSharedTrip !== undefined) {
+      return;
+    }
+
+    let isActive = true;
+
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    apiClient
+      .getSharedTrip(shareToken)
+      .then((nextSharedTrip) => {
+        if (!isActive) {
+          return;
+        }
+
+        setSharedTrip(nextSharedTrip);
+        setIsLoading(false);
+      })
+      .catch((error: unknown) => {
+        if (!isActive) {
+          return;
+        }
+
+        setErrorMessage(getSharedTripErrorMessage(error));
+        setSharedTrip(null);
+        setIsLoading(false);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [apiClient, initialSharedTrip, shareToken]);
+
+  return (
+    <div className="app-shell shared-app-shell">
+      <main className="app-main shared-main" aria-labelledby="shared-title">
+        <section className="workspace-hero shared-hero">
+          <div>
+            <p className="section-kicker">Shared itinerary</p>
+            <h1 id="shared-title">
+              {sharedTrip?.trip.title ?? "Shared Japan trip"}
+            </h1>
+            <p className="workspace-state">
+              This public link is read-only. It shows itinerary details without
+              private editing or storage controls.
+            </p>
+          </div>
+
+          <dl className="shell-status" aria-label="Shared trip status">
+            <div>
+              <dt>Permission</dt>
+              <dd>
+                {sharedTrip
+                  ? formatSharePermission(sharedTrip.share.permission)
+                  : "Read-only"}
+              </dd>
+            </div>
+            <div>
+              <dt>Days</dt>
+              <dd>{sharedTrip?.trip.days.length ?? 0}</dd>
+            </div>
+            <div>
+              <dt>Cities</dt>
+              <dd>{sharedTrip?.trip.cities.join(", ") ?? "Loading"}</dd>
+            </div>
+          </dl>
+        </section>
+
+        {errorMessage ? (
+          <section className="itinerary-state shared-error" role="alert">
+            <p className="section-kicker">Share unavailable</p>
+            <h2>Share link not available</h2>
+            <p>{errorMessage}</p>
+          </section>
+        ) : (
+          <ItineraryView itinerary={itinerary} isLoading={isLoading} />
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Ticket scope
- Implements T-029 / Ticket 29: Implement Public Read-Only Share Links.
- Adds owner-created public read-only links for saved trips and a public shared itinerary view.
- Does not start Ticket 30 or later. No PDF export, LINE sharing, hotels, transit, mobile, deployment, observability, AI generation changes, or provider cache changes.

## Changes made
- Added a `ShareRepository` for the existing Prisma `ShareLink` model.
- Added `ShareService` with owner-scoped share creation, public read-only lookup, reusable active links, and token validation.
- Added `POST /api/trips/:tripId/share` behind the existing anonymous session middleware.
- Added public `GET /api/share/:shareToken` without private session middleware.
- Added web API client methods for share creation and public share lookup.
- Added share state to the existing trip workflow hook.
- Added `ShareControls` near the storage panel and a minimal `/share/:shareToken` shared page without adding React Router.
- Extended the Playwright mocked MVP flow to create a share link, open it, and verify the itinerary is read-only.

## Share token design
- Tokens are generated with Node `crypto.randomBytes(32).toString("base64url")`.
- Tokens are URL-safe, high-entropy, and not derived from private trip IDs.
- Public lookup rejects malformed short tokens with the same safe not-found response.
- Repeated share creation reuses an existing active `read_only` link for the trip instead of minting multiple links.

## API behavior
- `POST /api/trips/:tripId/share` requires the current anonymous owner session and returns `{ share }`.
- Owners can create/reuse a read-only share link for their own saved trip.
- A different anonymous session receives the existing `TRIP_NOT_FOUND` response for someone else's trip.
- `GET /api/share/:shareToken` is public and returns shared read-only trip data for valid active read-only tokens.
- Missing, invalid, expired, and non-read-only tokens return structured `SHARE_LINK_NOT_FOUND`.
- No public PATCH/DELETE/save route exists for share tokens.

## Public read-only response shape
- Public response shape is `{ share, trip }`.
- `share` includes `token`, `permission`, `expiresAt`, `createdAt`, and `updatedAt`.
- `trip` uses the existing trip record shape needed to render itinerary details.
- The response does not include user ID, anonymous session ID, session cookie contents, private owner metadata, write endpoints, or edit capability.

## Web share control behavior
- The storage panel shows a read-only share-link control.
- Before a saved API trip is selected, the control is disabled with a save-first explanation.
- Dirty local edits disable sharing until the trip is saved.
- A saved trip can create/reuse a link and displays a copyable `/share/:token` URL.

## Shared page read-only behavior
- `/share/:shareToken` loads public trip data from `GET /api/share/:shareToken`.
- The page renders itinerary days, activities, weather summaries, and map links through the existing itinerary components.
- The page does not render edit, delete, reorder, add activity, save, reopen, revert, generation, retry, mock, or private storage controls.
- Invalid/unavailable share links show a clear read-only error state.

## Security / ownership behavior
- Private Trip CRUD remains anonymous-owner scoped.
- Private trip IDs alone do not grant access across sessions.
- Share token lookup bypasses private session only for read-only public data.
- Share tokens cannot be used to patch/delete a trip.
- Server-only config is not exposed to the web bundle.
- Share tokens are not logged by the new code.

## Tests added/updated
- API service tests for high-entropy token generation, owner share creation, active link reuse, non-owner denial, valid lookup, invalid token, and expired token behavior.
- API route tests for owner share creation, cross-owner denial, public read-only lookup, invalid/expired/non-read-only token errors, private owner scoping, and no write path through share tokens.
- Web client/helper tests for share endpoints.
- Share control tests for disabled pre-save state and copyable URL display.
- Shared page tests for read-only rendering and invalid-token error state.
- E2E update for create/share/open shared link and read-only itinerary assertions.

## Checks run
- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit`
- `pnpm --filter @japan-travel-planner/web exec vite build`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `git diff --check`

## Manual checks run
- Started API with `pnpm dev:api`.
- Confirmed `GET /api/health` returned HTTP 200 and JSON `status: ok`.
- Confirmed `GET /api/share/not-valid` returned structured `SHARE_LINK_NOT_FOUND`.
- Started web with `pnpm dev:web`.
- Browser-checked `http://localhost:5173/` rendered the empty itinerary state and disabled share control with save-first copy.
- Browser-checked `http://localhost:5173/share/not-valid` rendered the shared error page without edit/storage controls.
- Full create/share/open/read-only itinerary browser flow was verified by mocked Playwright E2E because local PostgreSQL was unavailable.

## Real DB-backed share flow
- Not manually tested against a real PostgreSQL database in this environment.
- Local `GET /api/trips` returned a 500 while API health worked, so the real DB-backed save/share flow could not be completed manually.
- API route/service tests use in-memory repositories, and Playwright E2E uses mocked API routes for the full browser flow.

## Real provider calls
- Real OpenAI calls: no.
- Real OpenWeather calls: no.
- Real Google Maps API calls: no.

## Known risks
- Share links currently do not expire when created; the repository supports `expiresAt` for future policy.
- No share revocation UI or endpoint yet.
- Existing public response includes the trip id, but private owner/session metadata remains excluded and private Trip CRUD remains owner-scoped.
- Real DB-backed share flow still needs verification in an environment with PostgreSQL available.

## Ticket boundary confirmation
- Ticket 30 and later were not started.
