### PR TITLE
Add hotel suggestion provider abstraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ AI_GENERATION_RATE_LIMIT_MAX=5
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/japan_travel_planner_ai?schema=public
 GOOGLE_MAPS_API_KEY=
 WEATHER_API_KEY=
+# Backend-only Rakuten Travel SimpleHotelSearch credentials.
+# RAKUTEN_API_KEY is a legacy alias for RAKUTEN_APP_ID; current Rakuten docs
+# also require RAKUTEN_ACCESS_KEY.
+RAKUTEN_APP_ID=
+RAKUTEN_ACCESS_KEY=
 RAKUTEN_API_KEY=
 # Signs the HTTP-only anonymous session cookie used for private trip editing.
 JWT_SECRET=replace-with-a-long-random-session-secret

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,8 @@ import { loadApiEnv, type ApiEnvConfig } from "./config/env.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { createRateLimitMiddleware } from "./middleware/rateLimit.js";
 import { createSessionMiddleware } from "./middleware/session.js";
+import type { HotelProvider } from "./providers/hotels/hotelProvider.js";
+import { createRakutenHotelProvider } from "./providers/hotels/rakutenHotelProvider.js";
 import {
   createGoogleMapsProvider,
   type MapsProvider
@@ -35,7 +37,10 @@ import {
   createPdfExportService,
   type PdfExportService
 } from "./services/pdfExportService.js";
-import { createShareService, type ShareService } from "./services/shareService.js";
+import {
+  createShareService,
+  type ShareService
+} from "./services/shareService.js";
 import { createTripService, type TripService } from "./services/tripService.js";
 
 export type CreateAppOptions = {
@@ -43,6 +48,7 @@ export type CreateAppOptions = {
   aiGenerationRateLimitMiddleware?: RequestHandler;
   aiItineraryService?: AiItineraryService;
   aiUsageLogger?: AiUsageLogger;
+  hotelProvider?: HotelProvider;
   mapsProvider?: MapsProvider;
   pdfExportService?: PdfExportService;
   providerResultCache?: ProviderResultCache;
@@ -83,9 +89,14 @@ export function createApp(options: CreateAppOptions = {}) {
     });
   const tripService = options.tripService ?? createTripService();
   const shareService = options.shareService ?? createShareService();
-  const pdfExportService =
-    options.pdfExportService ?? createPdfExportService();
+  const pdfExportService = options.pdfExportService ?? createPdfExportService();
   const mapsProvider = options.mapsProvider ?? createGoogleMapsProvider();
+  const hotelProvider =
+    options.hotelProvider ??
+    createRakutenHotelProvider({
+      accessKey: env.rakutenAccessKey,
+      appId: env.rakutenAppId
+    });
   const providerResultCache =
     options.providerResultCache ?? createProviderResultCache();
   const weatherProvider =
@@ -106,6 +117,7 @@ export function createApp(options: CreateAppOptions = {}) {
   app.use(
     "/api/enrichment",
     createEnrichmentRouter({
+      hotelProvider,
       mapsProvider,
       providerResultCache,
       weatherProvider

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -15,6 +15,8 @@ describe("loadApiEnv", () => {
         API_PORT: "4001",
         OPENAI_API_KEY: "sk-test-api-key",
         OPENAI_MODEL: "gpt-test-model",
+        RAKUTEN_ACCESS_KEY: "rakuten-access-key",
+        RAKUTEN_APP_ID: "rakuten-app-id",
         WEATHER_API_KEY: "weather-test-key",
         WEB_ORIGIN: "https://planner.example.com",
         JWT_SECRET: "test-session-secret-value"
@@ -25,6 +27,8 @@ describe("loadApiEnv", () => {
       apiPort: 4001,
       openAiApiKey: "sk-test-api-key",
       openAiModel: "gpt-test-model",
+      rakutenAccessKey: "rakuten-access-key",
+      rakutenAppId: "rakuten-app-id",
       weatherApiKey: "weather-test-key",
       webOrigin: "https://planner.example.com",
       jwtSecret: "test-session-secret-value"
@@ -34,7 +38,21 @@ describe("loadApiEnv", () => {
   test("does not require provider keys during API env loading", () => {
     expect(loadApiEnv({}).openAiApiKey).toBeUndefined();
     expect(loadApiEnv({}).openAiModel).toBe(defaultApiEnv.openAiModel);
+    expect(loadApiEnv({}).rakutenAccessKey).toBeUndefined();
+    expect(loadApiEnv({}).rakutenAppId).toBeUndefined();
     expect(loadApiEnv({}).weatherApiKey).toBeUndefined();
+  });
+
+  test("supports legacy RAKUTEN_API_KEY as the Rakuten app ID alias", () => {
+    expect(
+      loadApiEnv({
+        RAKUTEN_ACCESS_KEY: "rakuten-access-key",
+        RAKUTEN_API_KEY: "legacy-rakuten-app-id"
+      })
+    ).toMatchObject({
+      rakutenAccessKey: "rakuten-access-key",
+      rakutenAppId: "legacy-rakuten-app-id"
+    });
   });
 
   test("fails clearly for invalid API_PORT", () => {

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -4,6 +4,8 @@ export type ApiEnvConfig = {
   apiPort: number;
   openAiApiKey: string | undefined;
   openAiModel: string;
+  rakutenAccessKey: string | undefined;
+  rakutenAppId: string | undefined;
   weatherApiKey: string | undefined;
   webOrigin: string;
   jwtSecret: string;
@@ -18,6 +20,8 @@ export const defaultApiEnv = {
   apiPort: 3001,
   openAiApiKey: undefined,
   openAiModel: defaultOpenAiModel,
+  rakutenAccessKey: undefined,
+  rakutenAppId: undefined,
   weatherApiKey: undefined,
   webOrigin: "http://localhost:5173",
   jwtSecret: localDevelopmentJwtSecret
@@ -29,6 +33,9 @@ type ApiEnvSource = {
   API_PORT?: string | undefined;
   OPENAI_API_KEY?: string | undefined;
   OPENAI_MODEL?: string | undefined;
+  RAKUTEN_ACCESS_KEY?: string | undefined;
+  RAKUTEN_API_KEY?: string | undefined;
+  RAKUTEN_APP_ID?: string | undefined;
   WEATHER_API_KEY?: string | undefined;
   WEB_ORIGIN?: string | undefined;
   JWT_SECRET?: string | undefined;
@@ -97,10 +104,14 @@ function parseOpenAiApiKey(value: string | undefined) {
   return rawApiKey && rawApiKey.length > 0 ? rawApiKey : undefined;
 }
 
-function parseWeatherApiKey(value: string | undefined) {
-  const rawApiKey = value?.trim();
+function parseOptionalSecret(value: string | undefined) {
+  const rawValue = value?.trim();
 
-  return rawApiKey && rawApiKey.length > 0 ? rawApiKey : undefined;
+  return rawValue && rawValue.length > 0 ? rawValue : undefined;
+}
+
+function parseWeatherApiKey(value: string | undefined) {
+  return parseOptionalSecret(value);
 }
 
 function parseOpenAiModel(value: string | undefined) {
@@ -149,6 +160,10 @@ export function loadApiEnv(env: ApiEnvSource = process.env): ApiEnvConfig {
     apiPort: parseApiPort(env.API_PORT),
     openAiApiKey: parseOpenAiApiKey(env.OPENAI_API_KEY),
     openAiModel: parseOpenAiModel(env.OPENAI_MODEL),
+    rakutenAccessKey: parseOptionalSecret(env.RAKUTEN_ACCESS_KEY),
+    rakutenAppId: parseOptionalSecret(
+      env.RAKUTEN_APP_ID ?? env.RAKUTEN_API_KEY
+    ),
     weatherApiKey: parseWeatherApiKey(env.WEATHER_API_KEY),
     webOrigin: parseWebOrigin(env.WEB_ORIGIN),
     jwtSecret: parseJwtSecret(env.JWT_SECRET, env.NODE_ENV)

--- a/apps/api/src/providers/hotels/hotelProvider.test.ts
+++ b/apps/api/src/providers/hotels/hotelProvider.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  type HotelProvider,
+  HotelProviderConfigurationError,
+  HotelProviderError
+} from "./hotelProvider.js";
+
+describe("HotelProvider contract", () => {
+  test("uses normalized hotel suggestions independent of provider response shape", async () => {
+    const provider = {
+      name: "contract-test-provider",
+      searchHotels: vi.fn<HotelProvider["searchHotels"]>(async () => [
+        {
+          access: "3 minutes from Tokyo Station",
+          address: "1 Marunouchi, Chiyoda City, Tokyo",
+          amenities: ["Wi-Fi"],
+          bookingUrl: "https://example.com/hotel",
+          city: "Tokyo",
+          currency: "JPY",
+          description: "Central hotel for rail-friendly days.",
+          id: "contract-test-provider:hotel-1",
+          imageUrl: "https://example.com/hotel.jpg",
+          latitude: 35.6812,
+          longitude: 139.7671,
+          mapUrl: "https://www.google.com/maps/search/?api=1&query=Tokyo",
+          name: "Tokyo Station Hotel",
+          priceFrom: 18000,
+          provider: "contract-test-provider",
+          rating: 4.6,
+          reviewCount: 1200,
+          sourceUpdatedAt: null,
+          tags: ["Near Tokyo Station"],
+          thumbnailUrl: "https://example.com/hotel-thumb.jpg"
+        }
+      ])
+    } satisfies HotelProvider;
+
+    await expect(
+      provider.searchHotels({
+        city: "Tokyo",
+        endDate: "2026-04-08",
+        startDate: "2026-04-06"
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "contract-test-provider:hotel-1",
+        name: "Tokyo Station Hotel",
+        provider: "contract-test-provider"
+      })
+    ]);
+  });
+
+  test("provides explicit error types for configuration and provider failures", () => {
+    expect(new HotelProviderConfigurationError()).toMatchObject({
+      name: "HotelProviderConfigurationError",
+      message: "Hotel provider is not configured."
+    });
+    expect(new HotelProviderError()).toMatchObject({
+      name: "HotelProviderError",
+      message: "Hotel provider request failed."
+    });
+  });
+});

--- a/apps/api/src/providers/hotels/hotelProvider.ts
+++ b/apps/api/src/providers/hotels/hotelProvider.ts
@@ -1,0 +1,54 @@
+export type HotelSearchBudget = "budget" | "moderate" | "luxury";
+
+export type HotelSuggestionRequest = {
+  budget?: HotelSearchBudget | undefined;
+  city: string;
+  endDate: string;
+  latitude?: number | undefined;
+  longitude?: number | undefined;
+  maxResults?: number | undefined;
+  radiusKm?: number | undefined;
+  startDate: string;
+};
+
+export type HotelSuggestion = {
+  access: string | null;
+  address: string | null;
+  amenities: string[];
+  bookingUrl: string | null;
+  city: string;
+  currency: "JPY" | string;
+  description: string | null;
+  id: string;
+  imageUrl: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  mapUrl: string | null;
+  name: string;
+  priceFrom: number | null;
+  provider: string;
+  rating: number | null;
+  reviewCount: number | null;
+  sourceUpdatedAt: string | null;
+  tags: string[];
+  thumbnailUrl: string | null;
+};
+
+export type HotelProvider = {
+  name: string;
+  searchHotels: (input: HotelSuggestionRequest) => Promise<HotelSuggestion[]>;
+};
+
+export class HotelProviderConfigurationError extends Error {
+  constructor() {
+    super("Hotel provider is not configured.");
+    this.name = "HotelProviderConfigurationError";
+  }
+}
+
+export class HotelProviderError extends Error {
+  constructor() {
+    super("Hotel provider request failed.");
+    this.name = "HotelProviderError";
+  }
+}

--- a/apps/api/src/providers/hotels/rakutenHotelProvider.test.ts
+++ b/apps/api/src/providers/hotels/rakutenHotelProvider.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  HotelProviderConfigurationError,
+  HotelProviderError
+} from "./hotelProvider.js";
+import {
+  buildRakutenSimpleHotelSearchUrl,
+  createRakutenHotelProvider,
+  normalizeRakutenHotelResponse
+} from "./rakutenHotelProvider.js";
+
+const hotelRequest = {
+  budget: "budget" as const,
+  city: "Tokyo",
+  endDate: "2026-04-08",
+  latitude: 35.6812,
+  longitude: 139.7671,
+  maxResults: 3,
+  radiusKm: 1.5,
+  startDate: "2026-04-06"
+};
+
+const rakutenSuccessBody = {
+  hotels: [
+    {
+      hotel: [
+        {
+          hotelBasicInfo: {
+            access: "3 minutes walk from Tokyo Station.",
+            address1: "Tokyo",
+            address2: "Chiyoda City Marunouchi 1-1-1",
+            areaName: "Tokyo",
+            hotelImageUrl: "https://img.travel.rakuten.co.jp/hotel.jpg",
+            hotelInformationUrl: "https://travel.rakuten.co.jp/hotel-info",
+            hotelMinCharge: 18000,
+            hotelName: "Tokyo Station Stay",
+            hotelNo: 123456,
+            hotelSpecial: "A convenient base for rail-friendly Tokyo days.",
+            hotelThumbnailUrl: "https://img.travel.rakuten.co.jp/thumb.jpg",
+            latitude: 35.6812,
+            longitude: 139.7671,
+            nearestStation: "Tokyo",
+            planListUrl: "https://travel.rakuten.co.jp/plan-list",
+            reviewAverage: "4.5",
+            reviewCount: "321",
+            userReview: "Helpful staff and quiet rooms."
+          }
+        },
+        {
+          hotelRatingInfo: {
+            locationAverage: "4.7",
+            serviceAverage: "4.4"
+          }
+        },
+        {
+          hotelFacilitiesInfo: {
+            hotelFacilities: [{ item: "Wi-Fi" }, { item: "Large bath" }]
+          }
+        }
+      ]
+    }
+  ],
+  pagingInfo: {
+    recordCount: 1
+  }
+};
+
+describe("buildRakutenSimpleHotelSearchUrl", () => {
+  test("builds the current SimpleHotelSearch endpoint with app ID and normalized parameters", () => {
+    const url = buildRakutenSimpleHotelSearchUrl({
+      appId: "rakuten-app-id",
+      input: hotelRequest
+    });
+
+    expect(url?.origin).toBe("https://openapi.rakuten.co.jp");
+    expect(url?.pathname).toBe("/engine/api/Travel/SimpleHotelSearch/20170426");
+    expect(url?.searchParams.get("applicationId")).toBe("rakuten-app-id");
+    expect(url?.searchParams.get("format")).toBe("json");
+    expect(url?.searchParams.get("formatVersion")).toBe("2");
+    expect(url?.searchParams.get("datumType")).toBe("1");
+    expect(url?.searchParams.get("latitude")).toBe("35.6812");
+    expect(url?.searchParams.get("longitude")).toBe("139.7671");
+    expect(url?.searchParams.get("searchRadius")).toBe("1.5");
+    expect(url?.searchParams.get("hits")).toBe("3");
+    expect(url?.searchParams.get("sort")).toBe("+roomCharge");
+  });
+
+  test("falls back to known city coordinates for city-only requests", () => {
+    const url = buildRakutenSimpleHotelSearchUrl({
+      appId: "rakuten-app-id",
+      input: {
+        city: "Kyoto",
+        endDate: "2026-04-08",
+        startDate: "2026-04-06"
+      }
+    });
+
+    expect(url?.searchParams.get("latitude")).toBe("35.0116");
+    expect(url?.searchParams.get("longitude")).toBe("135.7681");
+  });
+
+  test("returns null when SimpleHotelSearch cannot be called for the city", () => {
+    const url = buildRakutenSimpleHotelSearchUrl({
+      appId: "rakuten-app-id",
+      input: {
+        city: "Unknown City",
+        endDate: "2026-04-08",
+        startDate: "2026-04-06"
+      }
+    });
+
+    expect(url).toBeNull();
+  });
+});
+
+describe("normalizeRakutenHotelResponse", () => {
+  test("normalizes Rakuten hotel response fields without exposing raw auth data", () => {
+    const hotels = normalizeRakutenHotelResponse(
+      {
+        ...rakutenSuccessBody,
+        accessKey: "do-not-leak",
+        applicationId: "do-not-leak"
+      },
+      hotelRequest
+    );
+
+    expect(hotels).toEqual([
+      expect.objectContaining({
+        access: "3 minutes walk from Tokyo Station.",
+        address: "Tokyo Chiyoda City Marunouchi 1-1-1",
+        amenities: ["Wi-Fi", "Large bath"],
+        bookingUrl: "https://travel.rakuten.co.jp/plan-list",
+        city: "Tokyo",
+        currency: "JPY",
+        description: "A convenient base for rail-friendly Tokyo days.",
+        id: "rakuten-travel:123456",
+        imageUrl: "https://img.travel.rakuten.co.jp/hotel.jpg",
+        latitude: 35.6812,
+        longitude: 139.7671,
+        mapUrl:
+          "https://www.google.com/maps/search/?api=1&query=35.6812%2C139.7671",
+        name: "Tokyo Station Stay",
+        priceFrom: 18000,
+        provider: "rakuten-travel",
+        rating: 4.5,
+        reviewCount: 321,
+        tags: ["Near Tokyo Station", "Location 4.7", "Service 4.4"],
+        thumbnailUrl: "https://img.travel.rakuten.co.jp/thumb.jpg"
+      })
+    ]);
+    expect(JSON.stringify(hotels)).not.toContain("do-not-leak");
+    expect(JSON.stringify(hotels)).not.toContain("accessKey");
+    expect(JSON.stringify(hotels)).not.toContain("applicationId");
+  });
+
+  test("returns an empty list when Rakuten has no results", () => {
+    expect(
+      normalizeRakutenHotelResponse(
+        {
+          hotels: []
+        },
+        hotelRequest
+      )
+    ).toEqual([]);
+  });
+
+  test("maps invalid provider response shape to a provider error", () => {
+    expect(() =>
+      normalizeRakutenHotelResponse(
+        {
+          hotels: "not-an-array"
+        },
+        hotelRequest
+      )
+    ).toThrow(HotelProviderError);
+  });
+});
+
+describe("createRakutenHotelProvider", () => {
+  test("calls Rakuten with access key header and returns normalized hotels", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (_url, _init) => {
+      void _url;
+      void _init;
+
+      return new Response(JSON.stringify(rakutenSuccessBody), {
+        headers: {
+          "Content-Type": "application/json"
+        },
+        status: 200
+      });
+    });
+    const provider = createRakutenHotelProvider({
+      accessKey: "rakuten-access-key",
+      appId: "rakuten-app-id",
+      fetch: fetchMock
+    });
+
+    await expect(provider.searchHotels(hotelRequest)).resolves.toEqual([
+      expect.objectContaining({
+        id: "rakuten-travel:123456",
+        name: "Tokyo Station Stay"
+      })
+    ]);
+
+    const firstCall = fetchMock.mock.calls[0];
+
+    if (!firstCall) {
+      throw new Error("Expected Rakuten fetch to be called.");
+    }
+
+    const [url, init] = firstCall;
+
+    expect(String(url)).toContain(
+      "https://openapi.rakuten.co.jp/engine/api/Travel/SimpleHotelSearch/20170426"
+    );
+    expect(new Headers(init?.headers).get("accessKey")).toBe(
+      "rakuten-access-key"
+    );
+  });
+
+  test("does not require Rakuten config until hotel search is requested", async () => {
+    const provider = createRakutenHotelProvider();
+
+    await expect(provider.searchHotels(hotelRequest)).rejects.toBeInstanceOf(
+      HotelProviderConfigurationError
+    );
+  });
+
+  test("maps provider network failure to a safe provider error", async () => {
+    const provider = createRakutenHotelProvider({
+      accessKey: "rakuten-access-key",
+      appId: "rakuten-app-id",
+      fetch: vi.fn(async () => {
+        throw new Error("network secret details");
+      })
+    });
+
+    await expect(provider.searchHotels(hotelRequest)).rejects.toBeInstanceOf(
+      HotelProviderError
+    );
+  });
+});

--- a/apps/api/src/providers/hotels/rakutenHotelProvider.ts
+++ b/apps/api/src/providers/hotels/rakutenHotelProvider.ts
@@ -1,0 +1,465 @@
+import { z } from "zod";
+
+import type { MapLinkInput } from "../maps/mapsProvider.js";
+import {
+  createGoogleMapsSearchLink,
+  createGoogleMapsSearchUrl
+} from "../maps/mapsProvider.js";
+import {
+  HotelProviderConfigurationError,
+  HotelProviderError,
+  type HotelProvider,
+  type HotelSearchBudget,
+  type HotelSuggestion,
+  type HotelSuggestionRequest
+} from "./hotelProvider.js";
+
+export type RakutenHotelProviderOptions = {
+  accessKey?: string | undefined;
+  appId?: string | undefined;
+  baseUrl?: string | undefined;
+  fetch?: typeof fetch | undefined;
+};
+
+type Coordinates = {
+  latitude: number;
+  longitude: number;
+};
+
+const rakutenProviderName = "rakuten-travel";
+const defaultBaseUrl =
+  "https://openapi.rakuten.co.jp/engine/api/Travel/SimpleHotelSearch/20170426";
+
+const knownCityCenters: Record<string, Coordinates> = {
+  fukuoka: { latitude: 33.5902, longitude: 130.4017 },
+  hiroshima: { latitude: 34.3853, longitude: 132.4553 },
+  kanazawa: { latitude: 36.5613, longitude: 136.6562 },
+  kobe: { latitude: 34.6901, longitude: 135.1955 },
+  kyoto: { latitude: 35.0116, longitude: 135.7681 },
+  nagoya: { latitude: 35.1815, longitude: 136.9066 },
+  nara: { latitude: 34.6851, longitude: 135.8048 },
+  okinawa: { latitude: 26.2124, longitude: 127.6809 },
+  osaka: { latitude: 34.6937, longitude: 135.5023 },
+  sapporo: { latitude: 43.0618, longitude: 141.3545 },
+  tokyo: { latitude: 35.6812, longitude: 139.7671 },
+  yokohama: { latitude: 35.4437, longitude: 139.638 }
+};
+
+const hotelBasicInfoSchema = z
+  .object({
+    access: z.string().nullable().optional(),
+    address1: z.string().nullable().optional(),
+    address2: z.string().nullable().optional(),
+    areaName: z.string().nullable().optional(),
+    hotelImageUrl: z.string().nullable().optional(),
+    hotelInformationUrl: z.string().nullable().optional(),
+    hotelMinCharge: z.number().nullable().optional(),
+    hotelName: z.string().nullable().optional(),
+    hotelNo: z.union([z.number(), z.string()]).nullable().optional(),
+    hotelSpecial: z.string().nullable().optional(),
+    hotelThumbnailUrl: z.string().nullable().optional(),
+    latitude: z.number().nullable().optional(),
+    longitude: z.number().nullable().optional(),
+    nearestStation: z.string().nullable().optional(),
+    planListUrl: z.string().nullable().optional(),
+    reviewAverage: z.union([z.number(), z.string()]).nullable().optional(),
+    reviewCount: z.union([z.number(), z.string()]).nullable().optional(),
+    userReview: z.string().nullable().optional()
+  })
+  .passthrough();
+
+const hotelRatingInfoSchema = z
+  .object({
+    equipmentAverage: z.union([z.number(), z.string()]).nullable().optional(),
+    locationAverage: z.union([z.number(), z.string()]).nullable().optional(),
+    mealAverage: z.union([z.number(), z.string()]).nullable().optional(),
+    roomAverage: z.union([z.number(), z.string()]).nullable().optional(),
+    serviceAverage: z.union([z.number(), z.string()]).nullable().optional()
+  })
+  .passthrough();
+
+const hotelFacilitiesInfoSchema = z
+  .object({
+    hotelFacilities: z
+      .union([
+        z.array(z.object({ item: z.string().optional() }).passthrough()),
+        z
+          .object({
+            item: z.union([z.string(), z.array(z.string())]).optional()
+          })
+          .passthrough()
+      ])
+      .optional()
+  })
+  .passthrough();
+
+const rakutenResponseSchema = z
+  .object({
+    hotels: z.array(z.unknown()).optional(),
+    pagingInfo: z.unknown().optional()
+  })
+  .passthrough();
+
+function cleanConfigValue(value: string | undefined) {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue && trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function requireRakutenConfig(options: {
+  accessKey?: string | undefined;
+  appId?: string | undefined;
+}) {
+  const appId = cleanConfigValue(options.appId);
+  const accessKey = cleanConfigValue(options.accessKey);
+
+  if (appId === null || accessKey === null) {
+    throw new HotelProviderConfigurationError();
+  }
+
+  return { accessKey, appId };
+}
+
+function normalizeCityKey(city: string) {
+  return city.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function getCoordinates(input: HotelSuggestionRequest) {
+  if (
+    input.latitude !== undefined &&
+    input.longitude !== undefined &&
+    Number.isFinite(input.latitude) &&
+    Number.isFinite(input.longitude)
+  ) {
+    return {
+      latitude: input.latitude,
+      longitude: input.longitude
+    };
+  }
+
+  return knownCityCenters[normalizeCityKey(input.city)] ?? null;
+}
+
+function clampHits(maxResults: number | undefined) {
+  if (maxResults === undefined) {
+    return 6;
+  }
+
+  return Math.min(30, Math.max(1, Math.trunc(maxResults)));
+}
+
+function clampSearchRadius(radiusKm: number | undefined) {
+  if (radiusKm === undefined) {
+    return 2;
+  }
+
+  return Math.min(3, Math.max(0.1, Math.round(radiusKm * 10) / 10));
+}
+
+function getSortForBudget(budget: HotelSearchBudget | undefined) {
+  if (budget === "budget") {
+    return "+roomCharge";
+  }
+
+  if (budget === "luxury") {
+    return "-roomCharge";
+  }
+
+  return "standard";
+}
+
+export function buildRakutenSimpleHotelSearchUrl(options: {
+  appId: string;
+  baseUrl?: string | undefined;
+  input: HotelSuggestionRequest;
+}) {
+  const coordinates = getCoordinates(options.input);
+
+  if (coordinates === null) {
+    return null;
+  }
+
+  const url = new URL(options.baseUrl ?? defaultBaseUrl);
+
+  url.searchParams.set("applicationId", options.appId);
+  url.searchParams.set("format", "json");
+  url.searchParams.set("formatVersion", "2");
+  url.searchParams.set("datumType", "1");
+  url.searchParams.set("latitude", String(coordinates.latitude));
+  url.searchParams.set("longitude", String(coordinates.longitude));
+  url.searchParams.set(
+    "searchRadius",
+    String(clampSearchRadius(options.input.radiusKm))
+  );
+  url.searchParams.set("hits", String(clampHits(options.input.maxResults)));
+  url.searchParams.set("page", "1");
+  url.searchParams.set("responseType", "middle");
+  url.searchParams.set("sort", getSortForBudget(options.input.budget));
+  url.searchParams.set("hotelThumbnailSize", "2");
+
+  return url;
+}
+
+async function fetchJson(fetchImpl: typeof fetch, url: URL, accessKey: string) {
+  let response: Response;
+
+  try {
+    response = await fetchImpl(url, {
+      headers: {
+        accessKey
+      }
+    });
+  } catch {
+    throw new HotelProviderError();
+  }
+
+  if (!response.ok) {
+    throw new HotelProviderError();
+  }
+
+  try {
+    return (await response.json()) as unknown;
+  } catch {
+    throw new HotelProviderError();
+  }
+}
+
+function parseNumber(value: number | string | null | undefined) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsedValue = Number(value);
+
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+  }
+
+  return null;
+}
+
+function cleanText(value: string | null | undefined) {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue && trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function buildAddress(basicInfo: z.infer<typeof hotelBasicInfoSchema>) {
+  return (
+    [cleanText(basicInfo.address1), cleanText(basicInfo.address2)]
+      .filter((part): part is string => part !== null)
+      .join(" ") || null
+  );
+}
+
+function formatNearestStationTag(nearestStation: string | null) {
+  if (nearestStation === null) {
+    return null;
+  }
+
+  return nearestStation.toLowerCase().endsWith("station")
+    ? `Near ${nearestStation}`
+    : `Near ${nearestStation} Station`;
+}
+
+function buildTags(options: {
+  basicInfo: z.infer<typeof hotelBasicInfoSchema>;
+  ratingInfo: z.infer<typeof hotelRatingInfoSchema> | null;
+}) {
+  const nearestStation = cleanText(options.basicInfo.nearestStation);
+  const tags = [
+    formatNearestStationTag(nearestStation),
+    parseNumber(options.ratingInfo?.locationAverage) !== null
+      ? `Location ${parseNumber(options.ratingInfo?.locationAverage)}`
+      : null,
+    parseNumber(options.ratingInfo?.serviceAverage) !== null
+      ? `Service ${parseNumber(options.ratingInfo?.serviceAverage)}`
+      : null
+  ];
+
+  return tags.filter((tag): tag is string => tag !== null);
+}
+
+function getHotelSection(
+  value: unknown,
+  key: "hotelBasicInfo" | "hotelFacilitiesInfo" | "hotelRatingInfo"
+) {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const entry = value as Record<string, unknown>;
+
+  if (entry[key] !== undefined) {
+    return entry[key];
+  }
+
+  const hotel = entry.hotel;
+
+  if (Array.isArray(hotel)) {
+    for (const section of hotel) {
+      if (typeof section === "object" && section !== null && key in section) {
+        return (section as Record<string, unknown>)[key];
+      }
+    }
+  }
+
+  if (typeof hotel === "object" && hotel !== null && key in hotel) {
+    return (hotel as Record<string, unknown>)[key];
+  }
+
+  return null;
+}
+
+function normalizeAmenities(
+  facilitiesInfo: z.infer<typeof hotelFacilitiesInfoSchema> | null
+) {
+  const hotelFacilities = facilitiesInfo?.hotelFacilities;
+
+  if (hotelFacilities === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(hotelFacilities)) {
+    return hotelFacilities
+      .map((facility) => cleanText(facility.item))
+      .filter((facility): facility is string => facility !== null);
+  }
+
+  const item = hotelFacilities.item;
+
+  if (Array.isArray(item)) {
+    return item
+      .map((facility) => cleanText(facility))
+      .filter((facility): facility is string => facility !== null);
+  }
+
+  const cleanedItem = cleanText(item);
+
+  return cleanedItem === null ? [] : [cleanedItem];
+}
+
+function getMapUrl(options: {
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  name: string;
+}) {
+  if (options.latitude !== null && options.longitude !== null) {
+    return createGoogleMapsSearchUrl(
+      `${options.latitude},${options.longitude}`
+    );
+  }
+
+  return createGoogleMapsSearchLink({
+    location: {
+      address: options.address ?? undefined,
+      name: options.name
+    }
+  } satisfies MapLinkInput);
+}
+
+function normalizeHotel(
+  hotel: unknown,
+  input: HotelSuggestionRequest
+): HotelSuggestion | null {
+  const basicInfoResult = hotelBasicInfoSchema.safeParse(
+    getHotelSection(hotel, "hotelBasicInfo")
+  );
+
+  if (!basicInfoResult.success) {
+    return null;
+  }
+
+  const basicInfo = basicInfoResult.data;
+  const name = cleanText(basicInfo.hotelName);
+  const hotelNo = cleanText(String(basicInfo.hotelNo ?? ""));
+
+  if (name === null || hotelNo === null) {
+    return null;
+  }
+
+  const ratingInfoResult = hotelRatingInfoSchema.safeParse(
+    getHotelSection(hotel, "hotelRatingInfo")
+  );
+  const facilitiesInfoResult = hotelFacilitiesInfoSchema.safeParse(
+    getHotelSection(hotel, "hotelFacilitiesInfo")
+  );
+  const ratingInfo = ratingInfoResult.success ? ratingInfoResult.data : null;
+  const facilitiesInfo = facilitiesInfoResult.success
+    ? facilitiesInfoResult.data
+    : null;
+  const address = buildAddress(basicInfo);
+  const latitude = parseNumber(basicInfo.latitude);
+  const longitude = parseNumber(basicInfo.longitude);
+  const bookingUrl =
+    cleanText(basicInfo.planListUrl) ??
+    cleanText(basicInfo.hotelInformationUrl);
+
+  return {
+    access: cleanText(basicInfo.access),
+    address,
+    amenities: normalizeAmenities(facilitiesInfo),
+    bookingUrl,
+    city: cleanText(basicInfo.areaName) ?? input.city,
+    currency: "JPY",
+    description:
+      cleanText(basicInfo.hotelSpecial) ??
+      cleanText(basicInfo.userReview) ??
+      cleanText(basicInfo.access),
+    id: `${rakutenProviderName}:${hotelNo}`,
+    imageUrl: cleanText(basicInfo.hotelImageUrl),
+    latitude,
+    longitude,
+    mapUrl: getMapUrl({ address, latitude, longitude, name }),
+    name,
+    priceFrom: parseNumber(basicInfo.hotelMinCharge),
+    provider: rakutenProviderName,
+    rating: parseNumber(basicInfo.reviewAverage),
+    reviewCount: parseNumber(basicInfo.reviewCount),
+    sourceUpdatedAt: null,
+    tags: buildTags({ basicInfo, ratingInfo }),
+    thumbnailUrl: cleanText(basicInfo.hotelThumbnailUrl)
+  };
+}
+
+export function normalizeRakutenHotelResponse(
+  body: unknown,
+  input: HotelSuggestionRequest
+) {
+  const parsedBody = rakutenResponseSchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    throw new HotelProviderError();
+  }
+
+  return (parsedBody.data.hotels ?? [])
+    .map((hotel) => normalizeHotel(hotel, input))
+    .filter((hotel): hotel is HotelSuggestion => hotel !== null);
+}
+
+export function createRakutenHotelProvider(
+  options: RakutenHotelProviderOptions = {}
+): HotelProvider {
+  const fetchImpl = options.fetch ?? fetch;
+
+  return {
+    name: rakutenProviderName,
+    async searchHotels(input) {
+      const config = requireRakutenConfig(options);
+      const url = buildRakutenSimpleHotelSearchUrl({
+        appId: config.appId,
+        baseUrl: options.baseUrl,
+        input
+      });
+
+      if (url === null) {
+        return [];
+      }
+
+      const body = await fetchJson(fetchImpl, url, config.accessKey);
+
+      return normalizeRakutenHotelResponse(body, input);
+    }
+  };
+}

--- a/apps/api/src/routes/enrichment.test.ts
+++ b/apps/api/src/routes/enrichment.test.ts
@@ -5,6 +5,11 @@ import { apiErrorSchema } from "@japan-travel-planner/shared";
 
 import { createApp } from "../app.js";
 import { defaultApiEnv } from "../config/env.js";
+import {
+  HotelProviderError,
+  type HotelProvider,
+  type HotelSuggestion
+} from "../providers/hotels/hotelProvider.js";
 import type { MapsProvider } from "../providers/maps/mapsProvider.js";
 import {
   WeatherProviderError,
@@ -41,15 +46,21 @@ const weatherSummary = {
   windSpeedUnit: "meters_per_second"
 } satisfies WeatherSummary;
 
-function createEnrichmentTestApp(options: {
-  mapsProvider?: MapsProvider | undefined;
-  providerResultCache?: ProviderResultCache | undefined;
-  weatherProvider?: WeatherProvider | undefined;
-} = {}) {
+function createEnrichmentTestApp(
+  options: {
+    hotelProvider?: HotelProvider | undefined;
+    mapsProvider?: MapsProvider | undefined;
+    providerResultCache?: ProviderResultCache | undefined;
+    weatherProvider?: WeatherProvider | undefined;
+  } = {}
+) {
   return createApp({
     env: defaultApiEnv,
     providerResultCache:
       options.providerResultCache ?? createMemoryProviderResultCache(),
+    ...(options.hotelProvider !== undefined
+      ? { hotelProvider: options.hotelProvider }
+      : {}),
     ...(options.mapsProvider !== undefined
       ? { mapsProvider: options.mapsProvider }
       : {}),
@@ -98,6 +109,188 @@ class InMemoryProviderResultRepository implements ProviderResultRepository {
 function createMemoryProviderResultCache() {
   return createProviderResultCache(new InMemoryProviderResultRepository());
 }
+
+const hotelSuggestion = {
+  access: "3 minutes walk from Tokyo Station.",
+  address: "Tokyo Chiyoda City Marunouchi 1-1-1",
+  amenities: ["Wi-Fi", "Large bath"],
+  bookingUrl: "https://travel.rakuten.co.jp/plan-list",
+  city: "Tokyo",
+  currency: "JPY",
+  description: "A convenient base for rail-friendly Tokyo days.",
+  id: "rakuten-travel:123456",
+  imageUrl: "https://img.travel.rakuten.co.jp/hotel.jpg",
+  latitude: 35.6812,
+  longitude: 139.7671,
+  mapUrl: "https://www.google.com/maps/search/?api=1&query=35.6812%2C139.7671",
+  name: "Tokyo Station Stay",
+  priceFrom: 18000,
+  provider: "rakuten-travel",
+  rating: 4.5,
+  reviewCount: 321,
+  sourceUpdatedAt: null,
+  tags: ["Near Tokyo Station"],
+  thumbnailUrl: "https://img.travel.rakuten.co.jp/thumb.jpg"
+} satisfies HotelSuggestion;
+
+describe("POST /api/enrichment/hotels/suggestions", () => {
+  test("returns normalized hotel suggestions", async () => {
+    const hotelProvider = {
+      name: "test-hotel-provider",
+      searchHotels: vi.fn(async () => [hotelSuggestion])
+    } satisfies HotelProvider;
+    const response = await request(createEnrichmentTestApp({ hotelProvider }))
+      .post("/api/enrichment/hotels/suggestions")
+      .send({
+        budget: "moderate",
+        city: "Tokyo",
+        endDate: "2026-04-08",
+        startDate: "2026-04-06"
+      });
+
+    expect(response.status).toBe(200);
+    expect(hotelProvider.searchHotels).toHaveBeenCalledWith({
+      budget: "moderate",
+      city: "Tokyo",
+      endDate: "2026-04-08",
+      maxResults: 6,
+      radiusKm: 2,
+      startDate: "2026-04-06"
+    });
+    expect(response.body).toEqual({
+      hotelSuggestions: [hotelSuggestion],
+      status: "available"
+    });
+  });
+
+  test("returns structured validation errors for invalid hotel input", async () => {
+    const response = await request(
+      createEnrichmentTestApp({
+        hotelProvider: {
+          name: "test-hotel-provider",
+          searchHotels: vi.fn(async () => [hotelSuggestion])
+        }
+      })
+    )
+      .post("/api/enrichment/hotels/suggestions")
+      .send({
+        city: "",
+        endDate: "2026-04-06",
+        latitude: 35.6812,
+        startDate: "2026-04-08"
+      });
+
+    expect(response.status).toBe(400);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "Request validation failed."
+    });
+    expect(response.body.error.fieldErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "city"
+        }),
+        expect.objectContaining({
+          path: "endDate"
+        }),
+        expect.objectContaining({
+          path: "longitude"
+        })
+      ])
+    );
+  });
+
+  test("returns a structured missing config error when Rakuten config is absent", async () => {
+    const response = await request(createEnrichmentTestApp())
+      .post("/api/enrichment/hotels/suggestions")
+      .send({
+        city: "Tokyo",
+        endDate: "2026-04-08",
+        startDate: "2026-04-06"
+      });
+
+    expect(response.status).toBe(503);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toEqual({
+      code: "HOTEL_PROVIDER_CONFIGURATION_ERROR",
+      message: "Hotel enrichment is not configured."
+    });
+  });
+
+  test("degrades provider failure to unavailable hotel suggestions", async () => {
+    const hotelProvider = {
+      name: "test-hotel-provider",
+      searchHotels: vi.fn(async () => {
+        throw new HotelProviderError();
+      })
+    } satisfies HotelProvider;
+    const response = await request(createEnrichmentTestApp({ hotelProvider }))
+      .post("/api/enrichment/hotels/suggestions")
+      .send({
+        city: "Tokyo",
+        endDate: "2026-04-08",
+        startDate: "2026-04-06"
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      hotelSuggestions: [],
+      status: "unavailable"
+    });
+  });
+
+  test("returns empty hotel suggestions when provider has no matches", async () => {
+    const hotelProvider = {
+      name: "test-hotel-provider",
+      searchHotels: vi.fn(async () => [])
+    } satisfies HotelProvider;
+    const response = await request(createEnrichmentTestApp({ hotelProvider }))
+      .post("/api/enrichment/hotels/suggestions")
+      .send({
+        city: "Unknown City",
+        endDate: "2026-04-08",
+        startDate: "2026-04-06"
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      hotelSuggestions: [],
+      status: "empty"
+    });
+  });
+
+  test("uses cached hotels for a second identical enrichment request", async () => {
+    const hotelProvider = {
+      name: "test-hotel-provider",
+      searchHotels: vi.fn(async () => [hotelSuggestion])
+    } satisfies HotelProvider;
+    const app = createEnrichmentTestApp({ hotelProvider });
+    const payload = {
+      city: "Tokyo",
+      endDate: "2026-04-08",
+      startDate: "2026-04-06"
+    };
+
+    const firstResponse = await request(app)
+      .post("/api/enrichment/hotels/suggestions")
+      .send(payload);
+    const secondResponse = await request(app)
+      .post("/api/enrichment/hotels/suggestions")
+      .send({
+        city: "  tokyo ",
+        endDate: "2026-04-08",
+        maxResults: 6,
+        radiusKm: 2,
+        startDate: "2026-04-06"
+      });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.body).toEqual(firstResponse.body);
+    expect(hotelProvider.searchHotels).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("POST /api/enrichment/maps/link", () => {
   test("returns an external Google Maps search link", async () => {
@@ -165,9 +358,7 @@ describe("POST /api/enrichment/maps/link", () => {
         throw new Error("provider unavailable");
       })
     } satisfies MapsProvider;
-    const response = await request(
-      createEnrichmentTestApp({ mapsProvider })
-    )
+    const response = await request(createEnrichmentTestApp({ mapsProvider }))
       .post("/api/enrichment/maps/link")
       .send({
         title: "Senso-ji morning visit",
@@ -189,9 +380,7 @@ describe("POST /api/enrichment/weather/summary", () => {
     const weatherProvider = {
       getDailySummary: vi.fn(async () => weatherSummary)
     } satisfies WeatherProvider;
-    const response = await request(
-      createEnrichmentTestApp({ weatherProvider })
-    )
+    const response = await request(createEnrichmentTestApp({ weatherProvider }))
       .post("/api/enrichment/weather/summary")
       .send({
         city: "Tokyo",
@@ -234,9 +423,7 @@ describe("POST /api/enrichment/weather/summary", () => {
         throw new WeatherProviderError();
       })
     } satisfies WeatherProvider;
-    const response = await request(
-      createEnrichmentTestApp({ weatherProvider })
-    )
+    const response = await request(createEnrichmentTestApp({ weatherProvider }))
       .post("/api/enrichment/weather/summary")
       .send({
         date: "2026-04-06",
@@ -255,9 +442,7 @@ describe("POST /api/enrichment/weather/summary", () => {
     const weatherProvider = {
       getDailySummary: vi.fn(async () => null)
     } satisfies WeatherProvider;
-    const response = await request(
-      createEnrichmentTestApp({ weatherProvider })
-    )
+    const response = await request(createEnrichmentTestApp({ weatherProvider }))
       .post("/api/enrichment/weather/summary")
       .send({
         city: "Unknown Place",

--- a/apps/api/src/routes/enrichment.ts
+++ b/apps/api/src/routes/enrichment.ts
@@ -3,12 +3,17 @@ import { z } from "zod";
 
 import { ApiError } from "../errors/ApiError.js";
 import { validateRequest } from "../middleware/validateRequest.js";
+import {
+  HotelProviderConfigurationError,
+  type HotelProvider
+} from "../providers/hotels/hotelProvider.js";
 import type { MapsProvider } from "../providers/maps/mapsProvider.js";
 import {
   WeatherProviderConfigurationError,
   type WeatherProvider
 } from "../providers/weather/weatherProvider.js";
 import type { ProviderResultCache } from "../services/enrichment/cache.js";
+import { createCachedHotelSuggestions } from "../services/enrichment/hotelEnrichment.js";
 import { createCachedMapLink } from "../services/enrichment/mapEnrichment.js";
 import { createCachedWeatherSummary } from "../services/enrichment/weatherEnrichment.js";
 
@@ -66,6 +71,43 @@ const weatherSummaryBodySchema = z
     }
   });
 
+const hotelSuggestionsBodySchema = z
+  .object({
+    budget: z.enum(["budget", "moderate", "luxury"]).optional(),
+    city: z.string().trim().min(1),
+    endDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Expected a YYYY-MM-DD date."),
+    latitude: z.number().min(-90).max(90).optional(),
+    longitude: z.number().min(-180).max(180).optional(),
+    maxResults: z.number().int().min(1).max(30).default(6),
+    radiusKm: z.number().min(0.1).max(3).default(2),
+    startDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Expected a YYYY-MM-DD date.")
+  })
+  .strict()
+  .superRefine((body, context) => {
+    const hasLatitude = body.latitude !== undefined;
+    const hasLongitude = body.longitude !== undefined;
+
+    if (hasLatitude !== hasLongitude) {
+      context.addIssue({
+        code: "custom",
+        message: "Provide both latitude and longitude.",
+        path: hasLatitude ? ["longitude"] : ["latitude"]
+      });
+    }
+
+    if (body.startDate > body.endDate) {
+      context.addIssue({
+        code: "custom",
+        message: "endDate must be on or after startDate.",
+        path: ["endDate"]
+      });
+    }
+  });
+
 function asyncHandler(handler: RequestHandler): RequestHandler {
   return (request, response, next) => {
     Promise.resolve(handler(request, response, next)).catch(next);
@@ -73,11 +115,38 @@ function asyncHandler(handler: RequestHandler): RequestHandler {
 }
 
 export function createEnrichmentRouter(options: {
+  hotelProvider: HotelProvider;
   mapsProvider: MapsProvider;
   providerResultCache: ProviderResultCache;
   weatherProvider: WeatherProvider;
 }) {
   const router = Router();
+
+  router.post(
+    "/hotels/suggestions",
+    validateRequest(hotelSuggestionsBodySchema),
+    asyncHandler(async (request, response) => {
+      try {
+        const result = await createCachedHotelSuggestions(
+          request.body,
+          options.hotelProvider,
+          options.providerResultCache
+        );
+
+        response.status(200).json(result);
+      } catch (error) {
+        if (error instanceof HotelProviderConfigurationError) {
+          throw new ApiError({
+            code: "HOTEL_PROVIDER_CONFIGURATION_ERROR",
+            message: "Hotel enrichment is not configured.",
+            statusCode: 503
+          });
+        }
+
+        throw error;
+      }
+    })
+  );
 
   router.post(
     "/maps/link",

--- a/apps/api/src/services/enrichment/hotelEnrichment.test.ts
+++ b/apps/api/src/services/enrichment/hotelEnrichment.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  HotelProviderConfigurationError,
+  HotelProviderError,
+  type HotelProvider,
+  type HotelSuggestion
+} from "../../providers/hotels/hotelProvider.js";
+import type {
+  ProviderResultRecord,
+  ProviderResultRepository,
+  ProviderResultWriteInput
+} from "../../repositories/providerResultRepository.js";
+import { createProviderResultCache } from "./cache.js";
+import {
+  createCachedHotelSuggestions,
+  createHotelSuggestions
+} from "./hotelEnrichment.js";
+
+const hotelRequest = {
+  city: "Tokyo",
+  endDate: "2026-04-08",
+  startDate: "2026-04-06"
+};
+
+const hotelSuggestion = {
+  access: "3 minutes from Tokyo Station",
+  address: "1 Marunouchi, Chiyoda City, Tokyo",
+  amenities: ["Wi-Fi"],
+  bookingUrl: "https://example.com/hotel",
+  city: "Tokyo",
+  currency: "JPY",
+  description: "Central hotel for rail-friendly days.",
+  id: "provider:hotel-1",
+  imageUrl: "https://example.com/hotel.jpg",
+  latitude: 35.6812,
+  longitude: 139.7671,
+  mapUrl: "https://www.google.com/maps/search/?api=1&query=Tokyo",
+  name: "Tokyo Station Stay",
+  priceFrom: 18000,
+  provider: "provider",
+  rating: 4.5,
+  reviewCount: 321,
+  sourceUpdatedAt: null,
+  tags: ["Near Tokyo Station"],
+  thumbnailUrl: "https://example.com/thumb.jpg"
+} satisfies HotelSuggestion;
+
+class InMemoryProviderResultRepository implements ProviderResultRepository {
+  private readonly records = new Map<string, ProviderResultRecord>();
+  private nextId = 1;
+
+  async findUsable(cacheKey: string, now = new Date()) {
+    const record = this.records.get(cacheKey);
+
+    if (record === undefined || record.expiresAt <= now) {
+      return null;
+    }
+
+    return structuredClone(record);
+  }
+
+  async upsert(input: ProviderResultWriteInput) {
+    const timestamp = new Date("2026-06-25T00:00:00.000Z");
+    const existingRecord = this.records.get(input.cacheKey);
+    const record: ProviderResultRecord = {
+      id: existingRecord?.id ?? `provider-result-${this.nextId++}`,
+      provider: input.provider,
+      operation: input.operation,
+      cacheKey: input.cacheKey,
+      requestHash: input.requestHash,
+      requestJson: structuredClone(input.requestJson),
+      responseJson: structuredClone(input.responseJson),
+      expiresAt: input.expiresAt,
+      createdAt: existingRecord?.createdAt ?? timestamp,
+      updatedAt: timestamp
+    };
+
+    this.records.set(input.cacheKey, record);
+
+    return structuredClone(record);
+  }
+}
+
+function createProvider(
+  searchHotels: HotelProvider["searchHotels"]
+): HotelProvider {
+  return {
+    name: "test-hotel-provider",
+    searchHotels
+  };
+}
+
+describe("createHotelSuggestions", () => {
+  test("returns available hotel suggestions", async () => {
+    const provider = createProvider(vi.fn(async () => [hotelSuggestion]));
+
+    await expect(
+      createHotelSuggestions(hotelRequest, provider)
+    ).resolves.toEqual({
+      hotelSuggestions: [hotelSuggestion],
+      status: "available"
+    });
+  });
+
+  test("returns empty when provider has no hotel suggestions", async () => {
+    const provider = createProvider(vi.fn(async () => []));
+
+    await expect(
+      createHotelSuggestions(hotelRequest, provider)
+    ).resolves.toEqual({
+      hotelSuggestions: [],
+      status: "empty"
+    });
+  });
+
+  test("preserves provider configuration failures for route-level handling", async () => {
+    const provider = createProvider(
+      vi.fn(async () => {
+        throw new HotelProviderConfigurationError();
+      })
+    );
+
+    await expect(
+      createHotelSuggestions(hotelRequest, provider)
+    ).rejects.toThrow(HotelProviderConfigurationError);
+  });
+
+  test("degrades provider failures to unavailable hotel suggestions", async () => {
+    const provider = createProvider(
+      vi.fn(async () => {
+        throw new HotelProviderError();
+      })
+    );
+
+    await expect(
+      createHotelSuggestions(hotelRequest, provider)
+    ).resolves.toEqual({
+      hotelSuggestions: [],
+      status: "unavailable"
+    });
+  });
+});
+
+describe("createCachedHotelSuggestions", () => {
+  test("reuses cached successful hotel suggestions", async () => {
+    const provider = createProvider(vi.fn(async () => [hotelSuggestion]));
+    const cache = createProviderResultCache(
+      new InMemoryProviderResultRepository()
+    );
+
+    const firstResult = await createCachedHotelSuggestions(
+      hotelRequest,
+      provider,
+      cache
+    );
+    const secondResult = await createCachedHotelSuggestions(
+      {
+        city: "  tokyo ",
+        endDate: "2026-04-08",
+        maxResults: 6,
+        radiusKm: 2,
+        startDate: "2026-04-06"
+      },
+      provider,
+      cache
+    );
+
+    expect(firstResult).toEqual({
+      hotelSuggestions: [hotelSuggestion],
+      status: "available"
+    });
+    expect(secondResult).toEqual(firstResult);
+    expect(provider.searchHotels).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not cache unavailable hotel provider failures", async () => {
+    const provider = createProvider(
+      vi
+        .fn()
+        .mockRejectedValueOnce(new HotelProviderError())
+        .mockResolvedValueOnce([hotelSuggestion])
+    );
+    const cache = createProviderResultCache(
+      new InMemoryProviderResultRepository()
+    );
+
+    await expect(
+      createCachedHotelSuggestions(hotelRequest, provider, cache)
+    ).resolves.toEqual({
+      hotelSuggestions: [],
+      status: "unavailable"
+    });
+    await expect(
+      createCachedHotelSuggestions(hotelRequest, provider, cache)
+    ).resolves.toEqual({
+      hotelSuggestions: [hotelSuggestion],
+      status: "available"
+    });
+    expect(provider.searchHotels).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/services/enrichment/hotelEnrichment.ts
+++ b/apps/api/src/services/enrichment/hotelEnrichment.ts
@@ -1,0 +1,129 @@
+import {
+  HotelProviderConfigurationError,
+  HotelProviderError,
+  type HotelProvider,
+  type HotelSuggestion,
+  type HotelSuggestionRequest
+} from "../../providers/hotels/hotelProvider.js";
+import type { ProviderResultCache } from "./cache.js";
+
+export const hotelSuggestionsCacheTtlMs = 24 * 60 * 60 * 1000;
+
+export type HotelEnrichmentResult =
+  | {
+      hotelSuggestions: HotelSuggestion[];
+      status: "available";
+    }
+  | {
+      hotelSuggestions: HotelSuggestion[];
+      status: "empty" | "unavailable";
+    };
+
+export async function createHotelSuggestions(
+  input: HotelSuggestionRequest,
+  provider: HotelProvider
+): Promise<HotelEnrichmentResult> {
+  try {
+    const hotelSuggestions = await provider.searchHotels(input);
+
+    if (hotelSuggestions.length === 0) {
+      return {
+        hotelSuggestions: [],
+        status: "empty"
+      };
+    }
+
+    return {
+      hotelSuggestions,
+      status: "available"
+    };
+  } catch (error) {
+    if (error instanceof HotelProviderConfigurationError) {
+      throw error;
+    }
+
+    if (error instanceof HotelProviderError) {
+      return {
+        hotelSuggestions: [],
+        status: "unavailable"
+      };
+    }
+
+    return {
+      hotelSuggestions: [],
+      status: "unavailable"
+    };
+  }
+}
+
+function isHotelSuggestion(value: unknown): value is HotelSuggestion {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const suggestion = value as Partial<HotelSuggestion>;
+
+  return (
+    typeof suggestion.id === "string" &&
+    typeof suggestion.name === "string" &&
+    typeof suggestion.provider === "string" &&
+    Array.isArray(suggestion.amenities) &&
+    Array.isArray(suggestion.tags)
+  );
+}
+
+export function isHotelEnrichmentResult(
+  value: unknown
+): value is HotelEnrichmentResult {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const result = value as Partial<HotelEnrichmentResult>;
+
+  if (result.status === "available") {
+    return (
+      Array.isArray(result.hotelSuggestions) &&
+      result.hotelSuggestions.every(isHotelSuggestion)
+    );
+  }
+
+  return (
+    (result.status === "empty" || result.status === "unavailable") &&
+    Array.isArray(result.hotelSuggestions) &&
+    result.hotelSuggestions.length === 0
+  );
+}
+
+export function normalizeHotelSuggestionsCacheInput(
+  input: HotelSuggestionRequest
+) {
+  return {
+    ...(input.budget !== undefined ? { budget: input.budget } : {}),
+    city: input.city,
+    endDate: input.endDate,
+    ...(input.latitude !== undefined ? { latitude: input.latitude } : {}),
+    ...(input.longitude !== undefined ? { longitude: input.longitude } : {}),
+    maxResults: input.maxResults ?? 6,
+    radiusKm: input.radiusKm ?? 2,
+    startDate: input.startDate
+  };
+}
+
+export async function createCachedHotelSuggestions(
+  input: HotelSuggestionRequest,
+  provider: HotelProvider,
+  cache: ProviderResultCache
+): Promise<HotelEnrichmentResult> {
+  const result = await cache.getOrSet({
+    provider: provider.name,
+    operation: "hotels.suggestions",
+    input: normalizeHotelSuggestionsCacheInput(input),
+    ttlMs: hotelSuggestionsCacheTtlMs,
+    load: () => createHotelSuggestions(input, provider),
+    isCachedValue: isHotelEnrichmentResult,
+    shouldCache: (hotelResult) => hotelResult.status !== "unavailable"
+  });
+
+  return result.value;
+}

--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -9,6 +9,31 @@ const corsHeaders = {
 
 const publicShareToken = "public-share-token-1234567890abcdef";
 const pdfBody = "%PDF-1.4\nMock itinerary PDF";
+const hotelSuggestionsFixture = [
+  {
+    access: "3 minutes walk from Tokyo Station.",
+    address: "Tokyo Chiyoda City Marunouchi 1-1-1",
+    amenities: ["Wi-Fi", "Large bath"],
+    bookingUrl: "https://travel.rakuten.co.jp/plan-list",
+    city: "Tokyo",
+    currency: "JPY",
+    description: "A convenient base for rail-friendly Tokyo days.",
+    id: "rakuten-travel:123456",
+    imageUrl: "https://img.travel.rakuten.co.jp/hotel.jpg",
+    latitude: 35.6812,
+    longitude: 139.7671,
+    mapUrl:
+      "https://www.google.com/maps/search/?api=1&query=35.6812%2C139.7671",
+    name: "Tokyo Station Stay",
+    priceFrom: 18000,
+    provider: "rakuten-travel",
+    rating: 4.5,
+    reviewCount: 321,
+    sourceUpdatedAt: null,
+    tags: ["Near Tokyo Station"],
+    thumbnailUrl: "https://img.travel.rakuten.co.jp/thumb.jpg"
+  }
+];
 
 const generatedItineraryFixture = {
   title: "AI Generated Tokyo And Kyoto Route",
@@ -133,6 +158,39 @@ async function routeGeneratedItinerary(page: Page) {
       status: 200
     });
   });
+}
+
+async function routeHotelSuggestions(page: Page) {
+  let hotelSuggestionRequests = 0;
+
+  await page.route("**/api/enrichment/hotels/suggestions", async (route) => {
+    if (isOptionsRequest(route)) {
+      await fulfillOptions(route);
+      return;
+    }
+
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().postDataJSON()).toMatchObject({
+      budget: "moderate",
+      city: "Tokyo",
+      startDate: "2026-04-06"
+    });
+    hotelSuggestionRequests += 1;
+
+    await route.fulfill({
+      contentType: "application/json",
+      headers: corsHeaders,
+      json: {
+        hotelSuggestions: hotelSuggestionsFixture,
+        status: "available"
+      },
+      status: 200
+    });
+  });
+
+  return {
+    getHotelSuggestionRequests: () => hotelSuggestionRequests
+  };
 }
 
 async function fillGeneratedTripRequest(page: Page) {
@@ -263,45 +321,48 @@ async function routeTripPersistence(
     });
   });
 
-  await page.route("**/api/trips/generated-trip-1/export/pdf", async (route) => {
-    if (isOptionsRequest(route)) {
-      await fulfillOptions(route);
-      return;
-    }
+  await page.route(
+    "**/api/trips/generated-trip-1/export/pdf",
+    async (route) => {
+      if (isOptionsRequest(route)) {
+        await fulfillOptions(route);
+        return;
+      }
 
-    expect(route.request().method()).toBe("GET");
-    privatePdfExportRequests += 1;
+      expect(route.request().method()).toBe("GET");
+      privatePdfExportRequests += 1;
 
-    if (
-      options.failFirstPrivateExport === true &&
-      privatePdfExportRequests === 1
-    ) {
+      if (
+        options.failFirstPrivateExport === true &&
+        privatePdfExportRequests === 1
+      ) {
+        await route.fulfill({
+          contentType: "application/json",
+          headers: corsHeaders,
+          json: {
+            error: {
+              code: "PDF_EXPORT_FAILED",
+              message: "PDF export could not be generated."
+            }
+          },
+          status: 500
+        });
+        return;
+      }
+
       await route.fulfill({
-        contentType: "application/json",
-        headers: corsHeaders,
-        json: {
-          error: {
-            code: "PDF_EXPORT_FAILED",
-            message: "PDF export could not be generated."
-          }
+        body: pdfBody,
+        contentType: "application/pdf",
+        headers: {
+          ...corsHeaders,
+          "cache-control": "no-store",
+          "content-disposition":
+            'attachment; filename="ai-generated-tokyo-and-kyoto-route.pdf"'
         },
-        status: 500
+        status: 200
       });
-      return;
     }
-
-    await route.fulfill({
-      body: pdfBody,
-      contentType: "application/pdf",
-      headers: {
-        ...corsHeaders,
-        "cache-control": "no-store",
-        "content-disposition":
-          'attachment; filename="ai-generated-tokyo-and-kyoto-route.pdf"'
-      },
-      status: 200
-    });
-  });
+  );
 
   await page.route("**/api/trips/generated-trip-1/share", async (route) => {
     if (isOptionsRequest(route)) {
@@ -494,15 +555,16 @@ test("traveler can plan and edit a mock itinerary", async ({ page }) => {
   await expect(
     dayOne.getByRole("heading", { name: "Morning walk through Ueno Park" })
   ).toBeVisible();
-  await expect(
-    dayOne.getByRole("heading", { name: editedTitle })
-  ).toHaveCount(0);
+  await expect(dayOne.getByRole("heading", { name: editedTitle })).toHaveCount(
+    0
+  );
 });
 
 test("traveler can generate and edit an itinerary from a mocked AI API response", async ({
   page
 }) => {
   await routeGeneratedItinerary(page);
+  const hotels = await routeHotelSuggestions(page);
 
   await page.goto("/");
   await page.getByRole("button", { name: "API" }).click();
@@ -533,6 +595,11 @@ test("traveler can generate and edit an itinerary from a mocked AI API response"
   await expect(
     page.getByRole("button", { name: "Save itinerary" })
   ).toBeEnabled();
+  await page.getByRole("button", { name: "Find hotels" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Tokyo Station Stay" })
+  ).toBeVisible();
+  await expect.poll(() => hotels.getHotelSuggestionRequests()).toBe(1);
 
   await page
     .getByRole("button", { name: "Edit Generated Senso-ji morning" })
@@ -681,8 +748,9 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
     throw new Error("Expected reopened itinerary edits to be patched.");
   }
 
-  expect(patchedPayload.days[0]?.activities.map((activity) => activity.title))
-    .toEqual(["Generated Asakusa lunch", patchedEditedTitle]);
+  expect(
+    patchedPayload.days[0]?.activities.map((activity) => activity.title)
+  ).toEqual(["Generated Asakusa lunch", patchedEditedTitle]);
 
   await page.reload();
   await page.getByRole("button", { name: "API" }).click();
@@ -696,17 +764,13 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
     patchedEditedTitle
   ]);
 
-  await expect(
-    page.getByRole("button", { name: "Export PDF" })
-  ).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Export PDF" })).toBeEnabled();
   await page.getByRole("button", { name: "Export PDF" }).click();
   await expect(
     page.getByRole("alert").getByText("PDF export could not be generated.")
   ).toBeVisible();
   await page.getByRole("button", { name: "Export PDF" }).click();
-  await expect
-    .poll(() => persistence.getPrivatePdfExportRequests())
-    .toBe(2);
+  await expect.poll(() => persistence.getPrivatePdfExportRequests()).toBe(2);
 
   await page.getByRole("button", { name: "Create public link" }).click();
   expect(persistence.getShareCreatedForTripId()).toBe("generated-trip-1");
@@ -740,9 +804,7 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
     page.getByRole("button", { name: "Export shared PDF" })
   ).toBeEnabled();
   await page.getByRole("button", { name: "Export shared PDF" }).click();
-  await expect
-    .poll(() => persistence.getSharedPdfExportRequests())
-    .toBe(1);
+  await expect.poll(() => persistence.getSharedPdfExportRequests()).toBe(1);
   await expect(page.getByRole("button", { name: /Edit/ })).toHaveCount(0);
   await expect(
     page.getByRole("button", { name: "Save itinerary" })
@@ -753,9 +815,9 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
   await expect(
     page.getByRole("button", { name: "Generate AI itinerary" })
   ).toHaveCount(0);
-  await expect(page.getByRole("region", { name: "Save and reopen" })).toHaveCount(
-    0
-  );
+  await expect(
+    page.getByRole("region", { name: "Save and reopen" })
+  ).toHaveCount(0);
 
   await page.goto("/share/invalid-public-share-token-1234567890");
   await expect(

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -361,6 +361,7 @@ select {
 }
 
 .export-controls,
+.hotel-suggestions,
 .share-controls {
   display: grid;
   gap: 14px;
@@ -369,6 +370,7 @@ select {
 }
 
 .export-controls h3,
+.hotel-suggestions h3,
 .share-controls h3 {
   margin: 8px 0 0;
   color: #172026;
@@ -378,6 +380,7 @@ select {
 }
 
 .export-help,
+.hotel-suggestions-help,
 .share-help {
   margin: 0;
   color: #52616d;
@@ -386,6 +389,7 @@ select {
 }
 
 .export-controls > button,
+.hotel-suggestions > button,
 .share-controls > button,
 .share-url-field button {
   width: 100%;
@@ -399,12 +403,14 @@ select {
 }
 
 .export-controls > button:disabled,
+.hotel-suggestions > button:disabled,
 .share-controls > button:disabled {
   cursor: not-allowed;
   opacity: 0.72;
 }
 
-.export-error {
+.export-error,
+.hotel-suggestions-alert {
   margin: 0;
   border: 1px solid #efb6ae;
   border-radius: 6px;
@@ -414,6 +420,123 @@ select {
   font-weight: 800;
   line-height: 1.4;
   padding: 9px 10px;
+}
+
+.hotel-suggestion-list {
+  display: grid;
+  gap: 12px;
+}
+
+.hotel-suggestion-card {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 12px;
+  border: 1px solid #d8e0e6;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 12px;
+}
+
+.hotel-suggestion-image {
+  width: 72px;
+  height: 72px;
+  border-radius: 6px;
+  object-fit: cover;
+}
+
+.hotel-suggestion-body {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.hotel-suggestion-provider,
+.hotel-suggestion-body h4,
+.hotel-suggestion-body p,
+.hotel-suggestion-meta,
+.hotel-suggestion-tags {
+  margin: 0;
+}
+
+.hotel-suggestion-provider {
+  color: #be3f32;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.hotel-suggestion-body h4 {
+  color: #172026;
+  font-size: 0.98rem;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+.hotel-suggestion-body p {
+  color: #52616d;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.hotel-suggestion-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.hotel-suggestion-meta div {
+  border: 1px solid #dce4ea;
+  border-radius: 6px;
+  background: #f8fafb;
+  padding: 7px 8px;
+}
+
+.hotel-suggestion-meta dt {
+  color: #657480;
+  font-size: 0.66rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.hotel-suggestion-meta dd {
+  margin: 3px 0 0;
+  color: #172026;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.hotel-suggestion-address,
+.hotel-suggestion-access {
+  overflow-wrap: anywhere;
+}
+
+.hotel-suggestion-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0;
+  list-style: none;
+}
+
+.hotel-suggestion-tags li {
+  border-radius: 999px;
+  background: #edf4f6;
+  color: #0d3b4f;
+  font-size: 0.72rem;
+  font-weight: 800;
+  padding: 5px 8px;
+}
+
+.hotel-suggestion-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.hotel-suggestion-links a {
+  color: #0d3b4f;
+  font-size: 0.84rem;
+  font-weight: 800;
 }
 
 .share-url-field {
@@ -975,8 +1098,15 @@ select {
   }
 
   .trip-day-heading,
-  .activity-card-header {
+  .activity-card-header,
+  .hotel-suggestion-card {
     display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .hotel-suggestion-image {
+    width: 100%;
+    height: 120px;
   }
 
   .trip-day-heading span,

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -17,17 +17,19 @@ describe("App", () => {
     expect(html).toContain("Refresh saved trips");
     expect(html).toContain("PDF itinerary");
     expect(html).toContain("Save this itinerary before exporting a PDF.");
+    expect(html).toContain("Hotel suggestions");
+    expect(html).toContain("Create an itinerary before searching hotels.");
     expect(html).toContain("Read-only share link");
-    expect(html).toContain("Save this itinerary before creating a public share link.");
+    expect(html).toContain(
+      "Save this itinerary before creating a public share link."
+    );
     expect(html).toContain("No itinerary yet");
     expect(html).toContain("API");
   });
 
   test("parses public share route tokens without adding a router dependency", () => {
     expect(
-      getShareTokenFromPathname(
-        "/share/public-share-token-1234567890abcdef"
-      )
+      getShareTokenFromPathname("/share/public-share-token-1234567890abcdef")
     ).toBe("public-share-token-1234567890abcdef");
     expect(getShareTokenFromPathname("/")).toBeNull();
   });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,10 @@ import {
   downloadPdfFile,
   ExportControls
 } from "./features/export/ExportControls.js";
+import {
+  HotelSuggestions,
+  type HotelSuggestionsStatus
+} from "./features/hotels/HotelSuggestions.js";
 import { ItineraryView } from "./features/itinerary/ItineraryView.js";
 import {
   cloneItinerary,
@@ -22,6 +26,7 @@ import {
   type TripDataMode
 } from "./features/trips/useTrips.js";
 import { createTripApiClient } from "./lib/api/client.js";
+import type { HotelSuggestion } from "./lib/api/types.js";
 import { mockItinerary } from "./mocks/index.js";
 import { SharedTripPage } from "./routes/SharedTripPage.js";
 
@@ -69,6 +74,14 @@ export function App() {
   const [exportErrorMessage, setExportErrorMessage] = useState<string | null>(
     null
   );
+  const [hotelSuggestions, setHotelSuggestions] = useState<HotelSuggestion[]>(
+    []
+  );
+  const [hotelSuggestionsError, setHotelSuggestionsError] = useState<
+    string | null
+  >(null);
+  const [hotelSuggestionsStatus, setHotelSuggestionsStatus] =
+    useState<HotelSuggestionsStatus>("idle");
   const tripApiClient = useMemo(() => createTripApiClient(), []);
   const generatedItinerary = useGeneratedItinerary();
   const itineraryEditor = useItineraryEditor(null);
@@ -90,6 +103,14 @@ export function App() {
   const selectedShareLink = trips.selectedTripId
     ? trips.shareLinksByTripId[trips.selectedTripId]
     : undefined;
+  const hotelTargetCity =
+    itinerary?.days[0]?.city ?? activeRequest?.cities[0] ?? null;
+  const hotelDisabledReason =
+    !itinerary || !activeRequest || !hotelTargetCity
+      ? "Create an itinerary before searching hotels."
+      : isSubmitting
+        ? "Wait for the itinerary to finish before searching hotels."
+        : undefined;
   const shareDisabledReason =
     dataMode === "mock"
       ? "Switch to API mode and save the trip before sharing."
@@ -139,9 +160,9 @@ export function App() {
           ? "Mock mode"
           : trips.status === "error" && itineraryEditor.isDirty
             ? "Retry needed"
-          : trips.status === "saved"
-            ? "Saved"
-            : "API ready",
+            : trips.status === "saved"
+              ? "Saved"
+              : "API ready",
       detail: "Anonymous session cookies, saved trips, and reopen controls"
     }
   ];
@@ -152,10 +173,17 @@ export function App() {
     );
   }
 
+  function resetHotelSuggestions() {
+    setHotelSuggestions([]);
+    setHotelSuggestionsError(null);
+    setHotelSuggestionsStatus("idle");
+  }
+
   function handleMockSubmit(request: TripRequest) {
     setActiveRequest(request);
     setLocalError(null);
     setExportErrorMessage(null);
+    resetHotelSuggestions();
     trips.clearError();
     generatedItinerary.clearError();
     setIsMockSubmitting(true);
@@ -177,6 +205,7 @@ export function App() {
     setActiveRequest(request);
     setLocalError(null);
     setExportErrorMessage(null);
+    resetHotelSuggestions();
     trips.clearError();
     generatedItinerary.clearError();
     resetToItinerary(null);
@@ -203,6 +232,7 @@ export function App() {
 
     setLocalError(null);
     setExportErrorMessage(null);
+    setHotelSuggestionsError(null);
     generatedItinerary.clearError();
 
     const result = await trips.saveTrip(
@@ -221,6 +251,7 @@ export function App() {
     itineraryEditor.revertItinerary();
     setLocalError(null);
     setExportErrorMessage(null);
+    setHotelSuggestionsError(null);
     trips.clearError();
     generatedItinerary.clearError();
   }
@@ -233,6 +264,7 @@ export function App() {
 
     setLocalError(null);
     setExportErrorMessage(null);
+    resetHotelSuggestions();
     generatedItinerary.clearError();
 
     const result = await trips.reopenTrip(trips.selectedTripId);
@@ -246,8 +278,39 @@ export function App() {
   async function handleLoadSavedTrips() {
     setLocalError(null);
     setExportErrorMessage(null);
+    setHotelSuggestionsError(null);
     generatedItinerary.clearError();
     await trips.loadSavedTrips();
+  }
+
+  async function handleLoadHotelSuggestions() {
+    if (!activeRequest || !hotelTargetCity) {
+      setHotelSuggestions([]);
+      setHotelSuggestionsError("Create an itinerary before searching hotels.");
+      setHotelSuggestionsStatus("error");
+      return;
+    }
+
+    setHotelSuggestions([]);
+    setHotelSuggestionsError(null);
+    setHotelSuggestionsStatus("loading");
+
+    try {
+      const result = await tripApiClient.getHotelSuggestions({
+        budget: activeRequest.budget,
+        city: hotelTargetCity,
+        endDate: activeRequest.endDate,
+        maxResults: 3,
+        startDate: activeRequest.startDate
+      });
+
+      setHotelSuggestions(result.hotelSuggestions);
+      setHotelSuggestionsStatus(result.status);
+    } catch (error) {
+      setHotelSuggestions([]);
+      setHotelSuggestionsError(getTripErrorMessage(error));
+      setHotelSuggestionsStatus("error");
+    }
   }
 
   async function handleExportPdf() {
@@ -278,6 +341,7 @@ export function App() {
 
     setLocalError(null);
     setExportErrorMessage(null);
+    setHotelSuggestionsError(null);
     generatedItinerary.clearError();
     await trips.createShareLink(trips.selectedTripId);
   }
@@ -286,6 +350,7 @@ export function App() {
     setDataMode(nextMode);
     setLocalError(null);
     setExportErrorMessage(null);
+    resetHotelSuggestions();
     trips.clearError();
     generatedItinerary.clearError();
   }
@@ -406,13 +471,13 @@ export function App() {
                       ? "Working"
                       : trips.status === "error" && itineraryEditor.isDirty
                         ? "Retry or revert local edits"
-                      : trips.status === "saved"
-                        ? "Saved"
-                        : itineraryEditor.isDirty
-                          ? "Local edits pending"
-                          : dataMode === "mock"
-                            ? "Mock mode"
-                            : "Ready"}
+                        : trips.status === "saved"
+                          ? "Saved"
+                          : itineraryEditor.isDirty
+                            ? "Local edits pending"
+                            : dataMode === "mock"
+                              ? "Mock mode"
+                              : "Ready"}
               </p>
 
               {storageMessage ? (
@@ -479,6 +544,15 @@ export function App() {
                 errorMessage={exportErrorMessage}
                 isExporting={isExportingPdf}
                 onExportPdf={handleExportPdf}
+              />
+
+              <HotelSuggestions
+                disabledReason={hotelDisabledReason}
+                errorMessage={hotelSuggestionsError}
+                onLoadSuggestions={handleLoadHotelSuggestions}
+                status={hotelSuggestionsStatus}
+                suggestions={hotelSuggestions}
+                targetCity={hotelTargetCity}
               />
 
               <ShareControls

--- a/apps/web/src/features/hotels/HotelSuggestions.test.tsx
+++ b/apps/web/src/features/hotels/HotelSuggestions.test.tsx
@@ -1,0 +1,108 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { HotelSuggestions } from "./HotelSuggestions.js";
+
+const suggestion = {
+  access: "3 minutes walk from Tokyo Station.",
+  address: "Tokyo Chiyoda City Marunouchi 1-1-1",
+  amenities: ["Wi-Fi", "Large bath"],
+  bookingUrl: "https://travel.rakuten.co.jp/plan-list",
+  city: "Tokyo",
+  currency: "JPY",
+  description: "A convenient base for rail-friendly Tokyo days.",
+  id: "rakuten-travel:123456",
+  imageUrl: "https://img.travel.rakuten.co.jp/hotel.jpg",
+  latitude: 35.6812,
+  longitude: 139.7671,
+  mapUrl: "https://www.google.com/maps/search/?api=1&query=35.6812%2C139.7671",
+  name: "Tokyo Station Stay",
+  priceFrom: 18000,
+  provider: "rakuten-travel",
+  rating: 4.5,
+  reviewCount: 321,
+  sourceUpdatedAt: null,
+  tags: ["Near Tokyo Station", "Location 4.7"],
+  thumbnailUrl: "https://img.travel.rakuten.co.jp/thumb.jpg"
+};
+
+describe("HotelSuggestions", () => {
+  test("renders normalized hotel suggestions", () => {
+    const html = renderToString(
+      <HotelSuggestions
+        onLoadSuggestions={() => undefined}
+        status="available"
+        suggestions={[suggestion]}
+        targetCity="Tokyo"
+      />
+    );
+
+    expect(html).toContain("Hotel suggestions");
+    expect(html).toContain("Rakuten Travel");
+    expect(html).toContain("Tokyo Station Stay");
+    expect(html).toContain("A convenient base for rail-friendly Tokyo days.");
+    expect(html).toContain("¥18,000");
+    expect(html).toContain("4.5");
+    expect(html).toContain("321");
+    expect(html).toContain("Booking page");
+    expect(html).toContain("Map");
+  });
+
+  test("renders an empty state", () => {
+    const html = renderToString(
+      <HotelSuggestions
+        onLoadSuggestions={() => undefined}
+        status="empty"
+        targetCity="Kyoto"
+      />
+    );
+
+    expect(html).toContain("No hotel suggestions found for Kyoto.");
+    expect(html).toContain("Find hotels");
+  });
+
+  test("renders unavailable and error states as recoverable alerts", () => {
+    const unavailableHtml = renderToString(
+      <HotelSuggestions
+        onLoadSuggestions={() => undefined}
+        status="unavailable"
+      />
+    );
+    const errorHtml = renderToString(
+      <HotelSuggestions
+        errorMessage="Hotel enrichment is not configured."
+        onLoadSuggestions={() => undefined}
+        status="error"
+      />
+    );
+
+    expect(unavailableHtml).toContain(
+      "Hotel suggestions are temporarily unavailable."
+    );
+    expect(unavailableHtml).toContain('role="alert"');
+    expect(errorHtml).toContain("Hotel enrichment is not configured.");
+    expect(errorHtml).toContain('role="alert"');
+  });
+
+  test("explains why hotel search is disabled before an itinerary exists", () => {
+    const html = renderToString(
+      <HotelSuggestions disabledReason="Create an itinerary before searching hotels." />
+    );
+
+    expect(html).toContain("Create an itinerary before searching hotels.");
+    expect(html).toContain("disabled");
+  });
+
+  test("renders loading state", () => {
+    const html = renderToString(
+      <HotelSuggestions
+        onLoadSuggestions={() => undefined}
+        status="loading"
+        targetCity="Tokyo"
+      />
+    );
+
+    expect(html).toContain("Searching hotels");
+    expect(html).toContain("disabled");
+  });
+});

--- a/apps/web/src/features/hotels/HotelSuggestions.tsx
+++ b/apps/web/src/features/hotels/HotelSuggestions.tsx
@@ -1,0 +1,207 @@
+import type { HotelSuggestion } from "../../lib/api/types.js";
+
+export type HotelSuggestionsStatus =
+  | "available"
+  | "empty"
+  | "error"
+  | "idle"
+  | "loading"
+  | "unavailable";
+
+export type HotelSuggestionsProps = {
+  disabledReason?: string | undefined;
+  errorMessage?: string | null | undefined;
+  onLoadSuggestions?: (() => void) | undefined;
+  suggestions?: HotelSuggestion[] | undefined;
+  targetCity?: string | null | undefined;
+  status?: HotelSuggestionsStatus | undefined;
+};
+
+function formatCurrency(value: number, currency: string) {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      currency,
+      maximumFractionDigits: 0,
+      style: "currency"
+    }).format(value);
+  } catch {
+    return `${currency} ${value}`;
+  }
+}
+
+function getProviderLabel(provider: string) {
+  if (provider === "rakuten-travel") {
+    return "Rakuten Travel";
+  }
+
+  return provider;
+}
+
+function getStatusMessage(options: {
+  disabledReason?: string | undefined;
+  errorMessage?: string | null | undefined;
+  status: HotelSuggestionsStatus;
+  targetCity?: string | null | undefined;
+}) {
+  if (options.disabledReason) {
+    return options.disabledReason;
+  }
+
+  if (options.status === "loading") {
+    return "Searching hotels";
+  }
+
+  if (options.status === "empty") {
+    return `No hotel suggestions found${
+      options.targetCity ? ` for ${options.targetCity}` : ""
+    }.`;
+  }
+
+  if (options.status === "unavailable") {
+    return "Hotel suggestions are temporarily unavailable.";
+  }
+
+  if (options.status === "error") {
+    return options.errorMessage ?? "Hotel suggestions could not be loaded.";
+  }
+
+  return options.targetCity
+    ? `Search hotel ideas near ${options.targetCity}.`
+    : "Create an itinerary before searching hotels.";
+}
+
+export function HotelSuggestions({
+  disabledReason,
+  errorMessage,
+  onLoadSuggestions,
+  suggestions = [],
+  targetCity,
+  status = "idle"
+}: HotelSuggestionsProps) {
+  const isLoading = status === "loading";
+  const isDisabled = isLoading || Boolean(disabledReason) || !onLoadSuggestions;
+  const statusMessage = getStatusMessage({
+    disabledReason,
+    errorMessage,
+    status,
+    targetCity
+  });
+
+  return (
+    <section
+      aria-labelledby="hotel-suggestions-title"
+      className="hotel-suggestions"
+    >
+      <header>
+        <p className="section-kicker">Hotels</p>
+        <h3 id="hotel-suggestions-title">Hotel suggestions</h3>
+      </header>
+
+      <p
+        className={
+          status === "error" || status === "unavailable"
+            ? "hotel-suggestions-alert"
+            : "hotel-suggestions-help"
+        }
+        role={
+          status === "error" || status === "unavailable" ? "alert" : undefined
+        }
+      >
+        {statusMessage}
+      </p>
+
+      <button disabled={isDisabled} onClick={onLoadSuggestions} type="button">
+        {isLoading ? "Searching hotels" : "Find hotels"}
+      </button>
+
+      {status === "available" && suggestions.length > 0 ? (
+        <div className="hotel-suggestion-list">
+          {suggestions.map((suggestion) => (
+            <article className="hotel-suggestion-card" key={suggestion.id}>
+              {(suggestion.thumbnailUrl ?? suggestion.imageUrl) ? (
+                <img
+                  alt=""
+                  className="hotel-suggestion-image"
+                  src={suggestion.thumbnailUrl ?? suggestion.imageUrl ?? ""}
+                />
+              ) : null}
+
+              <div className="hotel-suggestion-body">
+                <p className="hotel-suggestion-provider">
+                  {getProviderLabel(suggestion.provider)}
+                </p>
+                <h4>{suggestion.name}</h4>
+                {suggestion.description ? (
+                  <p>{suggestion.description}</p>
+                ) : null}
+
+                <dl className="hotel-suggestion-meta">
+                  {suggestion.priceFrom !== null ? (
+                    <div>
+                      <dt>From</dt>
+                      <dd>
+                        {formatCurrency(
+                          suggestion.priceFrom,
+                          suggestion.currency
+                        )}
+                      </dd>
+                    </div>
+                  ) : null}
+                  {suggestion.rating !== null ? (
+                    <div>
+                      <dt>Rating</dt>
+                      <dd>
+                        {suggestion.rating}
+                        {suggestion.reviewCount !== null
+                          ? ` (${suggestion.reviewCount})`
+                          : ""}
+                      </dd>
+                    </div>
+                  ) : null}
+                </dl>
+
+                {suggestion.address ? (
+                  <p className="hotel-suggestion-address">
+                    {suggestion.address}
+                  </p>
+                ) : null}
+                {suggestion.access ? (
+                  <p className="hotel-suggestion-access">{suggestion.access}</p>
+                ) : null}
+
+                {suggestion.tags.length > 0 ? (
+                  <ul className="hotel-suggestion-tags" aria-label="Hotel tags">
+                    {suggestion.tags.slice(0, 3).map((tag) => (
+                      <li key={tag}>{tag}</li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                <div className="hotel-suggestion-links">
+                  {suggestion.bookingUrl ? (
+                    <a
+                      href={suggestion.bookingUrl}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      Booking page
+                    </a>
+                  ) : null}
+                  {suggestion.mapUrl ? (
+                    <a
+                      href={suggestion.mapUrl}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      Map
+                    </a>
+                  ) : null}
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/trips/useTrips.test.ts
+++ b/apps/web/src/features/trips/useTrips.test.ts
@@ -70,6 +70,10 @@ function createMockClient(trip = createTripRecord()): TripApiClient {
         tokenUsage: null
       }
     })),
+    getHotelSuggestions: vi.fn(async () => ({
+      hotelSuggestions: [],
+      status: "empty" as const
+    })),
     getSharedTrip: vi.fn(async () => ({
       share: {
         token: "public-share-token-1234567890abcdef",

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -49,6 +49,39 @@ function pdfResponse(init: ResponseInit = {}) {
   });
 }
 
+function hotelSuggestionsResponse(init: ResponseInit = {}) {
+  return jsonResponse(
+    {
+      hotelSuggestions: [
+        {
+          access: "3 minutes from Tokyo Station",
+          address: "1 Marunouchi, Chiyoda City, Tokyo",
+          amenities: ["Wi-Fi"],
+          bookingUrl: "https://example.com/hotel",
+          city: "Tokyo",
+          currency: "JPY",
+          description: "Central hotel for rail-friendly days.",
+          id: "rakuten-travel:123456",
+          imageUrl: "https://example.com/hotel.jpg",
+          latitude: 35.6812,
+          longitude: 139.7671,
+          mapUrl: "https://www.google.com/maps/search/?api=1&query=Tokyo",
+          name: "Tokyo Station Stay",
+          priceFrom: 18000,
+          provider: "rakuten-travel",
+          rating: 4.5,
+          reviewCount: 321,
+          sourceUpdatedAt: null,
+          tags: ["Near Tokyo Station"],
+          thumbnailUrl: "https://example.com/thumb.jpg"
+        }
+      ],
+      status: "available"
+    },
+    init
+  );
+}
+
 describe("createTripApiClient", () => {
   test("creates trips with included anonymous session credentials", async () => {
     const trip = createTripRecord();
@@ -165,9 +198,9 @@ describe("createTripApiClient", () => {
       "http://localhost:3001/api/trips/trip-1/share",
       "http://localhost:3001/api/share/public-share-token-1234567890abcdef"
     ]);
-    expect(fetchMock.mock.calls.map(([, init]) => init?.method ?? "GET")).toEqual(
-      ["GET", "GET", "PATCH", "POST", "GET"]
-    );
+    expect(
+      fetchMock.mock.calls.map(([, init]) => init?.method ?? "GET")
+    ).toEqual(["GET", "GET", "PATCH", "POST", "GET"]);
     expect(
       fetchMock.mock.calls.every(([, init]) => init?.credentials === "include")
     ).toBe(true);
@@ -262,6 +295,59 @@ describe("createTripApiClient", () => {
         new Headers(init?.headers).get("Accept")?.includes("application/pdf")
       )
     ).toBe(true);
+  });
+
+  test("requests normalized hotel suggestions through the API", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        void _input;
+        void _init;
+        return hotelSuggestionsResponse();
+      }
+    );
+    const client = createTripApiClient({
+      baseUrl: "http://localhost:3001",
+      fetch: fetchMock
+    });
+
+    await expect(
+      client.getHotelSuggestions({
+        budget: "moderate",
+        city: "Tokyo",
+        endDate: "2026-04-08",
+        startDate: "2026-04-06"
+      })
+    ).resolves.toMatchObject({
+      hotelSuggestions: [
+        {
+          id: "rakuten-travel:123456",
+          name: "Tokyo Station Stay",
+          provider: "rakuten-travel"
+        }
+      ],
+      status: "available"
+    });
+
+    const firstCall = fetchMock.mock.calls[0];
+
+    if (!firstCall) {
+      throw new Error("Expected fetch to be called");
+    }
+
+    const [url, init] = firstCall;
+
+    expect(url).toBe("http://localhost:3001/api/enrichment/hotels/suggestions");
+    expect(init).toMatchObject({
+      credentials: "include",
+      method: "POST"
+    });
+    expect(new Headers(init?.headers).get("Accept")).toContain(
+      "application/json"
+    );
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      budget: "moderate",
+      city: "Tokyo"
+    });
   });
 
   test("parses structured API errors for UI display", async () => {

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -5,6 +5,8 @@ import {
 import type { TripRequest } from "../../../../../packages/shared/src/schemas/tripRequest.js";
 import type {
   GenerateItineraryResponse,
+  HotelSuggestionsRequest,
+  HotelSuggestionsResponse,
   PdfExportFile,
   ShareLinkRecord,
   SharedTripRecord,
@@ -49,6 +51,9 @@ export type TripApiClient = {
   generateItinerary: (
     payload: TripRequest
   ) => Promise<GenerateItineraryResponse>;
+  getHotelSuggestions: (
+    payload: HotelSuggestionsRequest
+  ) => Promise<HotelSuggestionsResponse>;
   getSharedTrip: (shareToken: string) => Promise<SharedTripRecord>;
   getTrip: (tripId: string) => Promise<TripRecord>;
   listTrips: () => Promise<TripRecord[]>;
@@ -216,6 +221,16 @@ export function createTripApiClient(
     async generateItinerary(payload) {
       return requestJson<GenerateItineraryResponse>(
         "/api/itineraries/generate",
+        {
+          body: JSON.stringify(payload),
+          method: "POST"
+        }
+      );
+    },
+
+    async getHotelSuggestions(payload) {
+      return requestJson<HotelSuggestionsResponse>(
+        "/api/enrichment/hotels/suggestions",
         {
           body: JSON.stringify(payload),
           method: "POST"

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -58,6 +58,52 @@ export type PdfExportFile = {
   filename: string;
 };
 
+export type HotelSearchBudget = "budget" | "moderate" | "luxury";
+
+export type HotelSuggestionsRequest = {
+  budget?: HotelSearchBudget | undefined;
+  city: string;
+  endDate: string;
+  latitude?: number | undefined;
+  longitude?: number | undefined;
+  maxResults?: number | undefined;
+  radiusKm?: number | undefined;
+  startDate: string;
+};
+
+export type HotelSuggestion = {
+  access: string | null;
+  address: string | null;
+  amenities: string[];
+  bookingUrl: string | null;
+  city: string;
+  currency: "JPY" | string;
+  description: string | null;
+  id: string;
+  imageUrl: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  mapUrl: string | null;
+  name: string;
+  priceFrom: number | null;
+  provider: string;
+  rating: number | null;
+  reviewCount: number | null;
+  sourceUpdatedAt: string | null;
+  tags: string[];
+  thumbnailUrl: string | null;
+};
+
+export type HotelSuggestionsResponse =
+  | {
+      hotelSuggestions: HotelSuggestion[];
+      status: "available";
+    }
+  | {
+      hotelSuggestions: HotelSuggestion[];
+      status: "empty" | "unavailable";
+    };
+
 export function tripRecordToItinerary(trip: TripRecord): Itinerary {
   return {
     title: trip.title,


### PR DESCRIPTION
## Ticket scope
Implements T-031 / Ticket 31: Add Hotel Suggestion Provider Abstraction. This starts the hotel integration layer only. Ticket 32 and later work was not started.

## Changes made
- Added a normalized backend `HotelProvider` interface and hotel suggestion shape.
- Added a Rakuten Travel SimpleHotelSearch provider implementation with response normalization.
- Added cache-aware hotel enrichment service.
- Added `POST /api/enrichment/hotels/suggestions` with Zod validation and structured errors.
- Added backend-only Rakuten env config parsing and `.env.example` documentation.
- Added a web API client method for hotel suggestions.
- Added a secondary `HotelSuggestions` UI panel with loading, empty, unavailable, and error states.
- Extended mocked E2E coverage to verify hotel suggestions do not break existing itinerary/edit/save/share/PDF flows.

## Hotel provider interface design
The API provider contract uses normalized `HotelSuggestionRequest` and `HotelSuggestion` types. Service and UI code consume fields such as `name`, `priceFrom`, `bookingUrl`, `rating`, `address`, `mapUrl`, `amenities`, and `tags`; they do not consume Rakuten raw response field names.

## Rakuten provider normalization
The Rakuten implementation targets the current SimpleHotelSearch endpoint:
`https://openapi.rakuten.co.jp/engine/api/Travel/SimpleHotelSearch/20170426`.

The provider sends `applicationId`, `format=json`, `formatVersion=2`, `datumType=1`, coordinates, radius, hits, response type, sort, and thumbnail size. It passes `accessKey` as a backend request header. It normalizes `hotelBasicInfo`, `hotelRatingInfo`, and `hotelFacilitiesInfo` into the provider-agnostic hotel suggestion shape.

SimpleHotelSearch does not accept arbitrary city text directly; it requires hotel number, coordinates, or area class codes. This PR accepts `city` in the app request and uses coordinates when provided, with a small common-Japan-city center fallback for city-only searches. Unknown city-only requests return an empty hotel suggestion result instead of making a malformed provider request.

## Backend-only key handling
- Added `RAKUTEN_APP_ID` and `RAKUTEN_ACCESS_KEY` as backend-only env vars.
- Kept `RAKUTEN_API_KEY` as a legacy alias for `RAKUTEN_APP_ID`; current Rakuten docs still require `RAKUTEN_ACCESS_KEY` too.
- No `VITE_RAKUTEN_*` variables were added.
- Verified no `RAKUTEN` or `VITE_RAKUTEN` strings appear in web source or the built web bundle.
- Missing Rakuten config does not block API startup.

## API route behavior
`POST /api/enrichment/hotels/suggestions` accepts city, date range, optional coordinates/radius/budget/maxResults, validates request input, and returns normalized hotel suggestions. Missing provider config returns `HOTEL_PROVIDER_CONFIGURATION_ERROR` with HTTP 503. Provider/network failures return a safe unavailable result instead of leaking provider details.

## HotelSuggestions UI behavior
The web app shows hotel search as a secondary panel after an itinerary exists. It renders normalized hotel cards and handles idle, loading, empty, unavailable, and error states. It does not block itinerary display and does not expose provider keys.

## Empty/error/degradation behavior
- No provider matches returns `{ status: "empty", hotelSuggestions: [] }`.
- Provider/network failures return `{ status: "unavailable", hotelSuggestions: [] }`.
- Missing config returns a structured 503 API error that the web UI displays as a recoverable alert.
- Existing itinerary, map, weather, sharing, PDF export, editing, save/reopen, and mock flows remain passing.

## Cache integration behavior
Successful hotel enrichment results are cached through the existing provider result cache. Unavailable provider failures are not cached, so later retries can recover. Cache keys normalize city/date/radius/maxResults/budget/coordinates and filter secret-like fields through the existing cache normalization.

## Tests added/updated
- Provider contract test.
- Rakuten provider URL/auth/normalization/missing-config/network/no-results tests.
- Hotel enrichment service tests for available, empty, missing config, unavailable, cache hit, and no-cache-on-unavailable.
- API route tests for success, validation, missing config, provider failure, empty state, and cache hit.
- Web API client test for hotel suggestions.
- `HotelSuggestions` component tests for suggestions, empty, unavailable/error, disabled, and loading states.
- App smoke test updated for hotel UI.
- E2E updated with mocked hotel suggestions and existing itinerary/edit/save/share/PDF regressions.

## Checks run
- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit`
- `pnpm --filter @japan-travel-planner/web exec vite build`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `git diff --check`

## Manual checks run
- Started API with `pnpm dev:api`.
- Started web with `pnpm dev:web`.
- Confirmed `GET /api/health` returned HTTP 200 with status `ok`.
- Confirmed web root returned HTTP 200.
- Called hotel suggestions endpoint without Rakuten config and confirmed structured `HOTEL_PROVIDER_CONFIGURATION_ERROR` 503.
- Confirmed no `RAKUTEN_*` provider secret or `VITE_RAKUTEN` appears in web source or built bundle.
- Confirmed no Ticket 32 route/transit or LINE/mobile work was added.

Full DB-backed local save/reopen was not manually tested because this environment does not have a working local `.env`/Postgres setup. Existing mocked E2E covers save/reopen/share/PDF regressions.

## Real provider calls
No real Rakuten API calls were made. No real OpenAI, OpenWeather, or Google Maps API calls were made.

## Known risks
- Rakuten auth/config is based on the current SimpleHotelSearch docs requiring both app ID and access key; local credentials were not available for a real smoke test.
- City-only search quality is limited because SimpleHotelSearch is coordinate/class-code based, not free-text city search.
- The first city-center fallback is intentionally small and MVP-oriented; broader area-code lookup can come later without changing the UI contract.
- Hotel suggestions are availability-agnostic because SimpleHotelSearch returns facility info, not live vacant room inventory.

## Ticket boundary confirmation
Ticket 32 and later were not started. No transit or route hints, LINE sharing, mobile app work, deployment, observability, AI generation behavior changes, PDF export behavior changes, provider cache schema changes, or Prisma migrations were added.
