### PR TITLE
Implement PDF export

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -31,6 +31,10 @@ import {
   createProviderResultCache,
   type ProviderResultCache
 } from "./services/enrichment/cache.js";
+import {
+  createPdfExportService,
+  type PdfExportService
+} from "./services/pdfExportService.js";
 import { createShareService, type ShareService } from "./services/shareService.js";
 import { createTripService, type TripService } from "./services/tripService.js";
 
@@ -40,6 +44,7 @@ export type CreateAppOptions = {
   aiItineraryService?: AiItineraryService;
   aiUsageLogger?: AiUsageLogger;
   mapsProvider?: MapsProvider;
+  pdfExportService?: PdfExportService;
   providerResultCache?: ProviderResultCache;
   sessionMiddleware?: RequestHandler;
   shareService?: ShareService;
@@ -78,6 +83,8 @@ export function createApp(options: CreateAppOptions = {}) {
     });
   const tripService = options.tripService ?? createTripService();
   const shareService = options.shareService ?? createShareService();
+  const pdfExportService =
+    options.pdfExportService ?? createPdfExportService();
   const mapsProvider = options.mapsProvider ?? createGoogleMapsProvider();
   const providerResultCache =
     options.providerResultCache ?? createProviderResultCache();
@@ -111,11 +118,11 @@ export function createApp(options: CreateAppOptions = {}) {
       usageLogger: aiUsageLogger
     })
   );
-  app.use("/api/share", createShareRouter(shareService));
+  app.use("/api/share", createShareRouter(shareService, pdfExportService));
   app.use(
     "/api/trips",
     sessionMiddleware,
-    createTripsRouter(tripService, shareService)
+    createTripsRouter(tripService, shareService, pdfExportService)
   );
   app.use(errorHandler);
 

