### PR TITLE
Add route hint provider abstraction

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,6 +11,8 @@ import {
   createGoogleMapsProvider,
   type MapsProvider
 } from "./providers/maps/mapsProvider.js";
+import { createGoogleRoutesProvider } from "./providers/routes/googleRoutesProvider.js";
+import type { RouteProvider } from "./providers/routes/routeProvider.js";
 import {
   createOpenWeatherProvider,
   type WeatherProvider
@@ -52,6 +54,7 @@ export type CreateAppOptions = {
   mapsProvider?: MapsProvider;
   pdfExportService?: PdfExportService;
   providerResultCache?: ProviderResultCache;
+  routeProvider?: RouteProvider;
   sessionMiddleware?: RequestHandler;
   shareService?: ShareService;
   tripService?: TripService;
@@ -104,6 +107,11 @@ export function createApp(options: CreateAppOptions = {}) {
     createOpenWeatherProvider({
       apiKey: env.weatherApiKey
     });
+  const routeProvider =
+    options.routeProvider ??
+    createGoogleRoutesProvider({
+      apiKey: env.googleMapsApiKey
+    });
   const app = express();
 
   app.use(
@@ -120,6 +128,7 @@ export function createApp(options: CreateAppOptions = {}) {
       hotelProvider,
       mapsProvider,
       providerResultCache,
+      routeProvider,
       weatherProvider
     })
   );

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -13,6 +13,7 @@ describe("loadApiEnv", () => {
         AI_GENERATION_RATE_LIMIT_MAX: "9",
         AI_GENERATION_RATE_LIMIT_WINDOW_MS: "120000",
         API_PORT: "4001",
+        GOOGLE_MAPS_API_KEY: "google-routes-test-key",
         OPENAI_API_KEY: "sk-test-api-key",
         OPENAI_MODEL: "gpt-test-model",
         RAKUTEN_ACCESS_KEY: "rakuten-access-key",
@@ -25,6 +26,7 @@ describe("loadApiEnv", () => {
       aiGenerationRateLimitMax: 9,
       aiGenerationRateLimitWindowMs: 120000,
       apiPort: 4001,
+      googleMapsApiKey: "google-routes-test-key",
       openAiApiKey: "sk-test-api-key",
       openAiModel: "gpt-test-model",
       rakutenAccessKey: "rakuten-access-key",
@@ -38,6 +40,7 @@ describe("loadApiEnv", () => {
   test("does not require provider keys during API env loading", () => {
     expect(loadApiEnv({}).openAiApiKey).toBeUndefined();
     expect(loadApiEnv({}).openAiModel).toBe(defaultApiEnv.openAiModel);
+    expect(loadApiEnv({}).googleMapsApiKey).toBeUndefined();
     expect(loadApiEnv({}).rakutenAccessKey).toBeUndefined();
     expect(loadApiEnv({}).rakutenAppId).toBeUndefined();
     expect(loadApiEnv({}).weatherApiKey).toBeUndefined();

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -2,6 +2,7 @@ export type ApiEnvConfig = {
   aiGenerationRateLimitMax: number;
   aiGenerationRateLimitWindowMs: number;
   apiPort: number;
+  googleMapsApiKey: string | undefined;
   openAiApiKey: string | undefined;
   openAiModel: string;
   rakutenAccessKey: string | undefined;
@@ -18,6 +19,7 @@ export const defaultApiEnv = {
   aiGenerationRateLimitMax: 5,
   aiGenerationRateLimitWindowMs: 60_000,
   apiPort: 3001,
+  googleMapsApiKey: undefined,
   openAiApiKey: undefined,
   openAiModel: defaultOpenAiModel,
   rakutenAccessKey: undefined,
@@ -31,6 +33,7 @@ type ApiEnvSource = {
   AI_GENERATION_RATE_LIMIT_MAX?: string | undefined;
   AI_GENERATION_RATE_LIMIT_WINDOW_MS?: string | undefined;
   API_PORT?: string | undefined;
+  GOOGLE_MAPS_API_KEY?: string | undefined;
   OPENAI_API_KEY?: string | undefined;
   OPENAI_MODEL?: string | undefined;
   RAKUTEN_ACCESS_KEY?: string | undefined;
@@ -158,6 +161,7 @@ export function loadApiEnv(env: ApiEnvSource = process.env): ApiEnvConfig {
       value: env.AI_GENERATION_RATE_LIMIT_WINDOW_MS
     }),
     apiPort: parseApiPort(env.API_PORT),
+    googleMapsApiKey: parseOptionalSecret(env.GOOGLE_MAPS_API_KEY),
     openAiApiKey: parseOpenAiApiKey(env.OPENAI_API_KEY),
     openAiModel: parseOpenAiModel(env.OPENAI_MODEL),
     rakutenAccessKey: parseOptionalSecret(env.RAKUTEN_ACCESS_KEY),

--- a/apps/api/src/providers/routes/googleRoutesProvider.test.ts
+++ b/apps/api/src/providers/routes/googleRoutesProvider.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  RouteProviderConfigurationError,
+  RouteProviderError
+} from "./routeProvider.js";
+import {
+  buildGoogleRoutesRequestBody,
+  createGoogleRoutesProvider,
+  createGoogleMapsDirectionsUrl,
+  normalizeGoogleRoutesResponse
+} from "./googleRoutesProvider.js";
+
+const routeRequest = {
+  destination: {
+    address: "4 Chome Ueno, Taito City, Tokyo",
+    label: "Ameyoko lunch crawl"
+  },
+  locale: "en-US",
+  maxAlternatives: 2,
+  origin: {
+    label: "Morning walk through Ueno Park",
+    latitude: 35.7156,
+    longitude: 139.7745
+  },
+  travelMode: "transit" as const
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json"
+    },
+    status
+  });
+}
+
+function getFirstFetchCall(fetchMock: typeof fetch) {
+  const firstCall = vi.mocked(fetchMock).mock.calls[0];
+
+  if (!firstCall) {
+    throw new Error("Expected fetch to be called.");
+  }
+
+  return firstCall;
+}
+
+const googleRoutesSuccessBody = {
+  routes: [
+    {
+      distanceMeters: 1200,
+      duration: "840s",
+      staticDuration: "780s",
+      legs: [
+        {
+          distanceMeters: 1200,
+          duration: "840s",
+          staticDuration: "780s",
+          steps: [
+            {
+              distanceMeters: 400,
+              navigationInstruction: {
+                instructions: "Walk to Ueno Station."
+              },
+              staticDuration: "300s",
+              travelMode: "WALK"
+            },
+            {
+              distanceMeters: 800,
+              navigationInstruction: {
+                instructions: "Take the Ginza Line toward Asakusa."
+              },
+              staticDuration: "480s",
+              transitDetails: {
+                transitLine: {
+                  name: "Tokyo Metro Ginza Line",
+                  shortName: "G"
+                }
+              },
+              travelMode: "TRANSIT"
+            }
+          ]
+        }
+      ],
+      rawAuthorization: "do-not-leak",
+      rawApiKey: "do-not-leak"
+    }
+  ],
+  requestHeaders: {
+    "X-Goog-Api-Key": "do-not-leak"
+  }
+};
+
+describe("buildGoogleRoutesRequestBody", () => {
+  test("builds the minimal Compute Routes request body", () => {
+    expect(buildGoogleRoutesRequestBody(routeRequest)).toEqual({
+      computeAlternativeRoutes: true,
+      destination: {
+        address: "4 Chome Ueno, Taito City, Tokyo"
+      },
+      languageCode: "en-US",
+      origin: {
+        location: {
+          latLng: {
+            latitude: 35.7156,
+            longitude: 139.7745
+          }
+        }
+      },
+      travelMode: "TRANSIT"
+    });
+  });
+
+  test("creates a Google Maps directions URL without an API key", () => {
+    const url = new URL(createGoogleMapsDirectionsUrl(routeRequest));
+
+    expect(url.origin).toBe("https://www.google.com");
+    expect(url.pathname).toBe("/maps/dir/");
+    expect(url.searchParams.get("api")).toBe("1");
+    expect(url.searchParams.get("origin")).toBe("35.7156,139.7745");
+    expect(url.searchParams.get("destination")).toBe(
+      "4 Chome Ueno, Taito City, Tokyo"
+    );
+    expect(url.searchParams.get("travelmode")).toBe("transit");
+    expect(url.search).not.toContain("key");
+  });
+});
+
+describe("createGoogleRoutesProvider", () => {
+  test("calls Compute Routes with required auth and field-mask headers", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      jsonResponse({ routes: [] })
+    );
+    const provider = createGoogleRoutesProvider({
+      apiKey: "google-routes-test-key",
+      baseUrl: "https://routes.example.test/directions/v2:computeRoutes",
+      fetch: fetchMock,
+      fieldMask: "routes.duration,routes.distanceMeters"
+    });
+
+    await expect(provider.getRouteHints(routeRequest)).resolves.toEqual([]);
+
+    const [url, init] = getFirstFetchCall(fetchMock);
+    const headers = new Headers(init?.headers);
+
+    expect(url).toBe("https://routes.example.test/directions/v2:computeRoutes");
+    expect(init?.method).toBe("POST");
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("X-Goog-Api-Key")).toBe("google-routes-test-key");
+    expect(headers.get("X-Goog-FieldMask")).toBe(
+      "routes.duration,routes.distanceMeters"
+    );
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      destination: {
+        address: "4 Chome Ueno, Taito City, Tokyo"
+      },
+      origin: {
+        location: {
+          latLng: {
+            latitude: 35.7156,
+            longitude: 139.7745
+          }
+        }
+      },
+      travelMode: "TRANSIT"
+    });
+  });
+
+  test("does not require Google config until route hints are requested", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      jsonResponse({ routes: [] })
+    );
+    const provider = createGoogleRoutesProvider({
+      fetch: fetchMock
+    });
+
+    await expect(provider.getRouteHints(routeRequest)).rejects.toBeInstanceOf(
+      RouteProviderConfigurationError
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("maps provider network and HTTP failures to a safe provider error", async () => {
+    const networkProvider = createGoogleRoutesProvider({
+      apiKey: "google-routes-test-key",
+      fetch: vi.fn(async () => {
+        throw new Error("network secret details");
+      })
+    });
+    const httpProvider = createGoogleRoutesProvider({
+      apiKey: "google-routes-test-key",
+      fetch: vi.fn<typeof fetch>(async () =>
+        jsonResponse({ error: { message: "raw provider detail" } }, 500)
+      )
+    });
+
+    await expect(
+      networkProvider.getRouteHints(routeRequest)
+    ).rejects.toBeInstanceOf(RouteProviderError);
+    await expect(
+      httpProvider.getRouteHints(routeRequest)
+    ).rejects.toBeInstanceOf(RouteProviderError);
+  });
+
+  test("returns an empty route hint list when Google returns no routes", async () => {
+    const provider = createGoogleRoutesProvider({
+      apiKey: "google-routes-test-key",
+      fetch: vi.fn<typeof fetch>(async () => jsonResponse({ routes: [] }))
+    });
+
+    await expect(provider.getRouteHints(routeRequest)).resolves.toEqual([]);
+  });
+
+  test("normalizes Google route responses into provider-neutral hints", () => {
+    const hints = normalizeGoogleRoutesResponse(
+      googleRoutesSuccessBody,
+      routeRequest,
+      new Date("2026-06-25T00:00:00.000Z")
+    );
+
+    expect(hints).toEqual([
+      {
+        destination: routeRequest.destination,
+        destinationLabel: "Ameyoko lunch crawl",
+        distanceMeters: 1200,
+        durationMinutes: 14,
+        id: "google-routes:morning-walk-through-ueno-park-ameyoko-lunch-crawl-transit:1",
+        mapUrl: expect.stringContaining("https://www.google.com/maps/dir/"),
+        origin: routeRequest.origin,
+        originLabel: "Morning walk through Ueno Park",
+        provider: "google-routes",
+        sourceUpdatedAt: "2026-06-25T00:00:00.000Z",
+        staticDurationMinutes: 13,
+        steps: [
+          {
+            distanceMeters: 400,
+            durationMinutes: 5,
+            instruction: "Walk to Ueno Station.",
+            transitLineName: null,
+            travelMode: "walk"
+          },
+          {
+            distanceMeters: 800,
+            durationMinutes: 8,
+            instruction: "Take the Ginza Line toward Asakusa.",
+            transitLineName: "Tokyo Metro Ginza Line",
+            travelMode: "transit"
+          }
+        ],
+        summary:
+          "Transit route from Morning walk through Ueno Park to Ameyoko lunch crawl, about 14 min, 1.2 km, via Tokyo Metro Ginza Line.",
+        transitLineNames: ["Tokyo Metro Ginza Line"],
+        travelMode: "transit",
+        warnings: []
+      }
+    ]);
+  });
+
+  test("adds local-verification warnings for beta walking and bicycle modes", () => {
+    const hints = normalizeGoogleRoutesResponse(
+      { routes: [{ duration: "600s" }] },
+      {
+        ...routeRequest,
+        maxAlternatives: 1,
+        travelMode: "walk"
+      },
+      new Date("2026-06-25T00:00:00.000Z")
+    );
+
+    expect(hints[0]?.warnings).toEqual([
+      "Walking and bicycle route details may be incomplete; verify locally before traveling."
+    ]);
+  });
+
+  test("does not expose raw provider secret or auth fields", () => {
+    const hints = normalizeGoogleRoutesResponse(
+      googleRoutesSuccessBody,
+      routeRequest,
+      new Date("2026-06-25T00:00:00.000Z")
+    );
+
+    expect(JSON.stringify(hints)).not.toContain("do-not-leak");
+    expect(JSON.stringify(hints)).not.toContain("rawAuthorization");
+    expect(JSON.stringify(hints)).not.toContain("X-Goog-Api-Key");
+  });
+});

--- a/apps/api/src/providers/routes/googleRoutesProvider.ts
+++ b/apps/api/src/providers/routes/googleRoutesProvider.ts
@@ -1,0 +1,530 @@
+import { z } from "zod";
+
+import {
+  RouteProviderConfigurationError,
+  RouteProviderError,
+  type RouteHint,
+  type RouteHintLocation,
+  type RouteHintRequest,
+  type RouteHintStep,
+  type RouteProvider,
+  type RouteTravelMode
+} from "./routeProvider.js";
+
+export type GoogleRoutesProviderOptions = {
+  apiKey?: string | undefined;
+  baseUrl?: string | undefined;
+  fetch?: typeof fetch | undefined;
+  fieldMask?: string | undefined;
+  now?: (() => Date) | undefined;
+};
+
+type GoogleTravelMode = "BICYCLE" | "DRIVE" | "TRANSIT" | "WALK";
+
+const googleRoutesProviderName = "google-routes";
+const defaultBaseUrl =
+  "https://routes.googleapis.com/directions/v2:computeRoutes";
+const defaultFieldMask = [
+  "routes.distanceMeters",
+  "routes.duration",
+  "routes.staticDuration",
+  "routes.legs.distanceMeters",
+  "routes.legs.duration",
+  "routes.legs.staticDuration",
+  "routes.legs.steps.distanceMeters",
+  "routes.legs.steps.staticDuration",
+  "routes.legs.steps.navigationInstruction.instructions",
+  "routes.legs.steps.transitDetails.transitLine.name",
+  "routes.legs.steps.transitDetails.transitLine.shortName",
+  "routes.legs.steps.travelMode"
+].join(",");
+
+const googleRouteStepSchema = z
+  .object({
+    distanceMeters: z.number().optional(),
+    navigationInstruction: z
+      .object({
+        instructions: z.string().optional()
+      })
+      .passthrough()
+      .optional(),
+    staticDuration: z.string().optional(),
+    transitDetails: z
+      .object({
+        transitLine: z
+          .object({
+            name: z.string().optional(),
+            shortName: z.string().optional()
+          })
+          .passthrough()
+          .optional()
+      })
+      .passthrough()
+      .optional(),
+    travelMode: z.string().optional()
+  })
+  .passthrough();
+
+const googleRouteLegSchema = z
+  .object({
+    distanceMeters: z.number().optional(),
+    duration: z.string().optional(),
+    staticDuration: z.string().optional(),
+    steps: z.array(googleRouteStepSchema).optional()
+  })
+  .passthrough();
+
+const googleRouteSchema = z
+  .object({
+    distanceMeters: z.number().optional(),
+    duration: z.string().optional(),
+    legs: z.array(googleRouteLegSchema).optional(),
+    staticDuration: z.string().optional()
+  })
+  .passthrough();
+
+const googleRoutesResponseSchema = z
+  .object({
+    routes: z.array(googleRouteSchema).optional()
+  })
+  .passthrough();
+
+type GoogleRoute = z.infer<typeof googleRouteSchema>;
+type GoogleRouteLeg = z.infer<typeof googleRouteLegSchema>;
+type GoogleRouteStep = z.infer<typeof googleRouteStepSchema>;
+
+function cleanConfigValue(value: string | undefined) {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue && trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function requireApiKey(apiKey: string | undefined) {
+  const configuredApiKey = cleanConfigValue(apiKey);
+
+  if (configuredApiKey === null) {
+    throw new RouteProviderConfigurationError();
+  }
+
+  return configuredApiKey;
+}
+
+function routeModeToGoogleMode(mode: RouteTravelMode): GoogleTravelMode {
+  if (mode === "bicycle") {
+    return "BICYCLE";
+  }
+
+  if (mode === "drive") {
+    return "DRIVE";
+  }
+
+  if (mode === "walk") {
+    return "WALK";
+  }
+
+  return "TRANSIT";
+}
+
+function googleModeToRouteMode(
+  mode: string | undefined,
+  fallback: RouteTravelMode
+): RouteTravelMode {
+  if (mode === "BICYCLE") {
+    return "bicycle";
+  }
+
+  if (mode === "DRIVE") {
+    return "drive";
+  }
+
+  if (mode === "WALK") {
+    return "walk";
+  }
+
+  if (mode === "TRANSIT") {
+    return "transit";
+  }
+
+  return fallback;
+}
+
+function coordinatesToText(location: RouteHintLocation) {
+  return location.latitude !== undefined && location.longitude !== undefined
+    ? `${location.latitude},${location.longitude}`
+    : null;
+}
+
+function routeLocationToWaypoint(location: RouteHintLocation) {
+  if (location.latitude !== undefined && location.longitude !== undefined) {
+    return {
+      location: {
+        latLng: {
+          latitude: location.latitude,
+          longitude: location.longitude
+        }
+      }
+    };
+  }
+
+  return {
+    address: location.address ?? location.label
+  };
+}
+
+function getDirectionsLocationValue(location: RouteHintLocation) {
+  return coordinatesToText(location) ?? location.address ?? location.label;
+}
+
+function getGoogleMapsTravelMode(mode: RouteTravelMode) {
+  if (mode === "bicycle") {
+    return "bicycling";
+  }
+
+  if (mode === "drive") {
+    return "driving";
+  }
+
+  if (mode === "walk") {
+    return "walking";
+  }
+
+  return "transit";
+}
+
+export function createGoogleMapsDirectionsUrl(input: RouteHintRequest) {
+  const url = new URL("https://www.google.com/maps/dir/");
+
+  url.searchParams.set("api", "1");
+  url.searchParams.set("origin", getDirectionsLocationValue(input.origin));
+  url.searchParams.set(
+    "destination",
+    getDirectionsLocationValue(input.destination)
+  );
+  url.searchParams.set("travelmode", getGoogleMapsTravelMode(input.travelMode));
+
+  return url.toString();
+}
+
+export function buildGoogleRoutesRequestBody(input: RouteHintRequest) {
+  return {
+    origin: routeLocationToWaypoint(input.origin),
+    destination: routeLocationToWaypoint(input.destination),
+    travelMode: routeModeToGoogleMode(input.travelMode),
+    ...(input.departureTime !== undefined
+      ? { departureTime: input.departureTime }
+      : {}),
+    ...(input.locale !== undefined ? { languageCode: input.locale } : {}),
+    ...(input.maxAlternatives !== undefined && input.maxAlternatives > 1
+      ? { computeAlternativeRoutes: true }
+      : {})
+  };
+}
+
+async function fetchRoutes(options: {
+  apiKey: string;
+  baseUrl: string;
+  body: unknown;
+  fetchImpl: typeof fetch;
+  fieldMask: string;
+}) {
+  let response: Response;
+
+  try {
+    response = await options.fetchImpl(options.baseUrl, {
+      body: JSON.stringify(options.body),
+      headers: {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": options.apiKey,
+        "X-Goog-FieldMask": options.fieldMask
+      },
+      method: "POST"
+    });
+  } catch {
+    throw new RouteProviderError();
+  }
+
+  if (!response.ok) {
+    throw new RouteProviderError();
+  }
+
+  try {
+    return (await response.json()) as unknown;
+  } catch {
+    throw new RouteProviderError();
+  }
+}
+
+function parseDurationSeconds(value: string | undefined) {
+  if (value === undefined) {
+    return null;
+  }
+
+  const match = value.match(/^(\d+(?:\.\d+)?)s$/);
+
+  if (match === null) {
+    return null;
+  }
+
+  const seconds = Number(match[1]);
+
+  return Number.isFinite(seconds) ? seconds : null;
+}
+
+function secondsToMinutes(seconds: number | null) {
+  if (seconds === null) {
+    return null;
+  }
+
+  return Math.max(0, Math.round(seconds / 60));
+}
+
+function sumNumbers(values: Array<number | undefined>) {
+  const numbers = values.filter(
+    (value): value is number =>
+      typeof value === "number" && Number.isFinite(value)
+  );
+
+  if (numbers.length === 0) {
+    return null;
+  }
+
+  return numbers.reduce((sum, value) => sum + value, 0);
+}
+
+function firstNonNull<T>(values: Array<T | null | undefined>) {
+  return (
+    values.find((value): value is T => value !== null && value !== undefined) ??
+    null
+  );
+}
+
+function getRouteDistanceMeters(route: GoogleRoute, legs: GoogleRouteLeg[]) {
+  return firstNonNull([
+    route.distanceMeters,
+    sumNumbers(legs.map((leg) => leg.distanceMeters))
+  ]);
+}
+
+function getRouteDurationMinutes(route: GoogleRoute, legs: GoogleRouteLeg[]) {
+  return secondsToMinutes(
+    firstNonNull([
+      parseDurationSeconds(route.duration),
+      sumNumbers(
+        legs.map((leg) => parseDurationSeconds(leg.duration) ?? undefined)
+      )
+    ])
+  );
+}
+
+function getRouteStaticDurationMinutes(
+  route: GoogleRoute,
+  legs: GoogleRouteLeg[]
+) {
+  return secondsToMinutes(
+    firstNonNull([
+      parseDurationSeconds(route.staticDuration),
+      sumNumbers(
+        legs.map((leg) => parseDurationSeconds(leg.staticDuration) ?? undefined)
+      )
+    ])
+  );
+}
+
+function getStepDurationMinutes(step: GoogleRouteStep) {
+  return secondsToMinutes(parseDurationSeconds(step.staticDuration));
+}
+
+function cleanText(value: string | undefined) {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue && trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function getTransitLineName(step: GoogleRouteStep) {
+  return (
+    cleanText(step.transitDetails?.transitLine?.name) ??
+    cleanText(step.transitDetails?.transitLine?.shortName)
+  );
+}
+
+function addUnique(values: string[], value: string | null) {
+  if (value === null) {
+    return;
+  }
+
+  if (
+    !values.some((candidate) => candidate.toLowerCase() === value.toLowerCase())
+  ) {
+    values.push(value);
+  }
+}
+
+function normalizeSteps(
+  steps: GoogleRouteStep[],
+  fallbackMode: RouteTravelMode
+): RouteHintStep[] {
+  return steps.map((step) => ({
+    distanceMeters:
+      typeof step.distanceMeters === "number" &&
+      Number.isFinite(step.distanceMeters)
+        ? step.distanceMeters
+        : null,
+    durationMinutes: getStepDurationMinutes(step),
+    instruction: cleanText(step.navigationInstruction?.instructions),
+    transitLineName: getTransitLineName(step),
+    travelMode: googleModeToRouteMode(step.travelMode, fallbackMode)
+  }));
+}
+
+function formatDistance(distanceMeters: number | null) {
+  if (distanceMeters === null) {
+    return null;
+  }
+
+  if (distanceMeters >= 1000) {
+    return `${Math.round((distanceMeters / 1000) * 10) / 10} km`;
+  }
+
+  return `${Math.round(distanceMeters)} m`;
+}
+
+function getTravelModeLabel(mode: RouteTravelMode) {
+  if (mode === "bicycle") {
+    return "Bicycle";
+  }
+
+  if (mode === "drive") {
+    return "Drive";
+  }
+
+  if (mode === "walk") {
+    return "Walk";
+  }
+
+  return "Transit";
+}
+
+function buildSummary(options: {
+  destinationLabel: string;
+  distanceMeters: number | null;
+  durationMinutes: number | null;
+  originLabel: string;
+  transitLineNames: string[];
+  travelMode: RouteTravelMode;
+}) {
+  const detailParts = [
+    options.durationMinutes !== null
+      ? `about ${options.durationMinutes} min`
+      : null,
+    formatDistance(options.distanceMeters),
+    options.transitLineNames.length > 0
+      ? `via ${options.transitLineNames.join(", ")}`
+      : null
+  ].filter((part): part is string => part !== null);
+  const detail = detailParts.length > 0 ? `, ${detailParts.join(", ")}` : "";
+
+  return `${getTravelModeLabel(options.travelMode)} route from ${
+    options.originLabel
+  } to ${options.destinationLabel}${detail}.`;
+}
+
+function createRouteHintId(input: RouteHintRequest, index: number) {
+  const slug = [input.origin.label, input.destination.label, input.travelMode]
+    .join("-")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  return `${googleRoutesProviderName}:${slug || "route"}:${index + 1}`;
+}
+
+function getModeWarnings(mode: RouteTravelMode) {
+  if (mode === "bicycle" || mode === "walk") {
+    return [
+      "Walking and bicycle route details may be incomplete; verify locally before traveling."
+    ];
+  }
+
+  return [];
+}
+
+export function normalizeGoogleRoutesResponse(
+  responseBody: unknown,
+  input: RouteHintRequest,
+  now: Date = new Date()
+): RouteHint[] {
+  const parsedResponse = googleRoutesResponseSchema.safeParse(responseBody);
+
+  if (!parsedResponse.success) {
+    throw new RouteProviderError();
+  }
+
+  const routes = parsedResponse.data.routes ?? [];
+  const maxAlternatives = input.maxAlternatives ?? 1;
+
+  return routes.slice(0, maxAlternatives).map((route, index) => {
+    const legs = route.legs ?? [];
+    const rawSteps = legs.flatMap((leg) => leg.steps ?? []);
+    const steps = normalizeSteps(rawSteps, input.travelMode);
+    const transitLineNames: string[] = [];
+
+    for (const step of steps) {
+      addUnique(transitLineNames, step.transitLineName);
+    }
+
+    const distanceMeters = getRouteDistanceMeters(route, legs);
+    const durationMinutes = getRouteDurationMinutes(route, legs);
+    const staticDurationMinutes = getRouteStaticDurationMinutes(route, legs);
+
+    return {
+      destination: { ...input.destination },
+      destinationLabel: input.destination.label,
+      distanceMeters,
+      durationMinutes,
+      id: createRouteHintId(input, index),
+      mapUrl: createGoogleMapsDirectionsUrl(input),
+      origin: { ...input.origin },
+      originLabel: input.origin.label,
+      provider: googleRoutesProviderName,
+      sourceUpdatedAt: now.toISOString(),
+      staticDurationMinutes,
+      steps,
+      summary: buildSummary({
+        destinationLabel: input.destination.label,
+        distanceMeters,
+        durationMinutes,
+        originLabel: input.origin.label,
+        transitLineNames,
+        travelMode: input.travelMode
+      }),
+      transitLineNames,
+      travelMode: input.travelMode,
+      warnings: getModeWarnings(input.travelMode)
+    };
+  });
+}
+
+export function createGoogleRoutesProvider(
+  options: GoogleRoutesProviderOptions = {}
+): RouteProvider {
+  const fetchImpl = options.fetch ?? fetch;
+  const baseUrl = options.baseUrl ?? defaultBaseUrl;
+  const fieldMask = options.fieldMask ?? defaultFieldMask;
+  const now = options.now ?? (() => new Date());
+
+  return {
+    name: googleRoutesProviderName,
+    async getRouteHints(input) {
+      const apiKey = requireApiKey(options.apiKey);
+      const responseBody = await fetchRoutes({
+        apiKey,
+        baseUrl,
+        body: buildGoogleRoutesRequestBody(input),
+        fetchImpl,
+        fieldMask
+      });
+
+      return normalizeGoogleRoutesResponse(responseBody, input, now());
+    }
+  };
+}

--- a/apps/api/src/providers/routes/routeProvider.test.ts
+++ b/apps/api/src/providers/routes/routeProvider.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  RouteProviderConfigurationError,
+  RouteProviderError,
+  type RouteHint,
+  type RouteProvider
+} from "./routeProvider.js";
+
+const routeHint = {
+  destination: {
+    address: "4 Chome Ueno, Taito City, Tokyo",
+    label: "Ameyoko lunch crawl"
+  },
+  destinationLabel: "Ameyoko lunch crawl",
+  distanceMeters: 900,
+  durationMinutes: 12,
+  id: "contract-test-provider:route-1",
+  mapUrl: "https://www.google.com/maps/dir/?api=1",
+  origin: {
+    address: "Uenokoen, Taito City, Tokyo",
+    label: "Morning walk through Ueno Park"
+  },
+  originLabel: "Morning walk through Ueno Park",
+  provider: "contract-test-provider",
+  sourceUpdatedAt: "2026-06-25T00:00:00.000Z",
+  staticDurationMinutes: 12,
+  steps: [
+    {
+      distanceMeters: 900,
+      durationMinutes: 12,
+      instruction: "Walk toward Ueno Station.",
+      transitLineName: null,
+      travelMode: "walk"
+    }
+  ],
+  summary:
+    "Walk route from Morning walk through Ueno Park to Ameyoko lunch crawl, about 12 min, 900 m.",
+  transitLineNames: [],
+  travelMode: "walk",
+  warnings: [
+    "Walking and bicycle route details may be incomplete; verify locally before traveling."
+  ]
+} satisfies RouteHint;
+
+describe("RouteProvider contract", () => {
+  test("uses normalized route hints independent of provider response shape", async () => {
+    const provider = {
+      name: "contract-test-provider",
+      getRouteHints: vi.fn<RouteProvider["getRouteHints"]>(async () => [
+        routeHint
+      ])
+    } satisfies RouteProvider;
+
+    await expect(
+      provider.getRouteHints({
+        destination: {
+          address: "4 Chome Ueno, Taito City, Tokyo",
+          label: "Ameyoko lunch crawl"
+        },
+        origin: {
+          address: "Uenokoen, Taito City, Tokyo",
+          label: "Morning walk through Ueno Park"
+        },
+        travelMode: "walk"
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({
+        destinationLabel: "Ameyoko lunch crawl",
+        originLabel: "Morning walk through Ueno Park",
+        provider: "contract-test-provider",
+        travelMode: "walk"
+      })
+    ]);
+  });
+
+  test("provides explicit error types for configuration and provider failures", () => {
+    expect(new RouteProviderConfigurationError()).toMatchObject({
+      message: "Route provider is not configured.",
+      name: "RouteProviderConfigurationError"
+    });
+    expect(new RouteProviderError()).toMatchObject({
+      message: "Route provider request failed.",
+      name: "RouteProviderError"
+    });
+  });
+});

--- a/apps/api/src/providers/routes/routeProvider.ts
+++ b/apps/api/src/providers/routes/routeProvider.ts
@@ -1,0 +1,64 @@
+export type RouteTravelMode = "bicycle" | "drive" | "transit" | "walk";
+
+export type RouteHintLocation = {
+  address?: string | undefined;
+  label: string;
+  latitude?: number | undefined;
+  longitude?: number | undefined;
+};
+
+export type RouteHintRequest = {
+  city?: string | undefined;
+  departureTime?: string | undefined;
+  destination: RouteHintLocation;
+  locale?: string | undefined;
+  maxAlternatives?: number | undefined;
+  origin: RouteHintLocation;
+  travelMode: RouteTravelMode;
+};
+
+export type RouteHintStep = {
+  distanceMeters: number | null;
+  durationMinutes: number | null;
+  instruction: string | null;
+  transitLineName: string | null;
+  travelMode: RouteTravelMode;
+};
+
+export type RouteHint = {
+  destination: RouteHintLocation;
+  destinationLabel: string;
+  distanceMeters: number | null;
+  durationMinutes: number | null;
+  id: string;
+  mapUrl: string | null;
+  origin: RouteHintLocation;
+  originLabel: string;
+  provider: string;
+  sourceUpdatedAt: string | null;
+  staticDurationMinutes: number | null;
+  steps: RouteHintStep[];
+  summary: string;
+  transitLineNames: string[];
+  travelMode: RouteTravelMode;
+  warnings: string[];
+};
+
+export type RouteProvider = {
+  getRouteHints: (input: RouteHintRequest) => Promise<RouteHint[]>;
+  name: string;
+};
+
+export class RouteProviderConfigurationError extends Error {
+  constructor() {
+    super("Route provider is not configured.");
+    this.name = "RouteProviderConfigurationError";
+  }
+}
+
+export class RouteProviderError extends Error {
+  constructor() {
+    super("Route provider request failed.");
+    this.name = "RouteProviderError";
+  }
+}

--- a/apps/api/src/routes/enrichment.test.ts
+++ b/apps/api/src/routes/enrichment.test.ts
@@ -12,6 +12,11 @@ import {
 } from "../providers/hotels/hotelProvider.js";
 import type { MapsProvider } from "../providers/maps/mapsProvider.js";
 import {
+  RouteProviderError,
+  type RouteHint,
+  type RouteProvider
+} from "../providers/routes/routeProvider.js";
+import {
   WeatherProviderError,
   type WeatherProvider,
   type WeatherSummary
@@ -51,6 +56,7 @@ function createEnrichmentTestApp(
     hotelProvider?: HotelProvider | undefined;
     mapsProvider?: MapsProvider | undefined;
     providerResultCache?: ProviderResultCache | undefined;
+    routeProvider?: RouteProvider | undefined;
     weatherProvider?: WeatherProvider | undefined;
   } = {}
 ) {
@@ -63,6 +69,9 @@ function createEnrichmentTestApp(
       : {}),
     ...(options.mapsProvider !== undefined
       ? { mapsProvider: options.mapsProvider }
+      : {}),
+    ...(options.routeProvider !== undefined
+      ? { routeProvider: options.routeProvider }
       : {}),
     ...(options.weatherProvider !== undefined
       ? { weatherProvider: options.weatherProvider }
@@ -132,6 +141,40 @@ const hotelSuggestion = {
   tags: ["Near Tokyo Station"],
   thumbnailUrl: "https://img.travel.rakuten.co.jp/thumb.jpg"
 } satisfies HotelSuggestion;
+
+const routeHint = {
+  destination: {
+    address: "4 Chome Ueno, Taito City, Tokyo",
+    label: "Ameyoko lunch crawl"
+  },
+  destinationLabel: "Ameyoko lunch crawl",
+  distanceMeters: 900,
+  durationMinutes: 12,
+  id: "test-route-provider:ueno-ameyoko:1",
+  mapUrl: "https://www.google.com/maps/dir/?api=1",
+  origin: {
+    address: "Uenokoen, Taito City, Tokyo",
+    label: "Morning walk through Ueno Park"
+  },
+  originLabel: "Morning walk through Ueno Park",
+  provider: "test-route-provider",
+  sourceUpdatedAt: "2026-06-25T00:00:00.000Z",
+  staticDurationMinutes: 12,
+  steps: [
+    {
+      distanceMeters: 900,
+      durationMinutes: 12,
+      instruction: "Walk toward Ameyoko.",
+      transitLineName: null,
+      travelMode: "walk"
+    }
+  ],
+  summary:
+    "Walk route from Morning walk through Ueno Park to Ameyoko lunch crawl, about 12 min, 900 m.",
+  transitLineNames: [],
+  travelMode: "walk",
+  warnings: []
+} satisfies RouteHint;
 
 describe("POST /api/enrichment/hotels/suggestions", () => {
   test("returns normalized hotel suggestions", async () => {
@@ -372,6 +415,160 @@ describe("POST /api/enrichment/maps/link", () => {
     expect(response.body).toEqual({
       mapUrl: null
     });
+  });
+});
+
+describe("POST /api/enrichment/routes/hints", () => {
+  const payload = {
+    destination: {
+      address: "4 Chome Ueno, Taito City, Tokyo",
+      label: "Ameyoko lunch crawl"
+    },
+    origin: {
+      address: "Uenokoen, Taito City, Tokyo",
+      label: "Morning walk through Ueno Park"
+    },
+    travelMode: "walk"
+  };
+
+  test("returns normalized route hints", async () => {
+    const routeProvider = {
+      getRouteHints: vi.fn(async () => [routeHint]),
+      name: "test-route-provider"
+    } satisfies RouteProvider;
+    const response = await request(createEnrichmentTestApp({ routeProvider }))
+      .post("/api/enrichment/routes/hints")
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(routeProvider.getRouteHints).toHaveBeenCalledWith({
+      ...payload,
+      maxAlternatives: 1
+    });
+    expect(response.body).toEqual({
+      routeHints: [routeHint],
+      status: "available"
+    });
+  });
+
+  test("returns structured validation errors for invalid route input", async () => {
+    const response = await request(
+      createEnrichmentTestApp({
+        routeProvider: {
+          getRouteHints: vi.fn(async () => [routeHint]),
+          name: "test-route-provider"
+        }
+      })
+    )
+      .post("/api/enrichment/routes/hints")
+      .send({
+        destination: {
+          label: "Ameyoko lunch crawl"
+        },
+        origin: {
+          label: "",
+          latitude: 35.7156
+        },
+        travelMode: "transit"
+      });
+
+    expect(response.status).toBe(400);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "Request validation failed."
+    });
+    expect(response.body.error.fieldErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "destination.address"
+        }),
+        expect.objectContaining({
+          path: "origin.label"
+        }),
+        expect.objectContaining({
+          path: "origin.longitude"
+        })
+      ])
+    );
+  });
+
+  test("returns a structured missing config error when Google config is absent", async () => {
+    const response = await request(createEnrichmentTestApp())
+      .post("/api/enrichment/routes/hints")
+      .send(payload);
+
+    expect(response.status).toBe(503);
+    expect(apiErrorSchema.safeParse(response.body).success).toBe(true);
+    expect(response.body.error).toEqual({
+      code: "ROUTE_PROVIDER_CONFIGURATION_ERROR",
+      message: "Route enrichment is not configured."
+    });
+  });
+
+  test("degrades provider failure to unavailable route hints", async () => {
+    const routeProvider = {
+      getRouteHints: vi.fn(async () => {
+        throw new RouteProviderError();
+      }),
+      name: "test-route-provider"
+    } satisfies RouteProvider;
+    const response = await request(createEnrichmentTestApp({ routeProvider }))
+      .post("/api/enrichment/routes/hints")
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      routeHints: [],
+      status: "unavailable"
+    });
+  });
+
+  test("returns empty route hints when provider has no route", async () => {
+    const routeProvider = {
+      getRouteHints: vi.fn(async () => []),
+      name: "test-route-provider"
+    } satisfies RouteProvider;
+    const response = await request(createEnrichmentTestApp({ routeProvider }))
+      .post("/api/enrichment/routes/hints")
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      routeHints: [],
+      status: "empty"
+    });
+  });
+
+  test("uses cached route hints for a second identical enrichment request", async () => {
+    const routeProvider = {
+      getRouteHints: vi.fn(async () => [routeHint]),
+      name: "test-route-provider"
+    } satisfies RouteProvider;
+    const app = createEnrichmentTestApp({ routeProvider });
+
+    const firstResponse = await request(app)
+      .post("/api/enrichment/routes/hints")
+      .send(payload);
+    const secondResponse = await request(app)
+      .post("/api/enrichment/routes/hints")
+      .send({
+        destination: {
+          address: "  4 Chome Ueno, Taito City, Tokyo ",
+          label: "Ameyoko lunch crawl"
+        },
+        maxAlternatives: 1,
+        origin: {
+          address: "Uenokoen, Taito City, Tokyo",
+          label: "Morning walk through Ueno Park"
+        },
+        travelMode: "walk"
+      });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.body).toEqual(firstResponse.body);
+    expect(routeProvider.getRouteHints).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/api/src/routes/enrichment.ts
+++ b/apps/api/src/routes/enrichment.ts
@@ -9,12 +9,17 @@ import {
 } from "../providers/hotels/hotelProvider.js";
 import type { MapsProvider } from "../providers/maps/mapsProvider.js";
 import {
+  RouteProviderConfigurationError,
+  type RouteProvider
+} from "../providers/routes/routeProvider.js";
+import {
   WeatherProviderConfigurationError,
   type WeatherProvider
 } from "../providers/weather/weatherProvider.js";
 import type { ProviderResultCache } from "../services/enrichment/cache.js";
 import { createCachedHotelSuggestions } from "../services/enrichment/hotelEnrichment.js";
 import { createCachedMapLink } from "../services/enrichment/mapEnrichment.js";
+import { createCachedRouteHints } from "../services/enrichment/routeEnrichment.js";
 import { createCachedWeatherSummary } from "../services/enrichment/weatherEnrichment.js";
 
 const mapLinkBodySchema = z
@@ -108,6 +113,53 @@ const hotelSuggestionsBodySchema = z
     }
   });
 
