### PR TITLE
Add optional LINE sharing flow

### DIFF
--- a/apps/web/e2e/trip-planning.spec.ts
+++ b/apps/web/e2e/trip-planning.spec.ts
@@ -870,6 +870,27 @@ test("traveler can save, refresh, and reopen an edited generated itinerary", asy
   );
 
   const shareUrl = await shareUrlInput.inputValue();
+  const lineShareLink = page.getByRole("link", {
+    name: "Share this read-only itinerary on LINE"
+  });
+  await expect(lineShareLink).toBeVisible();
+  await expect(lineShareLink).toHaveAttribute("target", "_blank");
+
+  const lineShareHref = await lineShareLink.getAttribute("href");
+
+  if (!lineShareHref) {
+    throw new Error("Expected LINE share link to have an href.");
+  }
+
+  const lineShareUrl = new URL(lineShareHref);
+  const lineShareMessage = lineShareUrl.searchParams.get("text") ?? "";
+
+  expect(`${lineShareUrl.origin}${lineShareUrl.pathname}`).toBe(
+    "https://line.me/R/share"
+  );
+  expect(lineShareMessage).toContain(`/share/${publicShareToken}`);
+  expect(lineShareMessage).not.toContain("/api/trips/");
+
   await page.goto(new URL(shareUrl).pathname);
 
   await expect(

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -395,7 +395,9 @@ select {
 .hotel-suggestions > button,
 .route-hints > button,
 .share-controls > button,
-.share-url-field button {
+.share-url-field button,
+.line-share button,
+.line-share-link {
   width: 100%;
   border: 1px solid #0d3b4f;
   border-radius: 6px;
@@ -409,7 +411,8 @@ select {
 .export-controls > button:disabled,
 .hotel-suggestions > button:disabled,
 .route-hints > button:disabled,
-.share-controls > button:disabled {
+.share-controls > button:disabled,
+.line-share button:disabled {
   cursor: not-allowed;
   opacity: 0.72;
 }
@@ -703,6 +706,42 @@ select {
 .share-url-field button {
   width: auto;
   min-width: 80px;
+}
+
+.line-share {
+  display: grid;
+  gap: 10px;
+  border: 1px solid #dce4ea;
+  border-radius: 8px;
+  background: #f8fafb;
+  padding: 12px;
+}
+
+.line-share-label,
+.line-share-help {
+  margin: 0;
+}
+
+.line-share-label {
+  color: #be3f32;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.line-share-help {
+  margin-top: 4px;
+  color: #52616d;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.line-share-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  text-decoration: none;
 }
 
 .mode-toggle,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -700,10 +700,14 @@ export function App() {
               />
 
               <ShareControls
+                cities={activeRequest?.cities}
                 disabledReason={shareDisabledReason}
+                endDate={activeRequest?.endDate}
                 isSharing={trips.status === "sharing"}
                 onCreateShareLink={handleCreateShareLink}
                 shareLink={selectedShareLink}
+                startDate={activeRequest?.startDate}
+                title={itinerary?.title}
                 tripId={trips.selectedTripId}
               />
             </section>

--- a/apps/web/src/features/sharing/LineShareButton.test.tsx
+++ b/apps/web/src/features/sharing/LineShareButton.test.tsx
@@ -1,0 +1,75 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  createLineShareHref,
+  createLineShareMessage,
+  LineShareButton,
+  lineShareBaseUrl
+} from "./LineShareButton.js";
+
+const publicShareUrl =
+  "https://planner.example.com/share/public-share-token-1234567890abcdef";
+
+describe("LINE share URL helpers", () => {
+  test("creates a share message from public itinerary details only", () => {
+    const message = createLineShareMessage({
+      cities: ["Tokyo", "Kyoto"],
+      endDate: "2026-04-08",
+      shareUrl: publicShareUrl,
+      startDate: "2026-04-06",
+      title: "Tokyo And Kyoto Spring Highlights"
+    });
+
+    expect(message).toContain("Tokyo And Kyoto Spring Highlights");
+    expect(message).toContain("Tokyo, Kyoto");
+    expect(message).toContain("2026-04-06 to 2026-04-08");
+    expect(message).toContain(publicShareUrl);
+    expect(message).not.toContain("/api/trips/");
+    expect(message).not.toContain("generated-trip-1");
+  });
+
+  test("encodes the public share URL and message text for LINE", () => {
+    const href = createLineShareHref({
+      cities: ["Tokyo", "Kyoto"],
+      endDate: "2026-04-08",
+      shareUrl: publicShareUrl,
+      startDate: "2026-04-06",
+      title: "Tokyo And Kyoto Spring Highlights"
+    });
+    const parsedHref = new URL(href);
+
+    expect(`${parsedHref.origin}${parsedHref.pathname}`).toBe(lineShareBaseUrl);
+    expect(parsedHref.searchParams.get("text")).toContain(publicShareUrl);
+    expect(href).toContain(encodeURIComponent(publicShareUrl));
+  });
+});
+
+describe("LineShareButton", () => {
+  test("is disabled before a public share URL exists", () => {
+    const html = renderToString(
+      <LineShareButton disabledReason="Create a public share link first." />
+    );
+
+    expect(html).toContain("Create a public share link first.");
+    expect(html).toContain("disabled");
+    expect(html).not.toContain("href=");
+  });
+
+  test("opens a safe LINE target when a public share URL exists", () => {
+    const html = renderToString(
+      <LineShareButton
+        cities={["Tokyo", "Kyoto"]}
+        endDate="2026-04-08"
+        shareUrl={publicShareUrl}
+        startDate="2026-04-06"
+        title="Tokyo And Kyoto Spring Highlights"
+      />
+    );
+
+    expect(html).toContain("Share on LINE");
+    expect(html).toContain("https://line.me/R/share?text=");
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+});

--- a/apps/web/src/features/sharing/LineShareButton.tsx
+++ b/apps/web/src/features/sharing/LineShareButton.tsx
@@ -1,0 +1,107 @@
+export type LineShareMessageInput = {
+  cities?: readonly string[] | undefined;
+  endDate?: string | null | undefined;
+  shareUrl: string;
+  startDate?: string | null | undefined;
+  title?: string | null | undefined;
+};
+
+export type LineShareButtonProps = Omit<LineShareMessageInput, "shareUrl"> & {
+  disabledReason?: string | undefined;
+  shareUrl?: string | null | undefined;
+};
+
+export const lineShareBaseUrl = "https://line.me/R/share";
+
+function cleanText(value: string | null | undefined) {
+  return value?.trim() || null;
+}
+
+function createDateSummary(
+  startDate: string | null | undefined,
+  endDate: string | null | undefined
+) {
+  const cleanStartDate = cleanText(startDate);
+  const cleanEndDate = cleanText(endDate);
+
+  if (cleanStartDate && cleanEndDate) {
+    return `${cleanStartDate} to ${cleanEndDate}`;
+  }
+
+  return cleanStartDate ?? cleanEndDate;
+}
+
+export function createLineShareMessage({
+  cities = [],
+  endDate,
+  shareUrl,
+  startDate,
+  title
+}: LineShareMessageInput) {
+  const citySummary = cities.map(cleanText).filter(Boolean).join(", ");
+  const dateSummary = createDateSummary(startDate, endDate);
+  const tripSummary = [citySummary, dateSummary].filter(Boolean).join(" - ");
+
+  return [
+    cleanText(title) ?? "Japan itinerary",
+    tripSummary,
+    `Read-only itinerary: ${shareUrl}`
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function createLineShareUrl(message: string) {
+  return `${lineShareBaseUrl}?text=${encodeURIComponent(message)}`;
+}
+
+export function createLineShareHref(input: LineShareMessageInput) {
+  return createLineShareUrl(createLineShareMessage(input));
+}
+
+export function LineShareButton({
+  cities,
+  disabledReason,
+  endDate,
+  shareUrl,
+  startDate,
+  title
+}: LineShareButtonProps) {
+  const lineShareHref = shareUrl
+    ? createLineShareHref({
+        cities,
+        endDate,
+        shareUrl,
+        startDate,
+        title
+      })
+    : null;
+
+  return (
+    <div className="line-share">
+      <div>
+        <p className="line-share-label">LINE</p>
+        <p className="line-share-help">
+          {disabledReason ??
+            "Share the public read-only itinerary through LINE."}
+        </p>
+      </div>
+
+      {lineShareHref && !disabledReason ? (
+        <a
+          aria-label="Share this read-only itinerary on LINE"
+          className="line-share-link"
+          href={lineShareHref}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Share on LINE
+        </a>
+      ) : (
+        <button disabled type="button">
+          Share on LINE
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/sharing/ShareControls.test.tsx
+++ b/apps/web/src/features/sharing/ShareControls.test.tsx
@@ -11,6 +11,16 @@ const shareLink = {
   updatedAt: "2026-01-01T00:00:00.000Z"
 };
 
+function getFirstHref(html: string) {
+  const href = html.match(/href="([^"]+)"/)?.[1];
+
+  if (!href) {
+    throw new Error("Expected rendered HTML to contain a link href.");
+  }
+
+  return href.replaceAll("&amp;", "&");
+}
+
 describe("ShareControls", () => {
   test("is explanatory and disabled before a saved trip exists", () => {
     const html = renderToString(
@@ -27,13 +37,21 @@ describe("ShareControls", () => {
     );
     expect(html).toContain("disabled");
     expect(html).not.toContain("Share URL");
+    expect(html).toContain("Share on LINE");
+    expect(html).toContain(
+      "Create a public share link before sharing on LINE."
+    );
   });
 
   test("renders a copyable public share URL for a saved trip", () => {
     const html = renderToString(
       <ShareControls
+        cities={["Tokyo", "Kyoto"]}
+        endDate="2026-04-08"
         onCreateShareLink={() => undefined}
         shareLink={shareLink}
+        startDate="2026-04-06"
+        title="Tokyo And Kyoto Spring Highlights"
         tripId="trip-1"
       />
     );
@@ -44,6 +62,45 @@ describe("ShareControls", () => {
     );
     expect(html).toContain("readOnly");
     expect(html).toContain("Copy");
+    expect(html).toContain("Share on LINE");
+  });
+
+  test("uses the same public read-only share URL for LINE", () => {
+    const html = renderToString(
+      <ShareControls
+        cities={["Tokyo", "Kyoto"]}
+        endDate="2026-04-08"
+        onCreateShareLink={() => undefined}
+        shareLink={shareLink}
+        startDate="2026-04-06"
+        title="Tokyo And Kyoto Spring Highlights"
+        tripId="trip-1"
+      />
+    );
+    const lineShareUrl = new URL(getFirstHref(html));
+
+    expect(`${lineShareUrl.origin}${lineShareUrl.pathname}`).toBe(
+      "https://line.me/R/share"
+    );
+    expect(lineShareUrl.searchParams.get("text")).toContain(
+      "http://localhost:5173/share/public-share-token-1234567890abcdef"
+    );
+  });
+
+  test("disables LINE sharing for dirty local edits", () => {
+    const html = renderToString(
+      <ShareControls
+        disabledReason="Save local edits before sharing the itinerary."
+        onCreateShareLink={() => undefined}
+        shareLink={shareLink}
+        tripId="trip-1"
+      />
+    );
+
+    expect(html).toContain("Save local edits before sharing the itinerary.");
+    expect(html).toContain("Share URL");
+    expect(html).toContain("disabled");
+    expect(html).not.toContain("https://line.me/R/share");
   });
 });
 

--- a/apps/web/src/features/sharing/ShareControls.tsx
+++ b/apps/web/src/features/sharing/ShareControls.tsx
@@ -1,10 +1,15 @@
 import type { ShareLinkRecord } from "../../lib/api/types.js";
+import { LineShareButton } from "./LineShareButton.js";
 
 export type ShareControlsProps = {
+  cities?: readonly string[] | undefined;
   disabledReason?: string | undefined;
+  endDate?: string | null | undefined;
   isSharing?: boolean | undefined;
   onCreateShareLink: () => void;
   shareLink?: ShareLinkRecord | undefined;
+  startDate?: string | null | undefined;
+  title?: string | null | undefined;
   tripId?: string | null | undefined;
 };
 
@@ -21,14 +26,22 @@ export function createShareUrl(token: string, origin?: string) {
 }
 
 export function ShareControls({
+  cities,
   disabledReason,
+  endDate,
   isSharing = false,
   onCreateShareLink,
   shareLink,
+  startDate,
+  title,
   tripId
 }: ShareControlsProps) {
   const shareUrl = shareLink ? createShareUrl(shareLink.token) : null;
   const canCreateShareLink = Boolean(tripId) && !isSharing && !disabledReason;
+  const lineShareDisabledReason =
+    shareUrl === null
+      ? "Create a public share link before sharing on LINE."
+      : disabledReason;
 
   async function copyShareUrl() {
     if (!shareUrl || typeof navigator === "undefined") {
@@ -73,6 +86,15 @@ export function ShareControls({
           </div>
         </div>
       ) : null}
+
+      <LineShareButton
+        cities={cities}
+        disabledReason={lineShareDisabledReason}
+        endDate={endDate}
+        shareUrl={shareUrl}
+        startDate={startDate}
+        title={title}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Ticket scope

Implements T-033 / Ticket 33: Add Optional LINE Sharing Flow.

This PR adds a lightweight LINE sharing affordance for saved trips that already have a public read-only share link. It does not start Ticket 34 or any later mobile, deployment, observability, or provider work.

## Changes made

- Added `LineShareButton` with helper functions for LINE message and share URL generation.
- Wired LINE sharing into the existing `ShareControls` panel.
- Passed itinerary title, cities, and dates from `App` into the share controls for the LINE message.
- Added scoped styles for the LINE share control.
- Extended the existing Playwright E2E trip/share flow to assert the generated LINE target.

## LINE sharing approach

Uses the current official LINE URL-scheme share pattern:

- `https://line.me/R/share?text={encoded_message}`

The message includes:

- trip title
- city/date summary when available
- the public read-only share URL

No LIFF app, LINE Login, Messaging API bot behavior, OAuth flow, server-side LINE identity, provider key, or backend LINE route was added.

## Public read-only URL handling

- LINE sharing is generated from the same `/share/:shareToken` URL created by existing public share-link behavior.
- The LINE message is URL-encoded with `encodeURIComponent`.
- The message does not include private trip IDs, session URLs, cookies, user IDs, internal API URLs, or provider keys.
- Dirty local edits disable LINE sharing until the user saves, so a stale public link is not silently shared.

## Missing-config or unavailable behavior

- No LINE config is required for the chosen URL-only MVP approach.
- Before a public share URL exists, the LINE control is disabled with explanatory text.
- Because no server-side LINE provider was added, LINE provider/config errors cannot affect regular share links.
- Browser or LINE app/web availability remains outside the app and is handled by the external `line.me` target.

## Regular share-link compatibility

- Existing public link creation and copy behavior remains intact.
- No API client changes were needed.
- No share-link backend changes were made.

## Shared-page read-only regression

- Shared-page implementation was not modified.
- Existing E2E still verifies the public shared page has no edit/save/revert/generate/storage controls.

## Tests added/updated

- Added unit tests for LINE message creation and URL encoding.
- Added component tests for disabled/enabled LINE share states.
- Updated `ShareControls` component tests to confirm LINE uses the same public read-only share URL.
- Updated E2E to assert the LINE share target after public share-link creation.

## Checks run

- `pnpm install` with global pnpm: failed because pnpm prompted for non-TTY module removal.
- `CI=true pnpm install` with global pnpm: restored dependencies but exited on pnpm build-script approval policy.
- `CI=true corepack pnpm install`: passed with repo-pinned pnpm 10.14.0; warning remained for ignored dependency build scripts.
- `corepack pnpm exec prettier --write apps/web/src/features/sharing/LineShareButton.tsx apps/web/src/features/sharing/LineShareButton.test.tsx apps/web/src/features/sharing/ShareControls.tsx apps/web/src/features/sharing/ShareControls.test.tsx apps/web/src/App.tsx apps/web/src/App.css apps/web/e2e/trip-planning.spec.ts`
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm build`
- `corepack pnpm --filter @japan-travel-planner/api test`
- `corepack pnpm --filter @japan-travel-planner/api typecheck`
- `corepack pnpm --filter @japan-travel-planner/api build`
- `corepack pnpm --filter @japan-travel-planner/api exec prisma validate`
- `corepack pnpm --filter @japan-travel-planner/api exec prisma generate`
- `corepack pnpm --filter @japan-travel-planner/api exec vitest run --pool=vmThreads --maxWorkers=1 --no-file-parallelism`
- `corepack pnpm --filter @japan-travel-planner/web test`
- `corepack pnpm --filter @japan-travel-planner/web exec tsc --noEmit`
- `corepack pnpm --filter @japan-travel-planner/web exec vite build`
- `corepack pnpm --filter @japan-travel-planner/web test:e2e`
- `corepack pnpm test:e2e`
- `git diff --check`

## Manual checks run

- Started API with `corepack pnpm dev:api`.
- Confirmed `GET http://localhost:3001/api/health` returns HTTP 200 with `status: ok`.
- Started web with `corepack pnpm dev:web`.
- Opened `http://localhost:5173` in the browser.
- Confirmed initial no-itinerary state renders.
- Confirmed no share URL exists initially.
- Confirmed LINE share control is disabled before a public share URL exists.
- Submitted a mock trip request and confirmed the mock itinerary appears.
- Confirmed 390px mobile viewport has no horizontal overflow.

Local real DB-backed save/share was not claimed: `GET /api/trips` returned an API 500 in this environment, so full database-backed share creation was validated through mocked Playwright E2E instead.

## Real external calls

- Real LINE API calls made: no.
- Real OpenAI calls made: no.
- Real Rakuten calls made: no.
- Real OpenWeather calls made: no.
- Real Google Maps or Google Routes API calls made: no.

## Known risks

- LINE web/app availability and final share UI behavior are controlled by LINE after the browser opens `line.me`.
- Browser popup/new-tab behavior may vary by browser policy, though this implementation uses a normal safe `<a target="_blank" rel="noopener noreferrer">` link rather than scripted `window.open`.
- Local package install with the global pnpm version triggered build-script approval policy; repo-pinned Corepack pnpm completed install and all checks passed.
- Full DB-backed manual share validation requires a working local `DATABASE_URL`.

## Ticket 34+ confirmation

Ticket 34 and later work was not started. No mobile app, deployment, observability, API integration, persistence, AI generation, hotel, route, weather, map, provider cache, PDF export, or shared-schema changes were made.