--- a/apps/api/src/routes/export.test.ts
+++ b/apps/api/src/routes/export.test.ts
@@ -1,0 +1,401 @@
+import request from "supertest";
+import { describe, expect, test } from "vitest";
+
+import { apiErrorSchema } from "../../../../packages/shared/src/schemas/apiError.js";
+
+import { createApp } from "../app.js";
+import { defaultApiEnv } from "../config/env.js";
+import type {
+  ShareLinkRecord,
+  SharePermission,
+  ShareRepository,
+  SharedTripRecord
+} from "../repositories/shareRepository.js";
+import type {
+  CreateTripInput,
+  TripOwner,
+  TripRepository,
+  TripResponse,
+  UpdateTripInput
+} from "../repositories/tripRepository.js";
+import { PdfExportService } from "../services/pdfExportService.js";
+import { ShareService } from "../services/shareService.js";
+import { TripService } from "../services/tripService.js";
+
+const validCreateTripPayload = {
+  title: "Tokyo And Kyoto Spring Highlights",
+  startDate: "2026-04-06",
+  endDate: "2026-04-08",
+  cities: ["Tokyo", "Kyoto"],
+  interests: ["temples", "local food"],
+  pace: "balanced",
+  budget: "moderate",
+  constraints: ["Avoid late-night activities"],
+  days: [
+    {
+      date: "2026-04-06",
+      city: "Tokyo",
+      summary: "Explore old Tokyo and classic food stops.",
+      weatherSummary: "Mild spring weather.",
+      activities: [
+        {
+          title: "Senso-ji and Nakamise-dori",
+          category: "culture",
+          timing: {
+            startTime: "09:30",
+            endTime: "11:30",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 120,
+          location: {
+            name: "Senso-ji",
+            address: "2 Chome-3-1 Asakusa, Taito City, Tokyo",
+            city: "Tokyo",
+            mapUrl:
+              "https://www.google.com/maps/search/?api=1&query=Senso-ji%20Tokyo"
+          },
+          costLevel: "free",
+          notes: "Arrive early for lighter crowds."
+        }
+      ]
+    }
+  ]
+} satisfies CreateTripInput;
+
+function expectSharedErrorResponse(responseBody: unknown) {
+  expect(apiErrorSchema.safeParse(responseBody).success).toBe(true);
+}
+
+function expectPdfResponse(response: request.Response) {
+  expect(response.status).toBe(200);
+  expect(response.headers["content-type"]).toContain("application/pdf");
+  expect(response.headers["content-disposition"]).toBe(
+    'attachment; filename="tokyo-and-kyoto-spring-highlights.pdf"'
+  );
+  expect(response.headers["cache-control"]).toBe("no-store");
+
+  const pdfText = response.body.toString("utf8");
+
+  expect(pdfText.startsWith("%PDF-1.4")).toBe(true);
+  expect(pdfText).toContain("Tokyo And Kyoto Spring Highlights");
+  expect(pdfText).toContain("Senso-ji and Nakamise-dori");
+  expect(pdfText).toContain("Mild spring weather.");
+  expect(pdfText).toContain(
+    "https://www.google.com/maps/search/?api=1&query=Senso-ji%20Tokyo"
+  );
+  expect(pdfText).not.toContain("anonymousSessionId");
+  expect(pdfText).not.toContain("userId");
+}
+
+class InMemoryTripRepository implements TripRepository {
+  private readonly owners = new Map<string, TripOwner>();
+  private readonly tripOwners = new Map<string, string>();
+  private readonly trips = new Map<string, TripResponse>();
+  private nextOwnerId = 1;
+  private nextTripId = 1;
+  private nextDayId = 1;
+  private nextActivityId = 1;
+
+  async findOrCreateOwner(anonymousSessionId: string) {
+    const existingOwner = this.owners.get(anonymousSessionId);
+
+    if (existingOwner !== undefined) {
+      return existingOwner;
+    }
+
+    const owner = {
+      id: `owner-${this.nextOwnerId++}`
+    };
+
+    this.owners.set(anonymousSessionId, owner);
+
+    return owner;
+  }
+
+  async listTrips(ownerId: string) {
+    return Array.from(this.trips.values())
+      .filter((trip) => this.tripOwners.get(trip.id) === ownerId)
+      .map((trip) => structuredClone(trip));
+  }
+
+  async createTrip(ownerId: string, input: CreateTripInput) {
+    const trip = this.tripFromInput(`trip-${this.nextTripId++}`, input);
+
+    this.trips.set(trip.id, trip);
+    this.tripOwners.set(trip.id, ownerId);
+
+    return structuredClone(trip);
+  }
+
+  async findTrip(ownerId: string, tripId: string) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return null;
+    }
+
+    return this.findAnyTrip(tripId);
+  }
+
+  findAnyTrip(tripId: string) {
+    const trip = this.trips.get(tripId);
+
+    return trip === undefined ? null : structuredClone(trip);
+  }
+
+  async updateTrip(ownerId: string, tripId: string, input: UpdateTripInput) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return null;
+    }
+
+    const existingTrip = this.trips.get(tripId);
+
+    if (existingTrip === undefined) {
+      return null;
+    }
+
+    const updatedTrip: TripResponse = {
+      ...structuredClone(existingTrip),
+      ...(input.title !== undefined ? { title: input.title } : {}),
+      updatedAt: new Date("2026-01-02T00:00:00.000Z").toISOString()
+    };
+
+    this.trips.set(tripId, updatedTrip);
+
+    return structuredClone(updatedTrip);
+  }
+
+  async deleteTrip(ownerId: string, tripId: string) {
+    if (this.tripOwners.get(tripId) !== ownerId) {
+      return false;
+    }
+
+    this.tripOwners.delete(tripId);
+    return this.trips.delete(tripId);
+  }
+
+  private tripFromInput(id: string, input: CreateTripInput): TripResponse {
+    const timestamp = new Date("2026-01-01T00:00:00.000Z").toISOString();
+
+    return {
+      id,
+      ...structuredClone(input),
+      days: input.days.map((day) => ({
+        id: `day-${this.nextDayId++}`,
+        ...day,
+        activities: day.activities.map((activity) => ({
+          ...activity,
+          id: activity.id ?? `activity-${this.nextActivityId++}`
+        }))
+      })),
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+  }
+}
+
+class InMemoryShareRepository implements ShareRepository {
+  private readonly shares = new Map<string, ShareLinkRecord>();
+  private nextShareId = 1;
+
+  constructor(private readonly trips: InMemoryTripRepository) {}
+
+  seedShare(
+    options: {
+      permission?: SharePermission | "write";
+      token: string;
+      tripId: string;
+    } & Partial<Pick<ShareLinkRecord, "expiresAt">>
+  ) {
+    const timestamp = new Date("2026-01-01T00:00:00.000Z").toISOString();
+    const share: ShareLinkRecord = {
+      id: `share-${this.nextShareId++}`,
+      tripId: options.tripId,
+      token: options.token,
+      permission:
+        options.permission === undefined || options.permission === "read_only"
+          ? "read_only"
+          : ("write" as SharePermission),
+      expiresAt: options.expiresAt ?? null,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+
+    this.shares.set(share.token, share);
+
+    return structuredClone(share);
+  }
+
+  async createReadOnlyLink(tripId: string, token: string) {
+    return this.seedShare({
+      token,
+      tripId
+    });
+  }
+
+  async findActiveReadOnlyByTripId(tripId: string, now = new Date()) {
+    const share = Array.from(this.shares.values()).find(
+      (candidate) =>
+        candidate.tripId === tripId &&
+        candidate.permission === "read_only" &&
+        (candidate.expiresAt === null || new Date(candidate.expiresAt) > now)
+    );
+
+    return share === undefined ? null : structuredClone(share);
+  }
+
+  async findReadOnlyTripByToken(token: string, now = new Date()) {
+    const share = this.shares.get(token);
+
+    if (
+      share === undefined ||
+      share.permission !== "read_only" ||
+      (share.expiresAt !== null && new Date(share.expiresAt) <= now)
+    ) {
+      return null;
+    }
+
+    const trip = this.trips.findAnyTrip(share.tripId);
+
+    return trip === null
+      ? null
+      : ({
+          share: structuredClone(share),
+          trip
+        } satisfies SharedTripRecord);
+  }
+}
+
+function createExportTestApp(options: { failPdf?: boolean } = {}) {
+  const tripRepository = new InMemoryTripRepository();
+  const shareRepository = new InMemoryShareRepository(tripRepository);
+  const shareService = new ShareService(tripRepository, shareRepository, {
+    now: () => new Date("2026-01-02T00:00:00.000Z"),
+    tokenFactory: () => "public-share-token-1234567890abcdef"
+  });
+  const pdfExportService = new PdfExportService({
+    now: () => new Date("2026-01-03T04:05:06.000Z"),
+    ...(options.failPdf
+      ? {
+          renderer: () => {
+            throw new Error("PDF failure");
+          }
+        }
+      : {})
+  });
+
+  return {
+    app: createApp({
+      env: defaultApiEnv,
+      pdfExportService,
+      shareService,
+      tripService: new TripService(tripRepository)
+    }),
+    shareRepository
+  };
+}
+
+async function createSavedTrip(options: { failPdf?: boolean } = {}) {
+  const { app, shareRepository } = createExportTestApp(options);
+  const owner = request.agent(app);
+  const createResponse = await owner
+    .post("/api/trips")
+    .send(validCreateTripPayload);
+
+  expect(createResponse.status).toBe(201);
+
+  return {
+    app,
+    owner,
+    shareRepository,
+    trip: createResponse.body.trip as TripResponse
+  };
+}
+
+describe("PDF export routes", () => {
+  test("owner can export their own saved trip as a PDF", async () => {
+    const { owner, trip } = await createSavedTrip();
+
+    const response = await owner.get(`/api/trips/${trip.id}/export/pdf`);
+
+    expectPdfResponse(response);
+  });
+
+  test("another owner cannot export someone else's private trip", async () => {
+    const { app, trip } = await createSavedTrip();
+    const otherTraveler = request.agent(app);
+
+    const response = await otherTraveler.get(
+      `/api/trips/${trip.id}/export/pdf`
+    );
+
+    expect(response.status).toBe(404);
+    expectSharedErrorResponse(response.body);
+    expect(response.body).toEqual({
+      error: {
+        code: "TRIP_NOT_FOUND",
+        message: "Trip was not found."
+      }
+    });
+  });
+
+  test("valid read-only share tokens can export the shared trip PDF", async () => {
+    const { app, owner, trip } = await createSavedTrip();
+    const createShareResponse = await owner.post(`/api/trips/${trip.id}/share`);
+
+    const response = await request(app).get(
+      `/api/share/${createShareResponse.body.share.token}/export/pdf`
+    );
+
+    expectPdfResponse(response);
+  });
+
+  test("invalid, expired, and non-read-only share tokens cannot export PDF", async () => {
+    const { app, shareRepository, trip } = await createSavedTrip();
+
+    shareRepository.seedShare({
+      token: "expired-share-token-1234567890",
+      tripId: trip.id,
+      expiresAt: "2026-01-01T00:00:00.000Z"
+    });
+    shareRepository.seedShare({
+      token: "write-share-token-1234567890",
+      tripId: trip.id,
+      permission: "write"
+    });
+
+    for (const token of [
+      "not-valid",
+      "expired-share-token-1234567890",
+      "write-share-token-1234567890"
+    ]) {
+      const response = await request(app).get(
+        `/api/share/${token}/export/pdf`
+      );
+
+      expect(response.status).toBe(404);
+      expectSharedErrorResponse(response.body);
+      expect(response.body).toEqual({
+        error: {
+          code: "SHARE_LINK_NOT_FOUND",
+          message: "Share link was not found."
+        }
+      });
+    }
+  });
+
+  test("PDF generation failure returns a recoverable structured error", async () => {
+    const { owner, trip } = await createSavedTrip({
+      failPdf: true
+    });
+
+    const response = await owner.get(`/api/trips/${trip.id}/export/pdf`);
+
+    expect(response.status).toBe(500);
+    expectSharedErrorResponse(response.body);
+    expect(response.body).toEqual({
+      error: {
+        code: "PDF_EXPORT_FAILED",
+        message: "PDF export could not be generated."
+      }
+    });
+  });
+});

--- a/apps/api/src/routes/export.ts
+++ b/apps/api/src/routes/export.ts
@@ -1,0 +1,21 @@
+import type { Response } from "express";
+
+import type { PdfExportFile } from "../services/pdfExportService.js";
+
+function escapeContentDispositionValue(value: string) {
+  return value.replace(/["\\]/g, "");
+}
+
+export function createPdfContentDisposition(filename: string) {
+  return `attachment; filename="${escapeContentDispositionValue(filename)}"`;
+}
+
+export function sendPdfExportResponse(
+  response: Response,
+  pdf: PdfExportFile
+) {
+  response.setHeader("Content-Type", "application/pdf");
+  response.setHeader("Content-Disposition", createPdfContentDisposition(pdf.filename));
+  response.setHeader("Cache-Control", "no-store");
+  response.status(200).send(pdf.buffer);
+}

--- a/apps/api/src/routes/share.ts
+++ b/apps/api/src/routes/share.ts
@@ -1,6 +1,8 @@
 import { Router, type RequestHandler } from "express";
 
 import { ApiError } from "../errors/ApiError.js";
+import { sendPdfExportResponse } from "./export.js";
+import type { PdfExportService } from "../services/pdfExportService.js";
 import type { ShareService } from "../services/shareService.js";
 
 function asyncHandler(handler: RequestHandler): RequestHandler {
@@ -21,8 +23,23 @@ function getShareToken(value: string | string[] | undefined) {
   });
 }
 
-export function createShareRouter(shareService: ShareService) {
+export function createShareRouter(
+  shareService: ShareService,
+  pdfExportService: PdfExportService
+) {
   const router = Router();
+
+  router.get(
+    "/:shareToken/export/pdf",
+    asyncHandler(async (request, response) => {
+      const sharedTrip = await shareService.getSharedTrip(
+        getShareToken(request.params.shareToken)
+      );
+      const pdf = await pdfExportService.createTripPdf(sharedTrip.trip);
+
+      sendPdfExportResponse(response, pdf);
+    })
+  );
 
   router.get(
     "/:shareToken",

--- a/apps/api/src/routes/trips.ts
+++ b/apps/api/src/routes/trips.ts
@@ -8,6 +8,8 @@ import type {
   CreateTripInput,
   UpdateTripInput
 } from "../repositories/tripRepository.js";
+import { sendPdfExportResponse } from "./export.js";
+import type { PdfExportService } from "../services/pdfExportService.js";
 import type { ShareService } from "../services/shareService.js";
 import type { TripService } from "../services/tripService.js";
 
@@ -144,7 +146,8 @@ function getTripId(value: string | string[] | undefined) {
 
 export function createTripsRouter(
   tripService: TripService,
-  shareService: ShareService
+  shareService: ShareService,
+  pdfExportService: PdfExportService
 ) {
   const router = Router();
 
@@ -195,6 +198,20 @@ export function createTripsRouter(
       );
 
       response.status(result.reused ? 200 : 201).json({ share: result.share });
+    })
+  );
+
+  router.get(
+    "/:tripId/export/pdf",
+    asyncHandler(async (request, response) => {
+      const session = requireAnonymousSession(request);
+      const trip = await tripService.getTrip(
+        session.id,
+        getTripId(request.params.tripId)
+      );
+      const pdf = await pdfExportService.createTripPdf(trip);
+
+      sendPdfExportResponse(response, pdf);
     })
   );
 

--- a/apps/api/src/services/pdfExportService.test.ts
+++ b/apps/api/src/services/pdfExportService.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "vitest";
+
+import { ApiError } from "../errors/ApiError.js";
+import type { TripResponse } from "../repositories/tripRepository.js";
+import { buildItineraryPdfLines } from "../templates/itineraryPdf/template.js";
+
+import { createPdfFilename, PdfExportService } from "./pdfExportService.js";
+
+const trip = {
+  id: "trip-1",
+  title: "Tokyo And Kyoto Spring Highlights",
+  startDate: "2026-04-06",
+  endDate: "2026-04-08",
+  cities: ["Tokyo", "Kyoto"],
+  interests: ["temples", "local food"],
+  pace: "balanced",
+  budget: "moderate",
+  constraints: ["Avoid late-night activities"],
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  days: [
+    {
+      id: "day-1",
+      date: "2026-04-06",
+      city: "Tokyo",
+      summary: "Explore old Tokyo and classic food stops.",
+      weatherSummary: "Mild spring weather.",
+      activities: [
+        {
+          id: "activity-1",
+          title: "Senso-ji and Nakamise-dori",
+          category: "culture",
+          timing: {
+            startTime: "09:30",
+            endTime: "11:30",
+            timeOfDay: "morning"
+          },
+          durationMinutes: 120,
+          location: {
+            name: "Senso-ji",
+            address: "2 Chome-3-1 Asakusa, Taito City, Tokyo",
+            city: "Tokyo",
+            mapUrl:
+              "https://www.google.com/maps/search/?api=1&query=Senso-ji%20Tokyo"
+          },
+          costLevel: "free",
+          notes: "Arrive early for lighter crowds."
+        }
+      ]
+    }
+  ]
+} satisfies TripResponse;
+
+describe("buildItineraryPdfLines", () => {
+  test("includes itinerary details needed for a readable PDF export", () => {
+    const lines = buildItineraryPdfLines(trip, {
+      exportedAt: new Date("2026-01-03T04:05:06.000Z")
+    }).map((line) => line.text);
+
+    expect(lines).toEqual(
+      expect.arrayContaining([
+        "Tokyo And Kyoto Spring Highlights",
+        "2026-04-06 to 2026-04-08",
+        "Cities: Tokyo, Kyoto",
+        "Pace: Balanced | Budget: Moderate",
+        "Interests: temples, local food",
+        "Constraints: Avoid late-night activities",
+        "Day 1: Tokyo (2026-04-06)",
+        "Summary: Explore old Tokyo and classic food stops.",
+        "Weather: Mild spring weather.",
+        "1. Senso-ji and Nakamise-dori",
+        "Timing: 09:30-11:30",
+        "Duration: 120 minutes",
+        "Location: Senso-ji, 2 Chome-3-1 Asakusa, Taito City, Tokyo, Tokyo",
+        "Category: Culture",
+        "Cost: Free",
+        "Notes: Arrive early for lighter crowds.",
+        "Map: https://www.google.com/maps/search/?api=1&query=Senso-ji%20Tokyo",
+        "Read-only export generated 2026-01-03T04:05:06.000Z"
+      ])
+    );
+  });
+});
+
+describe("PdfExportService", () => {
+  test("generates a deterministic PDF file and safe filename", async () => {
+    const service = new PdfExportService({
+      now: () => new Date("2026-01-03T04:05:06.000Z")
+    });
+
+    const pdf = await service.createTripPdf(trip);
+    const text = pdf.buffer.toString("utf8");
+
+    expect(pdf.filename).toBe("tokyo-and-kyoto-spring-highlights.pdf");
+    expect(text.startsWith("%PDF-1.4")).toBe(true);
+    expect(text).toContain("Tokyo And Kyoto Spring Highlights");
+    expect(text).toContain("Senso-ji and Nakamise-dori");
+    expect(text).toContain("Read-only export generated 2026-01-03T04:05:06.000Z");
+    expect(text).not.toContain("anonymousSessionId");
+    expect(text).not.toContain("userId");
+  });
+
+  test("sanitizes empty or unsafe titles for filenames", () => {
+    expect(createPdfFilename({ title: "Kyoto: Spring / Food!" })).toBe(
+      "kyoto-spring-food.pdf"
+    );
+    expect(createPdfFilename({ title: "!!!" })).toBe("itinerary.pdf");
+  });
+
+  test("maps PDF renderer failures to a safe structured API error", async () => {
+    const service = new PdfExportService({
+      renderer: () => {
+        throw new Error("renderer exploded");
+      }
+    });
+
+    await expect(service.createTripPdf(trip)).rejects.toBeInstanceOf(ApiError);
+    await expect(service.createTripPdf(trip)).rejects.toMatchObject({
+      code: "PDF_EXPORT_FAILED",
+      message: "PDF export could not be generated.",
+      statusCode: 500
+    });
+  });
+});

--- a/apps/api/src/services/pdfExportService.ts
+++ b/apps/api/src/services/pdfExportService.ts
@@ -1,0 +1,69 @@
+import { ApiError } from "../errors/ApiError.js";
+import type { TripResponse } from "../repositories/tripRepository.js";
+import {
+  buildItineraryPdfLines,
+  renderItineraryPdf
+} from "../templates/itineraryPdf/template.js";
+
+export type PdfExportFile = {
+  buffer: Buffer;
+  filename: string;
+};
+
+export type PdfExportRenderer = (
+  trip: TripResponse,
+  options: { exportedAt: Date }
+) => Buffer;
+
+export type PdfExportServiceOptions = {
+  now?: () => Date;
+  renderer?: PdfExportRenderer;
+};
+
+function slugifyFilename(value: string) {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+
+  return slug.length > 0 ? slug : "itinerary";
+}
+
+export function createPdfFilename(trip: Pick<TripResponse, "title">) {
+  return `${slugifyFilename(trip.title)}.pdf`;
+}
+
+export class PdfExportService {
+  private readonly now: () => Date;
+  private readonly renderer: PdfExportRenderer;
+
+  constructor(options: PdfExportServiceOptions = {}) {
+    this.now = options.now ?? (() => new Date());
+    this.renderer =
+      options.renderer ??
+      ((trip, { exportedAt }) =>
+        renderItineraryPdf(buildItineraryPdfLines(trip, { exportedAt })));
+  }
+
+  async createTripPdf(trip: TripResponse): Promise<PdfExportFile> {
+    try {
+      const exportedAt = this.now();
+
+      return {
+        buffer: this.renderer(trip, { exportedAt }),
+        filename: createPdfFilename(trip)
+      };
+    } catch {
+      throw new ApiError({
+        statusCode: 500,
+        code: "PDF_EXPORT_FAILED",
+        message: "PDF export could not be generated."
+      });
+    }
+  }
+}
+
+export function createPdfExportService(options: PdfExportServiceOptions = {}) {
+  return new PdfExportService(options);
+}

--- a/apps/api/src/templates/itineraryPdf/template.ts
+++ b/apps/api/src/templates/itineraryPdf/template.ts
@@ -1,0 +1,293 @@
+import type { TripResponse } from "../../repositories/tripRepository.js";
+
+type PdfLine = {
+  text: string;
+  type?: "heading" | "muted" | "normal";
+};
+
+const pageWidth = 612;
+const pageHeight = 792;
+const marginX = 50;
+const startY = 748;
+const bottomY = 58;
+const lineHeight = 16;
+const maxLineLength = 92;
+
+function titleCase(value: string) {
+  return value
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatTiming(activity: TripResponse["days"][number]["activities"][number]) {
+  const { endTime, startTime, timeOfDay } = activity.timing;
+
+  if (startTime && endTime) {
+    return `${startTime}-${endTime}`;
+  }
+
+  if (startTime) {
+    return startTime;
+  }
+
+  return timeOfDay ? titleCase(timeOfDay) : "Flexible";
+}
+
+function locationText(
+  activity: TripResponse["days"][number]["activities"][number]
+) {
+  return [
+    activity.location.name,
+    activity.location.address,
+    activity.location.city
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(", ");
+}
+
+function wrapText(text: string, maxLength = maxLineLength) {
+  const words = text.replace(/\s+/g, " ").trim().split(" ");
+  const lines: string[] = [];
+  let currentLine = "";
+
+  for (const word of words) {
+    if (currentLine.length === 0) {
+      currentLine = word;
+      continue;
+    }
+
+    if (`${currentLine} ${word}`.length > maxLength) {
+      lines.push(currentLine);
+      currentLine = word;
+      continue;
+    }
+
+    currentLine = `${currentLine} ${word}`;
+  }
+
+  if (currentLine.length > 0) {
+    lines.push(currentLine);
+  }
+
+  return lines.length > 0 ? lines : [""];
+}
+
+function addWrappedLine(lines: PdfLine[], text: string, type?: PdfLine["type"]) {
+  for (const [index, line] of wrapText(text).entries()) {
+    lines.push({
+      text: index === 0 ? line : `  ${line}`,
+      ...(type !== undefined ? { type } : {})
+    });
+  }
+}
+
+export function buildItineraryPdfLines(
+  trip: TripResponse,
+  options: { exportedAt?: Date } = {}
+): PdfLine[] {
+  const exportedAt = options.exportedAt ?? new Date();
+  const lines: PdfLine[] = [
+    {
+      text: trip.title,
+      type: "heading"
+    },
+    {
+      text: `${trip.startDate} to ${trip.endDate}`,
+      type: "muted"
+    },
+    {
+      text: `Cities: ${trip.cities.join(", ")}`
+    },
+    {
+      text: `Pace: ${titleCase(trip.pace)} | Budget: ${titleCase(trip.budget)}`
+    }
+  ];
+
+  if (trip.interests.length > 0) {
+    addWrappedLine(lines, `Interests: ${trip.interests.join(", ")}`);
+  }
+
+  if (trip.constraints.length > 0) {
+    addWrappedLine(lines, `Constraints: ${trip.constraints.join(", ")}`);
+  }
+
+  lines.push({ text: "" });
+
+  const sortedDays = [...trip.days].sort((left, right) =>
+    left.date.localeCompare(right.date)
+  );
+
+  sortedDays.forEach((day, dayIndex) => {
+    lines.push({
+      text: `Day ${dayIndex + 1}: ${day.city} (${day.date})`,
+      type: "heading"
+    });
+
+    if (day.summary) {
+      addWrappedLine(lines, `Summary: ${day.summary}`);
+    }
+
+    if (day.weatherSummary) {
+      addWrappedLine(lines, `Weather: ${day.weatherSummary}`);
+    }
+
+    day.activities.forEach((activity, activityIndex) => {
+      addWrappedLine(
+        lines,
+        `${activityIndex + 1}. ${activity.title}`,
+        "heading"
+      );
+      addWrappedLine(lines, `Timing: ${formatTiming(activity)}`);
+      addWrappedLine(lines, `Duration: ${activity.durationMinutes} minutes`);
+      addWrappedLine(lines, `Location: ${locationText(activity)}`);
+      addWrappedLine(lines, `Category: ${titleCase(activity.category)}`);
+      addWrappedLine(lines, `Cost: ${titleCase(activity.costLevel)}`);
+      addWrappedLine(lines, `Notes: ${activity.notes}`);
+
+      if (activity.location.mapUrl) {
+        addWrappedLine(lines, `Map: ${activity.location.mapUrl}`);
+      }
+    });
+
+    lines.push({ text: "" });
+  });
+
+  lines.push({
+    text: `Read-only export generated ${exportedAt.toISOString()}`,
+    type: "muted"
+  });
+
+  return lines;
+}
+
+function toPdfSafeText(text: string) {
+  return Array.from(text)
+    .map((character) => {
+      const code = character.charCodeAt(0);
+
+      return code >= 32 && code <= 126 ? character : "?";
+    })
+    .join("")
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)");
+}
+
+function chunkLines(lines: PdfLine[]) {
+  const pages: PdfLine[][] = [];
+  let currentPage: PdfLine[] = [];
+  let currentY = startY;
+
+  for (const line of lines) {
+    if (currentY < bottomY) {
+      pages.push(currentPage);
+      currentPage = [];
+      currentY = startY;
+    }
+
+    currentPage.push(line);
+    currentY -= lineHeight;
+  }
+
+  if (currentPage.length > 0) {
+    pages.push(currentPage);
+  }
+
+  return pages;
+}
+
+function textCommand(line: PdfLine, y: number) {
+  const fontSize = line.type === "heading" ? 13 : 10;
+  const font = line.type === "heading" ? "F2" : "F1";
+  const escapedText = toPdfSafeText(line.text);
+
+  return `BT /${font} ${fontSize} Tf ${marginX} ${y} Td (${escapedText}) Tj ET`;
+}
+
+function buildContentStream(lines: PdfLine[]) {
+  return lines
+    .map((line, index) => textCommand(line, startY - index * lineHeight))
+    .join("\n");
+}
+
+function pdfObject(id: number, body: string) {
+  return `${id} 0 obj\n${body}\nendobj\n`;
+}
+
+export function renderItineraryPdf(lines: PdfLine[]): Buffer {
+  const pages = chunkLines(lines);
+  const objects: string[] = [];
+  const catalogObjectId = 1;
+  const pagesObjectId = 2;
+  const fontObjectId = 3;
+  const boldFontObjectId = 4;
+  const firstPageObjectId = 5;
+  const firstContentObjectId = firstPageObjectId + pages.length;
+  const pageObjectIds = pages.map((_, index) => firstPageObjectId + index);
+  const contentObjectIds = pages.map(
+    (_, index) => firstContentObjectId + index
+  );
+
+  objects.push(pdfObject(catalogObjectId, "<< /Type /Catalog /Pages 2 0 R >>"));
+  objects.push(
+    pdfObject(
+      pagesObjectId,
+      `<< /Type /Pages /Kids [${pageObjectIds
+        .map((id) => `${id} 0 R`)
+        .join(" ")}] /Count ${pages.length} >>`
+    )
+  );
+  objects.push(
+    pdfObject(fontObjectId, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+  );
+  objects.push(
+    pdfObject(
+      boldFontObjectId,
+      "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"
+    )
+  );
+
+  pages.forEach((_, index) => {
+    objects.push(
+      pdfObject(
+        pageObjectIds[index] ?? firstPageObjectId,
+        `<< /Type /Page /Parent ${pagesObjectId} 0 R /MediaBox [0 0 ${pageWidth} ${pageHeight}] /Resources << /Font << /F1 ${fontObjectId} 0 R /F2 ${boldFontObjectId} 0 R >> >> /Contents ${
+          contentObjectIds[index] ?? firstContentObjectId
+        } 0 R >>`
+      )
+    );
+  });
+
+  pages.forEach((pageLines, index) => {
+    const stream = buildContentStream(pageLines);
+
+    objects.push(
+      pdfObject(
+        contentObjectIds[index] ?? firstContentObjectId,
+        `<< /Length ${Buffer.byteLength(stream, "utf8")} >>\nstream\n${stream}\nendstream`
+      )
+    );
+  });
+
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+
+  for (const object of objects) {
+    offsets.push(Buffer.byteLength(pdf, "utf8"));
+    pdf += object;
+  }
+
+  const xrefOffset = Buffer.byteLength(pdf, "utf8");
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += "0000000000 65535 f \n";
+  pdf += offsets
+    .slice(1)
+    .map((offset) => `${String(offset).padStart(10, "0")} 00000 n \n`)
+    .join("");
+  pdf += `trailer\n<< /Size ${
+    objects.length + 1
+  } /Root ${catalogObjectId} 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return Buffer.from(pdf, "utf8");
+}

--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -8,6 +8,7 @@ const corsHeaders = {
 };
 
 const publicShareToken = "public-share-token-1234567890abcdef";
+const pdfBody = "%PDF-1.4\nMock itinerary PDF";
 
 const generatedItineraryFixture = {
   title: "AI Generated Tokyo And Kyoto Route",
@@ -170,10 +171,12 @@ function createTripRecordFromPayload(payload: TripWritePayload) {
 
 async function routeTripPersistence(
   page: Page,
-  options: { failFirstSave?: boolean } = {}
+  options: { failFirstPrivateExport?: boolean; failFirstSave?: boolean } = {}
 ) {
   let savedTrip: ReturnType<typeof createTripRecordFromPayload> | null = null;
   let shareCreatedForTripId: string | null = null;
+  let privatePdfExportRequests = 0;
+  let sharedPdfExportRequests = 0;
   let saveAttempts = 0;
   let lastSavedPayload: TripWritePayload | null = null;
   let lastUpdatedPayload: TripWritePayload | null = null;
@@ -260,6 +263,46 @@ async function routeTripPersistence(
     });
   });
 
+  await page.route("**/api/trips/generated-trip-1/export/pdf", async (route) => {
+    if (isOptionsRequest(route)) {
+      await fulfillOptions(route);
+      return;
+    }
+
+    expect(route.request().method()).toBe("GET");
+    privatePdfExportRequests += 1;
+
+    if (
+      options.failFirstPrivateExport === true &&
+      privatePdfExportRequests === 1
+    ) {
+      await route.fulfill({
+        contentType: "application/json",
+        headers: corsHeaders,
+        json: {
+          error: {
+            code: "PDF_EXPORT_FAILED",
+            message: "PDF export could not be generated."
+          }
+        },
+        status: 500
+      });
+      return;
+    }
+
+    await route.fulfill({
+      body: pdfBody,
+      contentType: "application/pdf",
+      headers: {
+        ...corsHeaders,
+        "cache-control": "no-store",
+        "content-disposition":
+          'attachment; filename="ai-generated-tokyo-and-kyoto-route.pdf"'
+      },
+      status: 200
+    });
+  });
+
   await page.route("**/api/trips/generated-trip-1/share", async (route) => {
     if (isOptionsRequest(route)) {
       await fulfillOptions(route);
@@ -284,6 +327,31 @@ async function routeTripPersistence(
       status: 201
     });
   });
+
+  await page.route(
+    `**/api/share/${publicShareToken}/export/pdf`,
+    async (route) => {
+      if (isOptionsRequest(route)) {
+        await fulfillOptions(route);
+        return;
+      }
+
+      expect(route.request().method()).toBe("GET");
+      sharedPdfExportRequests += 1;
+
+      await route.fulfill({
+        body: pdfBody,
+        contentType: "application/pdf",
+        headers: {
+          ...corsHeaders,
+          "cache-control": "no-store",
+          "content-disposition":
+            'attachment; filename="ai-generated-tokyo-and-kyoto-route.pdf"'
+        },
+        status: 200
+      });
+    }
+  );
 
   await page.route("**/api/share/*", async (route) => {
     if (isOptionsRequest(route)) {
@@ -332,13 +400,16 @@ async function routeTripPersistence(
   return {
     getLastSavedPayload: () => lastSavedPayload,
     getLastUpdatedPayload: () => lastUpdatedPayload,
+    getPrivatePdfExportRequests: () => privatePdfExportRequests,
     getShareCreatedForTripId: () => shareCreatedForTripId,
+    getSharedPdfExportRequests: () => sharedPdfExportRequests,
     getSaveAttempts: () => saveAttempts
   };
 }
 
 test("traveler can plan and edit a mock itinerary", async ({ page }) => {
   await page.goto("/");
+  await page.getByRole("button", { exact: true, name: "Mock" }).click();
 
   await expect(
     page.getByRole("heading", { name: "No itinerary yet" })
@@ -486,6 +557,7 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
 }) => {
   await routeGeneratedItinerary(page);
   const persistence = await routeTripPersistence(page, {
+    failFirstPrivateExport: true,
     failFirstSave: true
   });
 
@@ -624,6 +696,18 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
     patchedEditedTitle
   ]);
 
+  await expect(
+    page.getByRole("button", { name: "Export PDF" })
+  ).toBeEnabled();
+  await page.getByRole("button", { name: "Export PDF" }).click();
+  await expect(
+    page.getByRole("alert").getByText("PDF export could not be generated.")
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Export PDF" }).click();
+  await expect
+    .poll(() => persistence.getPrivatePdfExportRequests())
+    .toBe(2);
+
   await page.getByRole("button", { name: "Create public link" }).click();
   expect(persistence.getShareCreatedForTripId()).toBe("generated-trip-1");
 
@@ -652,6 +736,13 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
     "href",
     "https://www.google.com/maps/search/?api=1&query=Generated%20Asakusa%20lunch%20Asakusa%20Tokyo"
   );
+  await expect(
+    page.getByRole("button", { name: "Export shared PDF" })
+  ).toBeEnabled();
+  await page.getByRole("button", { name: "Export shared PDF" }).click();
+  await expect
+    .poll(() => persistence.getSharedPdfExportRequests())
+    .toBe(1);
   await expect(page.getByRole("button", { name: /Edit/ })).toHaveCount(0);
   await expect(
     page.getByRole("button", { name: "Save itinerary" })
@@ -670,4 +761,7 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
   await expect(
     page.getByRole("heading", { name: "Share link not available" })
   ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Export shared PDF" })
+  ).toHaveCount(0);
 });

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -360,6 +360,7 @@ select {
   letter-spacing: 0;
 }
 
+.export-controls,
 .share-controls {
   display: grid;
   gap: 14px;
@@ -367,6 +368,7 @@ select {
   padding-top: 18px;
 }
 
+.export-controls h3,
 .share-controls h3 {
   margin: 8px 0 0;
   color: #172026;
@@ -375,6 +377,7 @@ select {
   letter-spacing: 0;
 }
 
+.export-help,
 .share-help {
   margin: 0;
   color: #52616d;
@@ -382,6 +385,7 @@ select {
   line-height: 1.45;
 }
 
+.export-controls > button,
 .share-controls > button,
 .share-url-field button {
   width: 100%;
@@ -394,9 +398,22 @@ select {
   padding: 11px 14px;
 }
 
+.export-controls > button:disabled,
 .share-controls > button:disabled {
   cursor: not-allowed;
   opacity: 0.72;
+}
+
+.export-error {
+  margin: 0;
+  border: 1px solid #efb6ae;
+  border-radius: 6px;
+  background: #fff1ef;
+  color: #9d3027;
+  font-size: 0.85rem;
+  font-weight: 800;
+  line-height: 1.4;
+  padding: 9px 10px;
 }
 
 .share-url-field {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -15,6 +15,8 @@ describe("App", () => {
     expect(html).toContain("Save and reopen");
     expect(html).toContain("Revert local edits");
     expect(html).toContain("Refresh saved trips");
+    expect(html).toContain("PDF itinerary");
+    expect(html).toContain("Save this itinerary before exporting a PDF.");
     expect(html).toContain("Read-only share link");
     expect(html).toContain("Save this itinerary before creating a public share link.");
     expect(html).toContain("No itinerary yet");

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,12 @@
 import "./App.css";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import type { TripRequest } from "../../../packages/shared/src/schemas/tripRequest.js";
+import {
+  downloadPdfFile,
+  ExportControls
+} from "./features/export/ExportControls.js";
 import { ItineraryView } from "./features/itinerary/ItineraryView.js";
 import {
   cloneItinerary,
@@ -13,9 +17,11 @@ import { ShareControls } from "./features/sharing/ShareControls.js";
 import { TripIntakeForm } from "./features/trip-intake/index.js";
 import {
   getDefaultTripDataMode,
+  getTripErrorMessage,
   useTrips,
   type TripDataMode
 } from "./features/trips/useTrips.js";
+import { createTripApiClient } from "./lib/api/client.js";
 import { mockItinerary } from "./mocks/index.js";
 import { SharedTripPage } from "./routes/SharedTripPage.js";
 
@@ -59,6 +65,11 @@ export function App() {
   );
   const [localError, setLocalError] = useState<string | null>(null);
   const [isMockSubmitting, setIsMockSubmitting] = useState(false);
+  const [isExportingPdf, setIsExportingPdf] = useState(false);
+  const [exportErrorMessage, setExportErrorMessage] = useState<string | null>(
+    null
+  );
+  const tripApiClient = useMemo(() => createTripApiClient(), []);
   const generatedItinerary = useGeneratedItinerary();
   const itineraryEditor = useItineraryEditor(null);
   const itinerary = itineraryEditor.itinerary;
@@ -87,6 +98,16 @@ export function App() {
         : itineraryEditor.isDirty
           ? "Save local edits before sharing the itinerary."
           : undefined;
+  const exportDisabledReason =
+    dataMode === "mock"
+      ? "Switch to API mode and save the trip before exporting."
+      : apiBusy
+        ? "Wait for the current trip operation to finish before exporting."
+        : !trips.selectedTripId
+          ? "Save this itinerary before exporting a PDF."
+          : itineraryEditor.isDirty
+            ? "Save local edits before exporting the itinerary."
+            : undefined;
 
   if (shareToken !== null) {
     return <SharedTripPage shareToken={shareToken} />;
@@ -134,6 +155,7 @@ export function App() {
   function handleMockSubmit(request: TripRequest) {
     setActiveRequest(request);
     setLocalError(null);
+    setExportErrorMessage(null);
     trips.clearError();
     generatedItinerary.clearError();
     setIsMockSubmitting(true);
@@ -154,6 +176,7 @@ export function App() {
 
     setActiveRequest(request);
     setLocalError(null);
+    setExportErrorMessage(null);
     trips.clearError();
     generatedItinerary.clearError();
     resetToItinerary(null);
@@ -179,6 +202,7 @@ export function App() {
     }
 
     setLocalError(null);
+    setExportErrorMessage(null);
     generatedItinerary.clearError();
 
     const result = await trips.saveTrip(
@@ -196,6 +220,7 @@ export function App() {
   function handleRevertItinerary() {
     itineraryEditor.revertItinerary();
     setLocalError(null);
+    setExportErrorMessage(null);
     trips.clearError();
     generatedItinerary.clearError();
   }
@@ -207,6 +232,7 @@ export function App() {
     }
 
     setLocalError(null);
+    setExportErrorMessage(null);
     generatedItinerary.clearError();
 
     const result = await trips.reopenTrip(trips.selectedTripId);
@@ -219,8 +245,29 @@ export function App() {
 
   async function handleLoadSavedTrips() {
     setLocalError(null);
+    setExportErrorMessage(null);
     generatedItinerary.clearError();
     await trips.loadSavedTrips();
+  }
+
+  async function handleExportPdf() {
+    if (!trips.selectedTripId) {
+      setExportErrorMessage("Save this itinerary before exporting a PDF.");
+      return;
+    }
+
+    setExportErrorMessage(null);
+    setIsExportingPdf(true);
+
+    try {
+      const pdf = await tripApiClient.exportTripPdf(trips.selectedTripId);
+
+      downloadPdfFile(pdf);
+    } catch (error) {
+      setExportErrorMessage(getTripErrorMessage(error));
+    } finally {
+      setIsExportingPdf(false);
+    }
   }
 
   async function handleCreateShareLink() {
@@ -230,6 +277,7 @@ export function App() {
     }
 
     setLocalError(null);
+    setExportErrorMessage(null);
     generatedItinerary.clearError();
     await trips.createShareLink(trips.selectedTripId);
   }
@@ -237,6 +285,7 @@ export function App() {
   function handleModeChange(nextMode: TripDataMode) {
     setDataMode(nextMode);
     setLocalError(null);
+    setExportErrorMessage(null);
     trips.clearError();
     generatedItinerary.clearError();
   }
@@ -424,6 +473,13 @@ export function App() {
               >
                 Reopen trip
               </button>
+
+              <ExportControls
+                disabledReason={exportDisabledReason}
+                errorMessage={exportErrorMessage}
+                isExporting={isExportingPdf}
+                onExportPdf={handleExportPdf}
+              />
 
               <ShareControls
                 disabledReason={shareDisabledReason}

--- a/apps/web/src/features/export/ExportControls.test.tsx
+++ b/apps/web/src/features/export/ExportControls.test.tsx
@@ -1,0 +1,44 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { ExportControls } from "./ExportControls.js";
+
+describe("ExportControls", () => {
+  test("is explanatory and disabled before a saved trip exists", () => {
+    const html = renderToString(
+      <ExportControls
+        disabledReason="Save this itinerary before exporting a PDF."
+        onExportPdf={() => undefined}
+      />
+    );
+
+    expect(html).toContain("PDF itinerary");
+    expect(html).toContain("Save this itinerary before exporting a PDF.");
+    expect(html).toContain("disabled");
+  });
+
+  test("renders a recoverable export error", () => {
+    const html = renderToString(
+      <ExportControls
+        errorMessage="PDF export could not be generated."
+        onExportPdf={() => undefined}
+      />
+    );
+
+    expect(html).toContain("PDF export could not be generated.");
+    expect(html).toContain('role="alert"');
+    expect(html).toContain("Export PDF");
+  });
+
+  test("supports a shared-page export label", () => {
+    const html = renderToString(
+      <ExportControls
+        label="Export shared PDF"
+        onExportPdf={() => undefined}
+      />
+    );
+
+    expect(html).toContain("Export shared PDF");
+    expect(html).toContain("Download a read-only PDF copy of this itinerary.");
+  });
+});

--- a/apps/web/src/features/export/ExportControls.tsx
+++ b/apps/web/src/features/export/ExportControls.tsx
@@ -1,0 +1,58 @@
+import type { PdfExportFile } from "../../lib/api/types.js";
+
+export type ExportControlsProps = {
+  disabledReason?: string | undefined;
+  errorMessage?: string | null | undefined;
+  isExporting?: boolean | undefined;
+  label?: string | undefined;
+  onExportPdf: () => void;
+};
+
+export function downloadPdfFile(file: PdfExportFile) {
+  if (typeof document === "undefined" || typeof URL === "undefined") {
+    return;
+  }
+
+  const objectUrl = URL.createObjectURL(file.blob);
+  const link = document.createElement("a");
+
+  link.href = objectUrl;
+  link.download = file.filename;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(objectUrl);
+}
+
+export function ExportControls({
+  disabledReason,
+  errorMessage,
+  isExporting = false,
+  label = "Export PDF",
+  onExportPdf
+}: ExportControlsProps) {
+  const isDisabled = isExporting || Boolean(disabledReason);
+
+  return (
+    <section aria-labelledby="export-controls-title" className="export-controls">
+      <header>
+        <p className="section-kicker">Export</p>
+        <h3 id="export-controls-title">PDF itinerary</h3>
+      </header>
+
+      <p className="export-help">
+        {disabledReason ?? "Download a read-only PDF copy of this itinerary."}
+      </p>
+
+      {errorMessage ? (
+        <p className="export-error" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <button disabled={isDisabled} onClick={onExportPdf} type="button">
+        {isExporting ? "Preparing PDF" : label}
+      </button>
+    </section>
+  );
+}

--- a/apps/web/src/features/trips/useTrips.test.ts
+++ b/apps/web/src/features/trips/useTrips.test.ts
@@ -50,6 +50,16 @@ function createMockClient(trip = createTripRecord()): TripApiClient {
       updatedAt: "2026-01-01T00:00:00.000Z"
     })),
     createTrip: vi.fn(async () => trip),
+    exportSharedTripPdf: vi.fn(async () => ({
+      blob: new Blob(["%PDF-1.4"]),
+      contentType: "application/pdf",
+      filename: "shared-trip.pdf"
+    })),
+    exportTripPdf: vi.fn(async () => ({
+      blob: new Blob(["%PDF-1.4"]),
+      contentType: "application/pdf",
+      filename: "trip.pdf"
+    })),
     generateItinerary: vi.fn(async () => ({
       itinerary: mockItinerary,
       metadata: {

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -39,6 +39,16 @@ function jsonResponse(body: unknown, init: ResponseInit = {}) {
   });
 }
 
+function pdfResponse(init: ResponseInit = {}) {
+  return new Response(new Blob(["%PDF-1.4\nTest PDF"]), {
+    headers: {
+      "Content-Disposition": 'attachment; filename="test-itinerary.pdf"',
+      "Content-Type": "application/pdf"
+    },
+    ...init
+  });
+}
+
 describe("createTripApiClient", () => {
   test("creates trips with included anonymous session credentials", async () => {
     const trip = createTripRecord();
@@ -213,6 +223,45 @@ describe("createTripApiClient", () => {
       cities: mockTripRequest.cities,
       interests: mockTripRequest.interests
     });
+  });
+
+  test("exports private and shared trip PDFs through the API", async () => {
+    const responses = [pdfResponse(), pdfResponse()];
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        void _input;
+        void _init;
+        return responses.shift() ?? pdfResponse();
+      }
+    );
+    const client = createTripApiClient({
+      baseUrl: "http://localhost:3001",
+      fetch: fetchMock
+    });
+
+    await expect(client.exportTripPdf("trip-1")).resolves.toMatchObject({
+      contentType: "application/pdf",
+      filename: "test-itinerary.pdf"
+    });
+    await expect(
+      client.exportSharedTripPdf("public-share-token-1234567890abcdef")
+    ).resolves.toMatchObject({
+      contentType: "application/pdf",
+      filename: "test-itinerary.pdf"
+    });
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "http://localhost:3001/api/trips/trip-1/export/pdf",
+      "http://localhost:3001/api/share/public-share-token-1234567890abcdef/export/pdf"
+    ]);
+    expect(
+      fetchMock.mock.calls.every(([, init]) => init?.credentials === "include")
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.every(([, init]) =>
+        new Headers(init?.headers).get("Accept")?.includes("application/pdf")
+      )
+    ).toBe(true);
   });
 
   test("parses structured API errors for UI display", async () => {

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -5,6 +5,7 @@ import {
 import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
 import type {
   GenerateItineraryResponse,
+  PdfExportFile,
   ShareLinkRecord,
   SharedTripRecord,
   TripRecord,
@@ -43,6 +44,8 @@ export class TripApiClientError extends Error {
 export type TripApiClient = {
   createShareLink: (tripId: string) => Promise<ShareLinkRecord>;
   createTrip: (payload: TripWritePayload) => Promise<TripRecord>;
+  exportSharedTripPdf: (shareToken: string) => Promise<PdfExportFile>;
+  exportTripPdf: (tripId: string) => Promise<PdfExportFile>;
   generateItinerary: (
     payload: TripRequest
   ) => Promise<GenerateItineraryResponse>;
@@ -75,6 +78,12 @@ async function parseJsonResponse(response: Response) {
   } catch {
     return null;
   }
+}
+
+function getFilenameFromContentDisposition(value: string | null) {
+  const match = value?.match(/filename="([^"]+)"/i);
+
+  return match?.[1] ?? "itinerary.pdf";
 }
 
 function createApiError(response: Response, body: unknown) {
@@ -141,6 +150,38 @@ export function createTripApiClient(
     }
   }
 
+  async function requestBlob(path: string): Promise<PdfExportFile> {
+    try {
+      const response = await fetchImpl(joinUrl(baseUrl, path), {
+        credentials: "include",
+        headers: {
+          Accept: "application/pdf"
+        }
+      });
+
+      if (!response.ok) {
+        throw createApiError(response, await parseJsonResponse(response));
+      }
+
+      return {
+        blob: await response.blob(),
+        contentType: response.headers.get("Content-Type") ?? "application/pdf",
+        filename: getFilenameFromContentDisposition(
+          response.headers.get("Content-Disposition")
+        )
+      };
+    } catch (error) {
+      if (error instanceof TripApiClientError) {
+        throw error;
+      }
+
+      throw new TripApiClientError({
+        code: "TRIP_API_UNAVAILABLE",
+        message: `Could not reach the trip API at ${baseUrl}.`
+      });
+    }
+  }
+
   return {
     async createShareLink(tripId) {
       const response = await requestJson<{ share: ShareLinkRecord }>(
@@ -160,6 +201,16 @@ export function createTripApiClient(
       });
 
       return response.trip;
+    },
+
+    async exportSharedTripPdf(shareToken) {
+      return requestBlob(
+        `/api/share/${encodeURIComponent(shareToken)}/export/pdf`
+      );
+    },
+
+    async exportTripPdf(tripId) {
+      return requestBlob(`/api/trips/${encodeURIComponent(tripId)}/export/pdf`);
     },
 
     async generateItinerary(payload) {

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -52,6 +52,12 @@ export type SharedTripRecord = {
   trip: TripRecord;
 };
 
+export type PdfExportFile = {
+  blob: Blob;
+  contentType: string;
+  filename: string;
+};
+
 export function tripRecordToItinerary(trip: TripRecord): Itinerary {
   return {
     title: trip.title,

--- a/apps/web/src/routes/SharedTripPage.test.tsx
+++ b/apps/web/src/routes/SharedTripPage.test.tsx
@@ -50,6 +50,7 @@ describe("SharedTripPage", () => {
     expect(html).toContain("Morning walk through Ueno Park");
     expect(html).toContain("Open in Google Maps");
     expect(html).toContain("Read-only");
+    expect(html).toContain("Export shared PDF");
     expect(html).not.toContain("Edit");
     expect(html).not.toContain("Delete");
     expect(html).not.toContain("Add activity");
@@ -70,6 +71,7 @@ describe("SharedTripPage", () => {
 
     expect(html).toContain("Share link not available");
     expect(html).toContain("Share link was not found.");
+    expect(html).not.toContain("Export shared PDF");
     expect(html).not.toContain("Save itinerary");
     expect(html).not.toContain("Generate AI itinerary");
   });

--- a/apps/web/src/routes/SharedTripPage.tsx
+++ b/apps/web/src/routes/SharedTripPage.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 
+import {
+  downloadPdfFile,
+  ExportControls
+} from "../features/export/ExportControls.js";
 import { ItineraryView } from "../features/itinerary/ItineraryView.js";
 import {
   createTripApiClient,
@@ -45,6 +49,10 @@ export function SharedTripPage({
     initialSharedTrip ?? null
   );
   const [isLoading, setIsLoading] = useState(initialSharedTrip === undefined);
+  const [isExportingPdf, setIsExportingPdf] = useState(false);
+  const [exportErrorMessage, setExportErrorMessage] = useState<string | null>(
+    null
+  );
   const itinerary = sharedTrip ? tripRecordToItinerary(sharedTrip.trip) : null;
 
   useEffect(() => {
@@ -65,6 +73,7 @@ export function SharedTripPage({
         }
 
         setSharedTrip(nextSharedTrip);
+        setExportErrorMessage(null);
         setIsLoading(false);
       })
       .catch((error: unknown) => {
@@ -73,6 +82,7 @@ export function SharedTripPage({
         }
 
         setErrorMessage(getSharedTripErrorMessage(error));
+        setExportErrorMessage(null);
         setSharedTrip(null);
         setIsLoading(false);
       });
@@ -81,6 +91,21 @@ export function SharedTripPage({
       isActive = false;
     };
   }, [apiClient, initialSharedTrip, shareToken]);
+
+  async function handleExportSharedPdf() {
+    setExportErrorMessage(null);
+    setIsExportingPdf(true);
+
+    try {
+      const pdf = await apiClient.exportSharedTripPdf(shareToken);
+
+      downloadPdfFile(pdf);
+    } catch (error) {
+      setExportErrorMessage(getSharedTripErrorMessage(error));
+    } finally {
+      setIsExportingPdf(false);
+    }
+  }
 
   return (
     <div className="app-shell shared-app-shell">
@@ -124,7 +149,20 @@ export function SharedTripPage({
             <p>{errorMessage}</p>
           </section>
         ) : (
-          <ItineraryView itinerary={itinerary} isLoading={isLoading} />
+          <>
+            <ExportControls
+              disabledReason={
+                sharedTrip === null
+                  ? "Shared itinerary must load before exporting."
+                  : undefined
+              }
+              errorMessage={exportErrorMessage}
+              isExporting={isExportingPdf}
+              label="Export shared PDF"
+              onExportPdf={handleExportSharedPdf}
+            />
+            <ItineraryView itinerary={itinerary} isLoading={isLoading} />
+          </>
         )}
       </main>
     </div>


### PR DESCRIPTION
## Ticket scope
Implement T-030 / Ticket 30: PDF export for saved private trips and read-only shared trips. Ticket 31 and later work was not started.

## Changes made
- Added API-side PDF export service, deterministic itinerary PDF template rendering, response headers, and export routes.
- Added private owner-scoped route `GET /api/trips/:tripId/export/pdf`.
- Added shared read-only route `GET /api/share/:shareToken/export/pdf`.
- Added web API client PDF blob methods and reusable export controls.
- Added private saved-trip export UI and shared-page export UI.
- Extended E2E coverage for private PDF export, shared PDF export, export failure recovery, and shared-page read-only regression.

## PDF generation approach
PDFs are generated on the API server with a small deterministic PDF renderer using built-in Node buffers. No browser-side PDF generation and no new PDF dependency were added, so access control remains on the backend and tests can assert stable template/route behavior.

## Private export API behavior
`GET /api/trips/:tripId/export/pdf` requires the current anonymous session, loads the trip through the existing owner-scoped trip service, and returns a PDF only for that owner. Other sessions continue to receive the existing safe not-found behavior.

## Shared export API behavior
`GET /api/share/:shareToken/export/pdf` uses the existing share-token lookup/permission checks from Ticket 29 and returns a read-only PDF for valid share links. Invalid, expired, or non-read-only tokens are rejected with the existing safe structured share error.

## PDF content structure
The PDF includes trip title, date range, cities, pace, budget, interests, constraints, chronological day sections, day city/date/summary/weather, ordered activities, timing, duration, location, category, cost level, notes, map URL text, and a read-only export timestamp footer.

## Web export control behavior
Saved private trips show an `Export PDF` control after save/reopen and explain why export is disabled before save, during API work, in mock mode, or while local edits are dirty. Shared pages show `Export shared PDF` without exposing edit/save/revert/generation controls.

## Failure/error behavior
PDF generation failures map to `PDF_EXPORT_FAILED` structured API errors. Web export failures surface a recoverable alert message and keep the user on the current itinerary state.

## Security/access-control behavior
Private export remains owner-scoped through the existing session middleware and trip service. Shared export remains read-only through existing share permission checks. PDF output does not include session IDs, user IDs, API keys, stack traces, or raw provider metadata.

## Tests added/updated
- API route tests for private owner export, cross-owner rejection, valid shared export, invalid/expired/non-read-only shared rejection, headers, and safe PDF failure.
- API service/template tests for PDF content, filename sanitization, metadata exclusion, and failure mapping.
- Web control/client tests for disabled state, shared label, recoverable error rendering, PDF endpoint calls, headers, and filenames.
- E2E tests for saved-trip export request, export failure recovery, shared PDF export, and shared read-only regression.

## Checks run
- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit`
- `pnpm --filter @japan-travel-planner/web exec vite build`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `pnpm test:e2e`
- `git diff --check`

## Manual checks run
- Started API with `pnpm dev:api`.
- Confirmed `GET /api/health` returned HTTP 200 with JSON status `ok`.
- Confirmed invalid shared PDF export returned a structured safe `SHARE_LINK_NOT_FOUND` 404.
- Confirmed invalid `API_PORT=invalid` fails clearly with the expected config validation message.
- Attempted local in-app browser check, but the browser crashed while opening the local app even though curl confirmed API/web were reachable. Mocked Playwright E2E covers the web export/download path.

## Real DB-backed export tested
Not manually tested. There is no local `.env`, so the API fell back to the default Postgres URL and trip creation returned 500 in this environment. Real DB-backed export requires a working `DATABASE_URL`. API route/service tests and mocked E2E cover the behavior without a live database.

## Provider calls
No real OpenAI, OpenWeather, Google Maps, hotel, transit, LINE, or other provider calls were made.

## Known risks
- The in-repo PDF renderer intentionally keeps output simple and readable. It is suitable for MVP itinerary text export, but not a full layout engine.
- Unicode characters outside basic printable ASCII are normalized to `?` in PDF text to keep the minimal renderer deterministic.
- Real DB-backed export still needs verification in an environment with a working Postgres database.

## Ticket boundary confirmation
Ticket 31 and later were not started. No hotel suggestions, transit route hints, LINE sharing, mobile app work, deployment, observability, AI generation behavior changes, provider cache changes, or Prisma schema/migration changes were added.