+const routeHintLocationBodySchema = z
+  .object({
+    address: z.string().trim().min(1).optional(),
+    label: z.string().trim().min(1),
+    latitude: z.number().min(-90).max(90).optional(),
+    longitude: z.number().min(-180).max(180).optional()
+  })
+  .strict()
+  .superRefine((location, context) => {
+    const hasLatitude = location.latitude !== undefined;
+    const hasLongitude = location.longitude !== undefined;
+
+    if (hasLatitude !== hasLongitude) {
+      context.addIssue({
+        code: "custom",
+        message: "Provide both latitude and longitude.",
+        path: hasLatitude ? ["longitude"] : ["latitude"]
+      });
+    }
+
+    if (!location.address && !(hasLatitude && hasLongitude)) {
+      context.addIssue({
+        code: "custom",
+        message: "Provide either address or latitude and longitude.",
+        path: ["address"]
+      });
+    }
+  });
+
+const routeHintsBodySchema = z
+  .object({
+    city: z.string().trim().min(1).optional(),
+    departureTime: z
+      .string()
+      .regex(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
+        "Expected an ISO 8601 date-time with timezone."
+      )
+      .optional(),
+    destination: routeHintLocationBodySchema,
+    locale: z.string().trim().min(2).max(20).optional(),
+    maxAlternatives: z.number().int().min(1).max(3).default(1),
+    origin: routeHintLocationBodySchema,
+    travelMode: z.enum(["bicycle", "drive", "transit", "walk"])
+  })
+  .strict();
+
 function asyncHandler(handler: RequestHandler): RequestHandler {
   return (request, response, next) => {
     Promise.resolve(handler(request, response, next)).catch(next);
@@ -118,6 +170,7 @@ export function createEnrichmentRouter(options: {
   hotelProvider: HotelProvider;
   mapsProvider: MapsProvider;
   providerResultCache: ProviderResultCache;
+  routeProvider: RouteProvider;
   weatherProvider: WeatherProvider;
 }) {
   const router = Router();
@@ -159,6 +212,32 @@ export function createEnrichmentRouter(options: {
           options.providerResultCache
         )
       });
+    })
+  );
+
+  router.post(
+    "/routes/hints",
+    validateRequest(routeHintsBodySchema),
+    asyncHandler(async (request, response) => {
+      try {
+        const result = await createCachedRouteHints(
+          request.body,
+          options.routeProvider,
+          options.providerResultCache
+        );
+
+        response.status(200).json(result);
+      } catch (error) {
+        if (error instanceof RouteProviderConfigurationError) {
+          throw new ApiError({
+            code: "ROUTE_PROVIDER_CONFIGURATION_ERROR",
+            message: "Route enrichment is not configured.",
+            statusCode: 503
+          });
+        }
+
+        throw error;
+      }
     })
   );
 

--- a/apps/api/src/services/enrichment/routeEnrichment.test.ts
+++ b/apps/api/src/services/enrichment/routeEnrichment.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  RouteProviderConfigurationError,
+  RouteProviderError,
+  type RouteHint,
+  type RouteHintRequest,
+  type RouteProvider
+} from "../../providers/routes/routeProvider.js";
+import type {
+  ProviderResultRecord,
+  ProviderResultRepository,
+  ProviderResultWriteInput
+} from "../../repositories/providerResultRepository.js";
+import { createProviderResultCache } from "./cache.js";
+import { createCachedRouteHints, createRouteHints } from "./routeEnrichment.js";
+
+const routeRequest = {
+  destination: {
+    address: "4 Chome Ueno, Taito City, Tokyo",
+    label: "Ameyoko lunch crawl"
+  },
+  origin: {
+    address: "Uenokoen, Taito City, Tokyo",
+    label: "Morning walk through Ueno Park"
+  },
+  travelMode: "walk"
+} satisfies RouteHintRequest;
+
+const routeHint = {
+  destination: routeRequest.destination,
+  destinationLabel: "Ameyoko lunch crawl",
+  distanceMeters: 900,
+  durationMinutes: 12,
+  id: "test-route-provider:ueno-ameyoko:1",
+  mapUrl: "https://www.google.com/maps/dir/?api=1",
+  origin: routeRequest.origin,
+  originLabel: "Morning walk through Ueno Park",
+  provider: "test-route-provider",
+  sourceUpdatedAt: "2026-06-25T00:00:00.000Z",
+  staticDurationMinutes: 12,
+  steps: [
+    {
+      distanceMeters: 900,
+      durationMinutes: 12,
+      instruction: "Walk toward Ameyoko.",
+      transitLineName: null,
+      travelMode: "walk"
+    }
+  ],
+  summary:
+    "Walk route from Morning walk through Ueno Park to Ameyoko lunch crawl, about 12 min, 900 m.",
+  transitLineNames: [],
+  travelMode: "walk",
+  warnings: []
+} satisfies RouteHint;
+
+class InMemoryProviderResultRepository implements ProviderResultRepository {
+  private readonly records = new Map<string, ProviderResultRecord>();
+  private nextId = 1;
+
+  async findUsable(cacheKey: string, now = new Date()) {
+    const record = this.records.get(cacheKey);
+
+    if (record === undefined || record.expiresAt <= now) {
+      return null;
+    }
+
+    return structuredClone(record);
+  }
+
+  async upsert(input: ProviderResultWriteInput) {
+    const timestamp = new Date("2026-06-25T00:00:00.000Z");
+    const existingRecord = this.records.get(input.cacheKey);
+    const record: ProviderResultRecord = {
+      id: existingRecord?.id ?? `provider-result-${this.nextId++}`,
+      provider: input.provider,
+      operation: input.operation,
+      cacheKey: input.cacheKey,
+      requestHash: input.requestHash,
+      requestJson: structuredClone(input.requestJson),
+      responseJson: structuredClone(input.responseJson),
+      expiresAt: input.expiresAt,
+      createdAt: existingRecord?.createdAt ?? timestamp,
+      updatedAt: timestamp
+    };
+
+    this.records.set(input.cacheKey, record);
+
+    return structuredClone(record);
+  }
+}
+
+function createProvider(
+  getRouteHints: RouteProvider["getRouteHints"]
+): RouteProvider {
+  return {
+    getRouteHints,
+    name: "test-route-provider"
+  };
+}
+
+describe("createRouteHints", () => {
+  test("returns available route hints", async () => {
+    const provider = createProvider(vi.fn(async () => [routeHint]));
+
+    await expect(createRouteHints(routeRequest, provider)).resolves.toEqual({
+      routeHints: [routeHint],
+      status: "available"
+    });
+  });
+
+  test("returns empty when the provider has no route", async () => {
+    const provider = createProvider(vi.fn(async () => []));
+
+    await expect(createRouteHints(routeRequest, provider)).resolves.toEqual({
+      routeHints: [],
+      status: "empty"
+    });
+  });
+
+  test("preserves provider configuration failures for route-level handling", async () => {
+    const provider = createProvider(
+      vi.fn(async () => {
+        throw new RouteProviderConfigurationError();
+      })
+    );
+
+    await expect(createRouteHints(routeRequest, provider)).rejects.toThrow(
+      RouteProviderConfigurationError
+    );
+  });
+
+  test("degrades provider failures to unavailable route hints", async () => {
+    const provider = createProvider(
+      vi.fn(async () => {
+        throw new RouteProviderError();
+      })
+    );
+
+    await expect(createRouteHints(routeRequest, provider)).resolves.toEqual({
+      routeHints: [],
+      status: "unavailable"
+    });
+  });
+});
+
+describe("createCachedRouteHints", () => {
+  test("reuses cached successful route hints", async () => {
+    const provider = createProvider(vi.fn(async () => [routeHint]));
+    const cache = createProviderResultCache(
+      new InMemoryProviderResultRepository()
+    );
+
+    const firstResult = await createCachedRouteHints(
+      routeRequest,
+      provider,
+      cache
+    );
+    const secondResult = await createCachedRouteHints(
+      {
+        destination: {
+          address: "  4 Chome Ueno, Taito City, Tokyo  ",
+          label: "Ameyoko lunch crawl"
+        },
+        maxAlternatives: 1,
+        origin: {
+          address: "Uenokoen, Taito City, Tokyo",
+          label: "Morning walk through Ueno Park"
+        },
+        travelMode: "walk"
+      },
+      provider,
+      cache
+    );
+
+    expect(firstResult).toEqual({
+      routeHints: [routeHint],
+      status: "available"
+    });
+    expect(secondResult).toEqual(firstResult);
+    expect(provider.getRouteHints).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not cache unavailable route provider failures", async () => {
+    const provider = createProvider(
+      vi
+        .fn<RouteProvider["getRouteHints"]>()
+        .mockRejectedValueOnce(new RouteProviderError())
+        .mockResolvedValueOnce([routeHint])
+    );
+    const cache = createProviderResultCache(
+      new InMemoryProviderResultRepository()
+    );
+
+    await expect(
+      createCachedRouteHints(routeRequest, provider, cache)
+    ).resolves.toEqual({
+      routeHints: [],
+      status: "unavailable"
+    });
+    await expect(
+      createCachedRouteHints(routeRequest, provider, cache)
+    ).resolves.toEqual({
+      routeHints: [routeHint],
+      status: "available"
+    });
+    expect(provider.getRouteHints).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/services/enrichment/routeEnrichment.ts
+++ b/apps/api/src/services/enrichment/routeEnrichment.ts
@@ -1,0 +1,172 @@
+import {
+  RouteProviderConfigurationError,
+  RouteProviderError,
+  type RouteHint,
+  type RouteHintLocation,
+  type RouteHintRequest,
+  type RouteHintStep,
+  type RouteProvider
+} from "../../providers/routes/routeProvider.js";
+import type { ProviderResultCache } from "./cache.js";
+
+export const routeHintsCacheTtlMs = 12 * 60 * 60 * 1000;
+
+export type RouteEnrichmentResult =
+  | {
+      routeHints: RouteHint[];
+      status: "available";
+    }
+  | {
+      routeHints: RouteHint[];
+      status: "empty" | "unavailable";
+    };
+
+export async function createRouteHints(
+  input: RouteHintRequest,
+  provider: RouteProvider
+): Promise<RouteEnrichmentResult> {
+  try {
+    const routeHints = await provider.getRouteHints(input);
+
+    if (routeHints.length === 0) {
+      return {
+        routeHints: [],
+        status: "empty"
+      };
+    }
+
+    return {
+      routeHints,
+      status: "available"
+    };
+  } catch (error) {
+    if (error instanceof RouteProviderConfigurationError) {
+      throw error;
+    }
+
+    if (error instanceof RouteProviderError) {
+      return {
+        routeHints: [],
+        status: "unavailable"
+      };
+    }
+
+    return {
+      routeHints: [],
+      status: "unavailable"
+    };
+  }
+}
+
+function isRouteHintLocation(value: unknown): value is RouteHintLocation {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const location = value as Partial<RouteHintLocation>;
+
+  return typeof location.label === "string";
+}
+
+function isRouteHintStep(value: unknown): value is RouteHintStep {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const step = value as Partial<RouteHintStep>;
+
+  return (
+    (step.instruction === null || typeof step.instruction === "string") &&
+    typeof step.travelMode === "string" &&
+    (step.distanceMeters === null || typeof step.distanceMeters === "number") &&
+    (step.durationMinutes === null ||
+      typeof step.durationMinutes === "number") &&
+    (step.transitLineName === null || typeof step.transitLineName === "string")
+  );
+}
+
+function isRouteHint(value: unknown): value is RouteHint {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const hint = value as Partial<RouteHint>;
+
+  return (
+    typeof hint.id === "string" &&
+    typeof hint.provider === "string" &&
+    typeof hint.originLabel === "string" &&
+    typeof hint.destinationLabel === "string" &&
+    isRouteHintLocation(hint.origin) &&
+    isRouteHintLocation(hint.destination) &&
+    typeof hint.travelMode === "string" &&
+    typeof hint.summary === "string" &&
+    Array.isArray(hint.transitLineNames) &&
+    Array.isArray(hint.steps) &&
+    hint.steps.every(isRouteHintStep) &&
+    Array.isArray(hint.warnings)
+  );
+}
+
+export function isRouteEnrichmentResult(
+  value: unknown
+): value is RouteEnrichmentResult {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const result = value as Partial<RouteEnrichmentResult>;
+
+  if (result.status === "available") {
+    return (
+      Array.isArray(result.routeHints) && result.routeHints.every(isRouteHint)
+    );
+  }
+
+  return (
+    (result.status === "empty" || result.status === "unavailable") &&
+    Array.isArray(result.routeHints) &&
+    result.routeHints.length === 0
+  );
+}
+
+function normalizeLocation(input: RouteHintLocation) {
+  return {
+    ...(input.address !== undefined ? { address: input.address } : {}),
+    label: input.label,
+    ...(input.latitude !== undefined ? { latitude: input.latitude } : {}),
+    ...(input.longitude !== undefined ? { longitude: input.longitude } : {})
+  };
+}
+
+export function normalizeRouteHintsCacheInput(input: RouteHintRequest) {
+  return {
+    ...(input.city !== undefined ? { city: input.city } : {}),
+    ...(input.departureTime !== undefined
+      ? { departureTime: input.departureTime }
+      : {}),
+    destination: normalizeLocation(input.destination),
+    ...(input.locale !== undefined ? { locale: input.locale } : {}),
+    maxAlternatives: input.maxAlternatives ?? 1,
+    origin: normalizeLocation(input.origin),
+    travelMode: input.travelMode
+  };
+}
+
+export async function createCachedRouteHints(
+  input: RouteHintRequest,
+  provider: RouteProvider,
+  cache: ProviderResultCache
+): Promise<RouteEnrichmentResult> {
+  const result = await cache.getOrSet({
+    provider: provider.name,
+    operation: "routes.hints",
+    input: normalizeRouteHintsCacheInput(input),
+    ttlMs: routeHintsCacheTtlMs,
+    load: () => createRouteHints(input, provider),
+    isCachedValue: isRouteEnrichmentResult,
+    shouldCache: (routeResult) => routeResult.status !== "unavailable"
+  });
+
+  return result.value;
+}

--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -34,6 +34,48 @@ const hotelSuggestionsFixture = [
     thumbnailUrl: "https://img.travel.rakuten.co.jp/thumb.jpg"
   }
 ];
+const routeHintsFixture = [
+  {
+    destination: {
+      address: "Asakusa, Tokyo",
+      label: "Generated Asakusa lunch"
+    },
+    destinationLabel: "Generated Asakusa lunch",
+    distanceMeters: 1200,
+    durationMinutes: 14,
+    id: "google-routes:generated-sensoji-generated-lunch:1",
+    mapUrl: "https://www.google.com/maps/dir/?api=1",
+    origin: {
+      address: "Senso-ji, Tokyo",
+      label: "Generated Senso-ji morning"
+    },
+    originLabel: "Generated Senso-ji morning",
+    provider: "google-routes",
+    sourceUpdatedAt: "2026-06-25T00:00:00.000Z",
+    staticDurationMinutes: 13,
+    steps: [
+      {
+        distanceMeters: 400,
+        durationMinutes: 5,
+        instruction: "Walk to Asakusa Station.",
+        transitLineName: null,
+        travelMode: "walk"
+      },
+      {
+        distanceMeters: 800,
+        durationMinutes: 8,
+        instruction: "Take the Ginza Line one stop.",
+        transitLineName: "Tokyo Metro Ginza Line",
+        travelMode: "transit"
+      }
+    ],
+    summary:
+      "Transit route from Generated Senso-ji morning to Generated Asakusa lunch, about 14 min, 1.2 km, via Tokyo Metro Ginza Line.",
+    transitLineNames: ["Tokyo Metro Ginza Line"],
+    travelMode: "transit",
+    warnings: []
+  }
+];
 
 const generatedItineraryFixture = {
   title: "AI Generated Tokyo And Kyoto Route",
@@ -190,6 +232,44 @@ async function routeHotelSuggestions(page: Page) {
 
   return {
     getHotelSuggestionRequests: () => hotelSuggestionRequests
+  };
+}
+
+async function routeRouteHints(page: Page) {
+  let routeHintRequests = 0;
+
+  await page.route("**/api/enrichment/routes/hints", async (route) => {
+    if (isOptionsRequest(route)) {
+      await fulfillOptions(route);
+      return;
+    }
+
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().postDataJSON()).toMatchObject({
+      city: "Tokyo",
+      destination: {
+        label: "Generated Asakusa lunch"
+      },
+      origin: {
+        label: "Generated Senso-ji morning"
+      },
+      travelMode: "transit"
+    });
+    routeHintRequests += 1;
+
+    await route.fulfill({
+      contentType: "application/json",
+      headers: corsHeaders,
+      json: {
+        routeHints: routeHintsFixture,
+        status: "available"
+      },
+      status: 200
+    });
+  });
+
+  return {
+    getRouteHintRequests: () => routeHintRequests
   };
 }
 
@@ -565,6 +645,7 @@ test("traveler can generate and edit an itinerary from a mocked AI API response"
 }) => {
   await routeGeneratedItinerary(page);
   const hotels = await routeHotelSuggestions(page);
+  const routes = await routeRouteHints(page);
 
   await page.goto("/");
   await page.getByRole("button", { name: "API" }).click();
@@ -600,6 +681,14 @@ test("traveler can generate and edit an itinerary from a mocked AI API response"
     page.getByRole("heading", { name: "Tokyo Station Stay" })
   ).toBeVisible();
   await expect.poll(() => hotels.getHotelSuggestionRequests()).toBe(1);
+  await page.getByRole("button", { name: "Find route" }).click();
+  await expect(
+    page.getByRole("heading", {
+      name: "Generated Senso-ji morning to Generated Asakusa lunch"
+    })
+  ).toBeVisible();
+  await expect(page.getByText("Tokyo Metro Ginza Line").first()).toBeVisible();
+  await expect.poll(() => routes.getRouteHintRequests()).toBe(1);
 
   await page
     .getByRole("button", { name: "Edit Generated Senso-ji morning" })

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -362,6 +362,7 @@ select {
 
 .export-controls,
 .hotel-suggestions,
+.route-hints,
 .share-controls {
   display: grid;
   gap: 14px;
@@ -371,6 +372,7 @@ select {
 
 .export-controls h3,
 .hotel-suggestions h3,
+.route-hints h3,
 .share-controls h3 {
   margin: 8px 0 0;
   color: #172026;
@@ -381,6 +383,7 @@ select {
 
 .export-help,
 .hotel-suggestions-help,
+.route-hints-help,
 .share-help {
   margin: 0;
   color: #52616d;
@@ -390,6 +393,7 @@ select {
 
 .export-controls > button,
 .hotel-suggestions > button,
+.route-hints > button,
 .share-controls > button,
 .share-url-field button {
   width: 100%;
@@ -404,13 +408,15 @@ select {
 
 .export-controls > button:disabled,
 .hotel-suggestions > button:disabled,
+.route-hints > button:disabled,
 .share-controls > button:disabled {
   cursor: not-allowed;
   opacity: 0.72;
 }
 
 .export-error,
-.hotel-suggestions-alert {
+.hotel-suggestions-alert,
+.route-hints-alert {
   margin: 0;
   border: 1px solid #efb6ae;
   border-radius: 6px;
@@ -534,6 +540,134 @@ select {
 }
 
 .hotel-suggestion-links a {
+  color: #0d3b4f;
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.route-hint-list {
+  display: grid;
+  gap: 12px;
+}
+
+.route-hint-card {
+  display: grid;
+  gap: 10px;
+  border: 1px solid #d8e0e6;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 12px;
+}
+
+.route-hint-mode,
+.route-hint-card h4,
+.route-hint-card p,
+.route-hint-meta,
+.route-hint-lines,
+.route-hint-warnings,
+.route-hint-steps {
+  margin: 0;
+}
+
+.route-hint-mode {
+  color: #be3f32;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.route-hint-card h4 {
+  color: #172026;
+  font-size: 0.98rem;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+.route-hint-card p,
+.route-hint-steps small {
+  color: #52616d;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.route-hint-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.route-hint-meta div {
+  min-width: 0;
+  border: 1px solid #dce4ea;
+  border-radius: 6px;
+  background: #f8fafb;
+  padding: 7px 8px;
+}
+
+.route-hint-meta dt {
+  color: #657480;
+  font-size: 0.66rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.route-hint-meta dd {
+  margin: 3px 0 0;
+  color: #172026;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.route-hint-lines,
+.route-hint-warnings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0;
+  list-style: none;
+}
+
+.route-hint-lines li {
+  border-radius: 999px;
+  background: #edf4f6;
+  color: #0d3b4f;
+  font-size: 0.72rem;
+  font-weight: 800;
+  padding: 5px 8px;
+}
+
+.route-hint-warnings li {
+  border: 1px solid #e8c9a4;
+  border-radius: 6px;
+  background: #fff7ed;
+  color: #8a4a0a;
+  font-size: 0.76rem;
+  font-weight: 800;
+  line-height: 1.35;
+  padding: 6px 8px;
+}
+
+.route-hint-steps {
+  display: grid;
+  gap: 8px;
+  padding-left: 18px;
+}
+
+.route-hint-steps li {
+  color: #172026;
+  font-size: 0.84rem;
+  font-weight: 800;
+  line-height: 1.35;
+  padding-left: 2px;
+}
+
+.route-hint-steps span,
+.route-hint-steps small {
+  display: block;
+}
+
+.route-hint-card a {
+  width: max-content;
   color: #0d3b4f;
   font-size: 0.84rem;
   font-weight: 800;
@@ -1094,6 +1228,10 @@ select {
   }
 
   .itinerary-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .route-hint-meta {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -19,6 +19,8 @@ describe("App", () => {
     expect(html).toContain("Save this itinerary before exporting a PDF.");
     expect(html).toContain("Hotel suggestions");
     expect(html).toContain("Create an itinerary before searching hotels.");
+    expect(html).toContain("Route hints");
+    expect(html).toContain("Create an itinerary before searching routes.");
     expect(html).toContain("Read-only share link");
     expect(html).toContain(
       "Save this itinerary before creating a public share link."

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,10 @@ import "./App.css";
 
 import { useMemo, useState } from "react";
 
+import type {
+  Activity,
+  Itinerary
+} from "../../../packages/shared/src/schemas/itinerary.js";
 import type { TripRequest } from "../../../packages/shared/src/schemas/tripRequest.js";
 import {
   downloadPdfFile,
@@ -17,6 +21,10 @@ import {
   useItineraryEditor
 } from "./features/itinerary/editing/useItineraryEditor.js";
 import { useGeneratedItinerary } from "./features/itinerary/useGeneratedItinerary.js";
+import {
+  RouteHints,
+  type RouteHintsStatus
+} from "./features/routes/RouteHints.js";
 import { ShareControls } from "./features/sharing/ShareControls.js";
 import { TripIntakeForm } from "./features/trip-intake/index.js";
 import {
@@ -26,7 +34,11 @@ import {
   type TripDataMode
 } from "./features/trips/useTrips.js";
 import { createTripApiClient } from "./lib/api/client.js";
-import type { HotelSuggestion } from "./lib/api/types.js";
+import type {
+  HotelSuggestion,
+  RouteHint,
+  RouteHintLocation
+} from "./lib/api/types.js";
 import { mockItinerary } from "./mocks/index.js";
 import { SharedTripPage } from "./routes/SharedTripPage.js";
 
@@ -62,6 +74,68 @@ function getCurrentPathname() {
   return typeof window === "undefined" ? "/" : window.location.pathname;
 }
 
+function getActivityRouteAddress(activity: Activity) {
+  return (
+    activity.location.address ??
+    [activity.location.name, activity.location.city]
+      .filter((part): part is string => Boolean(part))
+      .join(", ")
+  );
+}
+
+function getActivityRouteLocation(
+  activity: Activity
+): RouteHintLocation | null {
+  const address = getActivityRouteAddress(activity).trim();
+  const { latitude, longitude } = activity.location;
+  const hasCoordinates = latitude !== undefined && longitude !== undefined;
+
+  if (address.length === 0 && !hasCoordinates) {
+    return null;
+  }
+
+  return {
+    ...(address.length > 0 ? { address } : {}),
+    label: activity.title,
+    ...(hasCoordinates
+      ? {
+          latitude,
+          longitude
+        }
+      : {})
+  };
+}
+
+function getRouteHintTarget(itinerary: Itinerary | null) {
+  if (!itinerary) {
+    return null;
+  }
+
+  for (const day of itinerary.days) {
+    for (let index = 0; index < day.activities.length - 1; index += 1) {
+      const originActivity = day.activities[index];
+      const destinationActivity = day.activities[index + 1];
+
+      if (!originActivity || !destinationActivity) {
+        continue;
+      }
+
+      const origin = getActivityRouteLocation(originActivity);
+      const destination = getActivityRouteLocation(destinationActivity);
+
+      if (origin !== null && destination !== null) {
+        return {
+          city: day.city,
+          destination,
+          origin
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
 export function App() {
   const shareToken = getShareTokenFromPathname(getCurrentPathname());
   const [activeRequest, setActiveRequest] = useState<TripRequest | null>(null);
@@ -82,6 +156,10 @@ export function App() {
   >(null);
   const [hotelSuggestionsStatus, setHotelSuggestionsStatus] =
     useState<HotelSuggestionsStatus>("idle");
+  const [routeHints, setRouteHints] = useState<RouteHint[]>([]);
+  const [routeHintsError, setRouteHintsError] = useState<string | null>(null);
+  const [routeHintsStatus, setRouteHintsStatus] =
+    useState<RouteHintsStatus>("idle");
   const tripApiClient = useMemo(() => createTripApiClient(), []);
   const generatedItinerary = useGeneratedItinerary();
   const itineraryEditor = useItineraryEditor(null);
@@ -105,11 +183,22 @@ export function App() {
     : undefined;
   const hotelTargetCity =
     itinerary?.days[0]?.city ?? activeRequest?.cities[0] ?? null;
+  const routeHintTarget = useMemo(
+    () => getRouteHintTarget(itinerary),
+    [itinerary]
+  );
   const hotelDisabledReason =
     !itinerary || !activeRequest || !hotelTargetCity
       ? "Create an itinerary before searching hotels."
       : isSubmitting
         ? "Wait for the itinerary to finish before searching hotels."
+        : undefined;
+  const routeHintsDisabledReason = !itinerary
+    ? "Create an itinerary before searching routes."
+    : !routeHintTarget
+      ? "Add at least two located activities before searching routes."
+      : isSubmitting
+        ? "Wait for the itinerary to finish before searching routes."
         : undefined;
   const shareDisabledReason =
     dataMode === "mock"
@@ -179,11 +268,18 @@ export function App() {
     setHotelSuggestionsStatus("idle");
   }
 
+  function resetRouteHints() {
+    setRouteHints([]);
+    setRouteHintsError(null);
+    setRouteHintsStatus("idle");
+  }
+
   function handleMockSubmit(request: TripRequest) {
     setActiveRequest(request);
     setLocalError(null);
     setExportErrorMessage(null);
     resetHotelSuggestions();
+    resetRouteHints();
     trips.clearError();
     generatedItinerary.clearError();
     setIsMockSubmitting(true);
@@ -206,6 +302,7 @@ export function App() {
     setLocalError(null);
     setExportErrorMessage(null);
     resetHotelSuggestions();
+    resetRouteHints();
     trips.clearError();
     generatedItinerary.clearError();
     resetToItinerary(null);
@@ -233,6 +330,7 @@ export function App() {
     setLocalError(null);
     setExportErrorMessage(null);
     setHotelSuggestionsError(null);
+    setRouteHintsError(null);
     generatedItinerary.clearError();
 
     const result = await trips.saveTrip(
@@ -252,6 +350,7 @@ export function App() {
     setLocalError(null);
     setExportErrorMessage(null);
     setHotelSuggestionsError(null);
+    resetRouteHints();
     trips.clearError();
     generatedItinerary.clearError();
   }
@@ -265,6 +364,7 @@ export function App() {
     setLocalError(null);
     setExportErrorMessage(null);
     resetHotelSuggestions();
+    resetRouteHints();
     generatedItinerary.clearError();
 
     const result = await trips.reopenTrip(trips.selectedTripId);
@@ -279,6 +379,7 @@ export function App() {
     setLocalError(null);
     setExportErrorMessage(null);
     setHotelSuggestionsError(null);
+    setRouteHintsError(null);
     generatedItinerary.clearError();
     await trips.loadSavedTrips();
   }
@@ -313,6 +414,37 @@ export function App() {
     }
   }
 
+  async function handleLoadRouteHints() {
+    if (!routeHintTarget) {
+      setRouteHints([]);
+      setRouteHintsError("Create an itinerary before searching routes.");
+      setRouteHintsStatus("error");
+      return;
+    }
+
+    setRouteHints([]);
+    setRouteHintsError(null);
+    setRouteHintsStatus("loading");
+
+    try {
+      const result = await tripApiClient.getRouteHints({
+        city: routeHintTarget.city,
+        destination: routeHintTarget.destination,
+        locale: "en-US",
+        maxAlternatives: 1,
+        origin: routeHintTarget.origin,
+        travelMode: "transit"
+      });
+
+      setRouteHints(result.routeHints);
+      setRouteHintsStatus(result.status);
+    } catch (error) {
+      setRouteHints([]);
+      setRouteHintsError(getTripErrorMessage(error));
+      setRouteHintsStatus("error");
+    }
+  }
+
   async function handleExportPdf() {
     if (!trips.selectedTripId) {
       setExportErrorMessage("Save this itinerary before exporting a PDF.");
@@ -342,6 +474,7 @@ export function App() {
     setLocalError(null);
     setExportErrorMessage(null);
     setHotelSuggestionsError(null);
+    setRouteHintsError(null);
     generatedItinerary.clearError();
     await trips.createShareLink(trips.selectedTripId);
   }
@@ -351,6 +484,7 @@ export function App() {
     setLocalError(null);
     setExportErrorMessage(null);
     resetHotelSuggestions();
+    resetRouteHints();
     trips.clearError();
     generatedItinerary.clearError();
   }
@@ -553,6 +687,16 @@ export function App() {
                 status={hotelSuggestionsStatus}
                 suggestions={hotelSuggestions}
                 targetCity={hotelTargetCity}
+              />
+
+              <RouteHints
+                destinationLabel={routeHintTarget?.destination.label}
+                disabledReason={routeHintsDisabledReason}
+                errorMessage={routeHintsError}
+                onLoadRouteHints={handleLoadRouteHints}
+                originLabel={routeHintTarget?.origin.label}
+                routeHints={routeHints}
+                status={routeHintsStatus}
               />
 
               <ShareControls

--- a/apps/web/src/features/routes/RouteHints.test.tsx
+++ b/apps/web/src/features/routes/RouteHints.test.tsx
@@ -1,0 +1,121 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { RouteHints } from "./RouteHints.js";
+
+const routeHint = {
+  destination: {
+    address: "4 Chome Ueno, Taito City, Tokyo",
+    label: "Ameyoko lunch crawl"
+  },
+  destinationLabel: "Ameyoko lunch crawl",
+  distanceMeters: 1200,
+  durationMinutes: 14,
+  id: "google-routes:ueno-ameyoko:1",
+  mapUrl: "https://www.google.com/maps/dir/?api=1",
+  origin: {
+    address: "Uenokoen, Taito City, Tokyo",
+    label: "Morning walk through Ueno Park"
+  },
+  originLabel: "Morning walk through Ueno Park",
+  provider: "google-routes",
+  sourceUpdatedAt: "2026-06-25T00:00:00.000Z",
+  staticDurationMinutes: 13,
+  steps: [
+    {
+      distanceMeters: 400,
+      durationMinutes: 5,
+      instruction: "Walk to Ueno Station.",
+      transitLineName: null,
+      travelMode: "walk" as const
+    },
+    {
+      distanceMeters: 800,
+      durationMinutes: 8,
+      instruction: "Take the Ginza Line toward Asakusa.",
+      transitLineName: "Tokyo Metro Ginza Line",
+      travelMode: "transit" as const
+    }
+  ],
+  summary:
+    "Transit route from Morning walk through Ueno Park to Ameyoko lunch crawl, about 14 min, 1.2 km, via Tokyo Metro Ginza Line.",
+  transitLineNames: ["Tokyo Metro Ginza Line"],
+  travelMode: "transit" as const,
+  warnings: ["Verify transfers locally before traveling."]
+};
+
+describe("RouteHints", () => {
+  test("renders normalized route hints", () => {
+    const html = renderToString(
+      <RouteHints
+        onLoadRouteHints={() => undefined}
+        routeHints={[routeHint]}
+        status="available"
+      />
+    );
+
+    expect(html).toContain("Route hints");
+    expect(html).toContain("Transit");
+    expect(html).toContain(
+      "Morning walk through Ueno Park to Ameyoko lunch crawl"
+    );
+    expect(html).toContain("14 min");
+    expect(html).toContain("1.2 km");
+    expect(html).toContain("Tokyo Metro Ginza Line");
+    expect(html).toContain("Walk to Ueno Station.");
+    expect(html).toContain("Open route map");
+    expect(html).toContain("Verify transfers locally before traveling.");
+  });
+
+  test("renders an empty state", () => {
+    const html = renderToString(
+      <RouteHints onLoadRouteHints={() => undefined} status="empty" />
+    );
+
+    expect(html).toContain("No route hint was found for these locations.");
+    expect(html).toContain("Find route");
+  });
+
+  test("renders unavailable and error states as recoverable alerts", () => {
+    const unavailableHtml = renderToString(
+      <RouteHints onLoadRouteHints={() => undefined} status="unavailable" />
+    );
+    const errorHtml = renderToString(
+      <RouteHints
+        errorMessage="Route enrichment is not configured."
+        onLoadRouteHints={() => undefined}
+        status="error"
+      />
+    );
+
+    expect(unavailableHtml).toContain(
+      "Route hints are temporarily unavailable."
+    );
+    expect(unavailableHtml).toContain('role="alert"');
+    expect(errorHtml).toContain("Route enrichment is not configured.");
+    expect(errorHtml).toContain('role="alert"');
+  });
+
+  test("explains why route search is disabled before an itinerary exists", () => {
+    const html = renderToString(
+      <RouteHints disabledReason="Create an itinerary before searching routes." />
+    );
+
+    expect(html).toContain("Create an itinerary before searching routes.");
+    expect(html).toContain("disabled");
+  });
+
+  test("renders loading state", () => {
+    const html = renderToString(
+      <RouteHints
+        onLoadRouteHints={() => undefined}
+        originLabel="Morning walk through Ueno Park"
+        destinationLabel="Ameyoko lunch crawl"
+        status="loading"
+      />
+    );
+
+    expect(html).toContain("Finding route");
+    expect(html).toContain("disabled");
+  });
+});

--- a/apps/web/src/features/routes/RouteHints.tsx
+++ b/apps/web/src/features/routes/RouteHints.tsx
@@ -1,0 +1,196 @@
+import type { RouteHint, RouteTravelMode } from "../../lib/api/types.js";
+
+export type RouteHintsStatus =
+  | "available"
+  | "empty"
+  | "error"
+  | "idle"
+  | "loading"
+  | "unavailable";
+
+export type RouteHintsProps = {
+  destinationLabel?: string | null | undefined;
+  disabledReason?: string | undefined;
+  errorMessage?: string | null | undefined;
+  onLoadRouteHints?: (() => void) | undefined;
+  originLabel?: string | null | undefined;
+  routeHints?: RouteHint[] | undefined;
+  status?: RouteHintsStatus | undefined;
+};
+
+const travelModeLabels: Record<RouteTravelMode, string> = {
+  bicycle: "Bicycle",
+  drive: "Drive",
+  transit: "Transit",
+  walk: "Walk"
+};
+
+function formatDistance(distanceMeters: number | null) {
+  if (distanceMeters === null) {
+    return "Unknown";
+  }
+
+  if (distanceMeters >= 1000) {
+    return `${Math.round((distanceMeters / 1000) * 10) / 10} km`;
+  }
+
+  return `${Math.round(distanceMeters)} m`;
+}
+
+function formatDuration(durationMinutes: number | null) {
+  return durationMinutes === null ? "Unknown" : `${durationMinutes} min`;
+}
+
+function getStatusMessage(options: {
+  destinationLabel?: string | null | undefined;
+  disabledReason?: string | undefined;
+  errorMessage?: string | null | undefined;
+  originLabel?: string | null | undefined;
+  status: RouteHintsStatus;
+}) {
+  if (options.disabledReason) {
+    return options.disabledReason;
+  }
+
+  if (options.status === "loading") {
+    return "Finding route hint";
+  }
+
+  if (options.status === "empty") {
+    return "No route hint was found for these locations.";
+  }
+
+  if (options.status === "unavailable") {
+    return "Route hints are temporarily unavailable.";
+  }
+
+  if (options.status === "error") {
+    return options.errorMessage ?? "Route hints could not be loaded.";
+  }
+
+  if (options.originLabel && options.destinationLabel) {
+    return `Find a route hint from ${options.originLabel} to ${options.destinationLabel}.`;
+  }
+
+  return "Create an itinerary with at least two located activities before searching routes.";
+}
+
+export function RouteHints({
+  destinationLabel,
+  disabledReason,
+  errorMessage,
+  onLoadRouteHints,
+  originLabel,
+  routeHints = [],
+  status = "idle"
+}: RouteHintsProps) {
+  const isLoading = status === "loading";
+  const isDisabled = isLoading || Boolean(disabledReason) || !onLoadRouteHints;
+  const statusMessage = getStatusMessage({
+    destinationLabel,
+    disabledReason,
+    errorMessage,
+    originLabel,
+    status
+  });
+
+  return (
+    <section aria-labelledby="route-hints-title" className="route-hints">
+      <header>
+        <p className="section-kicker">Routes</p>
+        <h3 id="route-hints-title">Route hints</h3>
+      </header>
+
+      <p
+        className={
+          status === "error" || status === "unavailable"
+            ? "route-hints-alert"
+            : "route-hints-help"
+        }
+        role={
+          status === "error" || status === "unavailable" ? "alert" : undefined
+        }
+      >
+        {statusMessage}
+      </p>
+
+      <button disabled={isDisabled} onClick={onLoadRouteHints} type="button">
+        {isLoading ? "Finding route" : "Find route"}
+      </button>
+
+      {status === "available" && routeHints.length > 0 ? (
+        <div className="route-hint-list">
+          {routeHints.map((routeHint) => (
+            <article className="route-hint-card" key={routeHint.id}>
+              <p className="route-hint-mode">
+                {travelModeLabels[routeHint.travelMode]}
+              </p>
+              <h4>
+                {routeHint.originLabel} to {routeHint.destinationLabel}
+              </h4>
+              <p>{routeHint.summary}</p>
+
+              <dl className="route-hint-meta">
+                <div>
+                  <dt>Duration</dt>
+                  <dd>{formatDuration(routeHint.durationMinutes)}</dd>
+                </div>
+                <div>
+                  <dt>Distance</dt>
+                  <dd>{formatDistance(routeHint.distanceMeters)}</dd>
+                </div>
+                <div>
+                  <dt>Mode</dt>
+                  <dd>{travelModeLabels[routeHint.travelMode]}</dd>
+                </div>
+              </dl>
+
+              {routeHint.transitLineNames.length > 0 ? (
+                <ul className="route-hint-lines" aria-label="Transit lines">
+                  {routeHint.transitLineNames.map((lineName) => (
+                    <li key={lineName}>{lineName}</li>
+                  ))}
+                </ul>
+              ) : null}
+
+              {routeHint.warnings.length > 0 ? (
+                <ul className="route-hint-warnings" aria-label="Route warnings">
+                  {routeHint.warnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              ) : null}
+
+              {routeHint.steps.length > 0 ? (
+                <ol className="route-hint-steps" aria-label="Route steps">
+                  {routeHint.steps.slice(0, 4).map((step, index) => (
+                    <li
+                      key={`${routeHint.id}-${index}-${step.instruction ?? step.travelMode}`}
+                    >
+                      <span>
+                        {step.instruction ??
+                          `${travelModeLabels[step.travelMode]} segment`}
+                      </span>
+                      <small>
+                        {formatDuration(step.durationMinutes)}
+                        {step.transitLineName
+                          ? ` - ${step.transitLineName}`
+                          : ""}
+                      </small>
+                    </li>
+                  ))}
+                </ol>
+              ) : null}
+
+              {routeHint.mapUrl ? (
+                <a href={routeHint.mapUrl} rel="noreferrer" target="_blank">
+                  Open route map
+                </a>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/trips/useTrips.test.ts
+++ b/apps/web/src/features/trips/useTrips.test.ts
@@ -74,6 +74,10 @@ function createMockClient(trip = createTripRecord()): TripApiClient {
       hotelSuggestions: [],
       status: "empty" as const
     })),
+    getRouteHints: vi.fn(async () => ({
+      routeHints: [],
+      status: "empty" as const
+    })),
     getSharedTrip: vi.fn(async () => ({
       share: {
         token: "public-share-token-1234567890abcdef",

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -82,6 +82,50 @@ function hotelSuggestionsResponse(init: ResponseInit = {}) {
   );
 }
 
+function routeHintsResponse(init: ResponseInit = {}) {
+  return jsonResponse(
+    {
+      routeHints: [
+        {
+          destination: {
+            address: "4 Chome Ueno, Taito City, Tokyo",
+            label: "Ameyoko lunch crawl"
+          },
+          destinationLabel: "Ameyoko lunch crawl",
+          distanceMeters: 900,
+          durationMinutes: 12,
+          id: "google-routes:ueno-ameyoko:1",
+          mapUrl: "https://www.google.com/maps/dir/?api=1",
+          origin: {
+            address: "Uenokoen, Taito City, Tokyo",
+            label: "Morning walk through Ueno Park"
+          },
+          originLabel: "Morning walk through Ueno Park",
+          provider: "google-routes",
+          sourceUpdatedAt: "2026-06-25T00:00:00.000Z",
+          staticDurationMinutes: 12,
+          steps: [
+            {
+              distanceMeters: 900,
+              durationMinutes: 12,
+              instruction: "Walk toward Ameyoko.",
+              transitLineName: null,
+              travelMode: "walk"
+            }
+          ],
+          summary:
+            "Walk route from Morning walk through Ueno Park to Ameyoko lunch crawl, about 12 min, 900 m.",
+          transitLineNames: [],
+          travelMode: "walk",
+          warnings: []
+        }
+      ],
+      status: "available"
+    },
+    init
+  );
+}
+
 describe("createTripApiClient", () => {
   test("creates trips with included anonymous session credentials", async () => {
     const trip = createTripRecord();
@@ -347,6 +391,69 @@ describe("createTripApiClient", () => {
     expect(JSON.parse(String(init?.body))).toMatchObject({
       budget: "moderate",
       city: "Tokyo"
+    });
+  });
+
+  test("requests normalized route hints through the API", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        void _input;
+        void _init;
+        return routeHintsResponse();
+      }
+    );
+    const client = createTripApiClient({
+      baseUrl: "http://localhost:3001",
+      fetch: fetchMock
+    });
+
+    await expect(
+      client.getRouteHints({
+        destination: {
+          address: "4 Chome Ueno, Taito City, Tokyo",
+          label: "Ameyoko lunch crawl"
+        },
+        origin: {
+          address: "Uenokoen, Taito City, Tokyo",
+          label: "Morning walk through Ueno Park"
+        },
+        travelMode: "walk"
+      })
+    ).resolves.toMatchObject({
+      routeHints: [
+        {
+          destinationLabel: "Ameyoko lunch crawl",
+          originLabel: "Morning walk through Ueno Park",
+          provider: "google-routes"
+        }
+      ],
+      status: "available"
+    });
+
+    const firstCall = fetchMock.mock.calls[0];
+
+    if (!firstCall) {
+      throw new Error("Expected fetch to be called");
+    }
+
+    const [url, init] = firstCall;
+
+    expect(url).toBe("http://localhost:3001/api/enrichment/routes/hints");
+    expect(init).toMatchObject({
+      credentials: "include",
+      method: "POST"
+    });
+    expect(new Headers(init?.headers).get("Accept")).toContain(
+      "application/json"
+    );
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      destination: {
+        label: "Ameyoko lunch crawl"
+      },
+      origin: {
+        label: "Morning walk through Ueno Park"
+      },
+      travelMode: "walk"
     });
   });
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -8,6 +8,8 @@ import type {
   HotelSuggestionsRequest,
   HotelSuggestionsResponse,
   PdfExportFile,
+  RouteHintsRequest,
+  RouteHintsResponse,
   ShareLinkRecord,
   SharedTripRecord,
   TripRecord,
@@ -54,6 +56,7 @@ export type TripApiClient = {
   getHotelSuggestions: (
     payload: HotelSuggestionsRequest
   ) => Promise<HotelSuggestionsResponse>;
+  getRouteHints: (payload: RouteHintsRequest) => Promise<RouteHintsResponse>;
   getSharedTrip: (shareToken: string) => Promise<SharedTripRecord>;
   getTrip: (tripId: string) => Promise<TripRecord>;
   listTrips: () => Promise<TripRecord[]>;
@@ -236,6 +239,13 @@ export function createTripApiClient(
           method: "POST"
         }
       );
+    },
+
+    async getRouteHints(payload) {
+      return requestJson<RouteHintsResponse>("/api/enrichment/routes/hints", {
+        body: JSON.stringify(payload),
+        method: "POST"
+      });
     },
 
     async getTrip(tripId) {

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -104,6 +104,62 @@ export type HotelSuggestionsResponse =
       status: "empty" | "unavailable";
     };
 
+export type RouteTravelMode = "bicycle" | "drive" | "transit" | "walk";
+
+export type RouteHintLocation = {
+  address?: string | undefined;
+  label: string;
+  latitude?: number | undefined;
+  longitude?: number | undefined;
+};
+
+export type RouteHintsRequest = {
+  city?: string | undefined;
+  departureTime?: string | undefined;
+  destination: RouteHintLocation;
+  locale?: string | undefined;
+  maxAlternatives?: number | undefined;
+  origin: RouteHintLocation;
+  travelMode: RouteTravelMode;
+};
+
+export type RouteHintStep = {
+  distanceMeters: number | null;
+  durationMinutes: number | null;
+  instruction: string | null;
+  transitLineName: string | null;
+  travelMode: RouteTravelMode;
+};
+
+export type RouteHint = {
+  destination: RouteHintLocation;
+  destinationLabel: string;
+  distanceMeters: number | null;
+  durationMinutes: number | null;
+  id: string;
+  mapUrl: string | null;
+  origin: RouteHintLocation;
+  originLabel: string;
+  provider: string;
+  sourceUpdatedAt: string | null;
+  staticDurationMinutes: number | null;
+  steps: RouteHintStep[];
+  summary: string;
+  transitLineNames: string[];
+  travelMode: RouteTravelMode;
+  warnings: string[];
+};
+
+export type RouteHintsResponse =
+  | {
+      routeHints: RouteHint[];
+      status: "available";
+    }
+  | {
+      routeHints: RouteHint[];
+      status: "empty" | "unavailable";
+    };
+
 export function tripRecordToItinerary(trip: TripRecord): Itinerary {
   return {
     title: trip.title,


### PR DESCRIPTION
## Ticket scope

Implements T-032 / Ticket 32: Add Transit Or Route Hint Provider Abstraction.

This PR adds a backend-owned route hint provider contract, a Google Routes provider adapter, a route enrichment endpoint, provider-cache integration, and a secondary web UI panel for optional route hints between itinerary activities.

## Changes made

- Added normalized route hint provider types and explicit configuration/provider error classes.
- Added Google Routes API adapter that constructs `computeRoutes` requests, sends backend-only auth and field-mask headers, and normalizes provider responses.
- Added route enrichment service with `available`, `empty`, and `unavailable` states.
- Added `POST /api/enrichment/routes/hints` with Zod validation and structured missing-config errors.
- Added `GOOGLE_MAPS_API_KEY` parsing to API env config as an optional backend-only secret.
- Added web API client/types for route hints.
- Added `RouteHints` component and integrated it into the planner sidebar as a non-blocking, on-demand panel.
- Added mocked E2E coverage for route hints in the generated-trip flow.

## Route provider/files added

- `apps/api/src/providers/routes/routeProvider.ts`
- `apps/api/src/providers/routes/googleRoutesProvider.ts`
- `apps/api/src/services/enrichment/routeEnrichment.ts`
- `apps/web/src/features/routes/RouteHints.tsx`
- Associated provider, service, route, client, component, and E2E tests.

## Google Routes docs checked

Checked current official Google Maps Platform docs before implementation:

- Compute Routes overview: https://developers.google.com/maps/documentation/routes/compute-route-over
- Compute Routes REST reference: https://developers.google.com/maps/documentation/routes/reference/rest/v2/TopLevel/computeRoutes
- Field mask requirements: https://developers.google.com/maps/documentation/routes/choose_fields
- Route travel modes: https://developers.google.com/maps/documentation/routes/reference/rest/v2/RouteTravelMode

Used docs only for endpoint shape, required POST/body/header behavior, travel-mode mapping, and response normalization. Automated tests do not make real Google Routes API calls.

## Env/config behavior

- Uses backend-only `GOOGLE_MAPS_API_KEY`.
- Missing `GOOGLE_MAPS_API_KEY` does not block API startup.
- Missing config returns a structured `ROUTE_PROVIDER_CONFIGURATION_ERROR` only when route enrichment is requested.
- No `VITE_GOOGLE_*` variable was added.
- Frontend bundle/source scan found no `GOOGLE_MAPS_API_KEY` or `VITE_GOOGLE` references.

## Cache behavior

- Route hints use the existing provider result cache with operation `routes.hints`.
- Successful and empty route results can be cached.
- Unavailable provider failures are not cached.
- No Prisma schema or migration changes were needed.

## Tests added/updated

- Provider contract tests for normalized route hints and error classes.
- Google provider tests for request construction, auth headers, field mask, missing config, provider failures, no route, normalization, warnings, and secret stripping.
- Route enrichment service tests for available/empty/unavailable/config/cache behavior.
- API route tests for success, validation, missing config, provider failure, empty, and cache hit.
- Web client tests for route hint API calls.
- RouteHints component tests for available, empty, unavailable, error, disabled, and loading states.
- App smoke and mocked E2E updates.

## Checks run

- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @japan-travel-planner/api test`
- `pnpm --filter @japan-travel-planner/api typecheck`
- `pnpm --filter @japan-travel-planner/api build`
- `pnpm --filter @japan-travel-planner/api exec prisma validate`
- `pnpm --filter @japan-travel-planner/api exec prisma generate`
- `pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter @japan-travel-planner/web test`
- `pnpm --filter @japan-travel-planner/web exec tsc --noEmit`
- `pnpm --filter @japan-travel-planner/web exec vite build`
- `pnpm --filter @japan-travel-planner/web test:e2e`
- `git diff --check`
- Frontend key scan for `GOOGLE_MAPS_API_KEY|VITE_GOOGLE`: no matches.
- Ticket 33 LINE implementation scan: no LINE files/code added.

## Manual checks run

- Started API with `GOOGLE_MAPS_API_KEY` empty using `pnpm dev:api`.
- Confirmed `GET /api/health` returned HTTP 200 and JSON status ok.
- Confirmed `POST /api/enrichment/routes/hints` without Google config returned HTTP 503 with structured `ROUTE_PROVIDER_CONFIGURATION_ERROR`.
- Started web with `pnpm dev:web` and opened `http://localhost:5173`.
- Confirmed initial empty itinerary state before submit.
- Submitted a valid mock trip request and confirmed the mock itinerary appeared.
- Confirmed route hints panel enabled for the first two located activities.
- Confirmed route hints missing-config UI showed a recoverable alert and did not block itinerary display.
- Confirmed existing map links and weather text remained visible in the itinerary.
- Reordered an activity and confirmed dirty state appeared.
- Checked 390px mobile viewport: no horizontal overflow.

## Known risks

- No real Google Routes API smoke test was run because no local Google Maps Platform credentials were configured. This PR relies on mocked provider tests for Google request/normalization behavior.
- Full DB-backed save/reopen/share/PDF manual validation was not claimed locally; the mocked Playwright E2E suite covers those flows. A real DB-backed manual pass still requires a working `DATABASE_URL`.
- Root checks should be run sequentially in this repo because multiple parallel commands invoke `prisma generate` against the same generated output directory.

## Ticket 33+ confirmation

Ticket 33 and later were not started. This PR does not add LINE sharing, mobile app work, deployment/observability work, AI behavior changes, Prisma migrations, embedded maps, route optimization, itinerary reordering based on routes, or frontend Google keys.
